### PR TITLE
Add TlsLib.Benchmark: handshake and record throughput vs OpenSSL

### DIFF
--- a/TlsLib.Benchmark/Lazarus/TlsLib.BenchmarkConsole.lpi
+++ b/TlsLib.Benchmark/Lazarus/TlsLib.BenchmarkConsole.lpi
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="TlsLib.BenchmarkConsole"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default"/>
+      </Modes>
+    </RunParams>
+    <RequiredPackages Count="3">
+      <Item1>
+        <PackageName Value="TlsLib4PascalPackage"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="mormot2"/>
+      </Item2>
+      <Item3>
+        <PackageName Value="FCL"/>
+      </Item3>
+    </RequiredPackages>
+    <Units Count="1">
+      <Unit0>
+        <Filename Value="TlsLib.BenchmarkConsole.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value=".\bin\TlsLib.BenchmarkConsole"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\src\Core"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <CodeGeneration>
+      <Optimizations>
+        <OptimizationLevel Value="3"/>
+      </Optimizations>
+    </CodeGeneration>
+    <Linking>
+      <Debugging>
+        <GenerateDebugInfo Value="False"/>
+        <UseLineInfoUnit Value="False"/>
+        <UseHeaptrc Value="False"/>
+      </Debugging>
+    </Linking>
+  </CompilerOptions>
+</CONFIG>

--- a/TlsLib.Benchmark/Lazarus/TlsLib.BenchmarkConsole.lpr
+++ b/TlsLib.Benchmark/Lazarus/TlsLib.BenchmarkConsole.lpr
@@ -1,0 +1,40 @@
+program TlsLib.BenchmarkConsole;
+
+{$MODE DELPHI}
+{$APPTYPE CONSOLE}
+
+// Console runner for the TlsLib benchmarks. Aggregates the TLS-layer benchmarks (the
+// handshake-throughput and record-throughput comparisons against OpenSSL) and prints each
+// as an ASCII table over the TlsLib benchmark harness (BenchmarkCommon) for timing/format.
+
+uses
+  SysUtils,
+  BenchmarkCommon,
+  OpenSslBenchSupport,
+  TlsHandshakeBenchmark,
+  TlsRecordThroughputBenchmark;
+
+procedure ConsoleLog(const AMessage: String);
+begin
+  WriteLn(AMessage);
+end;
+
+begin
+  try
+    // record which OpenSSL produced the reference figures (empty when it did not load)
+    if TOpenSslBench.Available then
+      ConsoleLog(TOpenSslBench.VersionString);
+    ConsoleLog('');
+    TTlsHandshakeBenchmark.Run(ConsoleLog);
+    ConsoleLog('');
+    TTlsRecordThroughputBenchmark.Run(ConsoleLog);
+    ConsoleLog('');
+    TBenchmarkReport.WriteRunSummary(ConsoleLog);
+  except
+    on E: Exception do
+    begin
+      WriteLn('Benchmark error: ', E.ClassName, ': ', E.Message);
+      ExitCode := 1;
+    end;
+  end;
+end.

--- a/TlsLib.Benchmark/src/Core/BenchmarkCommon.pas
+++ b/TlsLib.Benchmark/src/Core/BenchmarkCommon.pas
@@ -1,0 +1,377 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit BenchmarkCommon;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$WARNINGS OFF}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  TBenchmarkLogProc = procedure(const AMessage: String);
+  TBenchmarkTimedOpMethodProc = procedure of object;
+
+const
+  BENCH_DURATION_MS = UInt32(3000);
+  BENCH_ROUNDS = 3;
+  BENCH_LABEL_COL_WIDTH = 32;
+  BENCH_VALUE_COL_WIDTH = 16;
+  BENCH_KDF_VALUE_COL_WIDTH = 22;
+  { Wide enough for "9,999.99 MB/s / 9,999.99 MB/s" in cipher combined cells. }
+  BENCH_CIPHER_COMBINED_COL_WIDTH = 36;
+  DEFAULT_BENCH_BUFFER_SIZES: array [0 .. 2] of Int32 = (65536, 1048576, 16777216);
+
+procedure BenchFillRandom(var ADest: TBytes);
+procedure BenchAllocRandom(ALen: Int32; var ADest: TBytes);
+
+type
+  TBenchmarkReport = class sealed(TObject)
+  public
+  class var
+    FloatFormat: TFormatSettings;
+  strict private
+    class constructor Create;
+  public
+    class function GetPlatformInfo: String;
+    class function BuildSeparator(AWidth: Int32): String;
+    class function BuildHeaderRow(const AFirstColTitle: String;
+      const AColumnLabels: array of String): String; overload;
+    class function BuildHeaderRow(const AFirstColTitle: String;
+      const AColumnLabels: array of String;
+      AValueColumnWidth: Int32): String; overload;
+    class function BuildHeaderRowForBufferSizes(const AFirstColTitle: String;
+      const ABufferSizes: array of Int32): String; overload;
+    class function BuildHeaderRowForBufferSizes(const AFirstColTitle: String;
+      const ABufferSizes: array of Int32;
+      AValueColumnWidth: Int32): String; overload;
+    class function BuildDataRow(const ARowLabel: String;
+      const ACells: array of String): String; overload;
+    class function BuildDataRow(const ARowLabel: String;
+      const ACells: array of String;
+      AValueColumnWidth: Int32): String; overload;
+    class procedure WriteStandardFooter(ALogProc: TBenchmarkLogProc;
+      ATableWidth: Int32);
+    { The "complete / platform / date" summary without a leading separator, for a runner
+      that prints several tables and wants the summary emitted only once at the end. }
+    class procedure WriteRunSummary(ALogProc: TBenchmarkLogProc);
+  end;
+
+  { Shared column / cell formatting for benchmark tables. }
+  TBenchmarkFormat = class sealed(TObject)
+  public
+    class function FormatBufferSize(ASize: Int32): String;
+    class function FormatThroughputMbPerSec(ARate: Double): String;
+    class function FormatThroughputEncDecMbPerPair(AEncMbPerSec,
+      ADecMbPerSec: Double): String;
+    class function FormatMeanMilliseconds(AMs: Double): String;
+  end;
+
+  { Fixed-window timing loops (shared by all benchmark sections). Uses TThread.GetTickCount (UInt32).}
+  TBenchmarkTiming = class sealed(TObject)
+  public
+    class function MeasureThroughputMbPerSec(
+      const RunOnePass: TBenchmarkTimedOpMethodProc; ABytesPerPass: Int64): Double;
+    class function MeasureMeanMillisecondsPerOp(
+      const RunOneOp: TBenchmarkTimedOpMethodProc): Double;
+  end;
+
+implementation
+
+uses
+  Classes,
+  Math;
+
+procedure BenchFillRandom(var ADest: TBytes);
+var
+  Li: Int32;
+begin
+  for Li := 0 to System.High(ADest) do
+    ADest[Li] := Byte(Random(256));
+end;
+
+procedure BenchAllocRandom(ALen: Int32; var ADest: TBytes);
+begin
+  System.SetLength(ADest, ALen);
+  BenchFillRandom(ADest);
+end;
+
+{ TBenchmarkReport }
+
+class constructor TBenchmarkReport.Create;
+begin
+{$IFDEF FPC}
+  FloatFormat := DefaultFormatSettings;
+{$ELSE}
+  FloatFormat := FormatSettings;
+{$ENDIF}
+  FloatFormat.ThousandSeparator := ',';
+  FloatFormat.DecimalSeparator := '.';
+end;
+
+class function TBenchmarkReport.BuildSeparator(AWidth: Int32): String;
+begin
+  Result := StringOfChar('-', AWidth);
+end;
+
+class function TBenchmarkReport.BuildHeaderRow(const AFirstColTitle: String;
+  const AColumnLabels: array of String): String;
+begin
+  Result := BuildHeaderRow(AFirstColTitle, AColumnLabels, BENCH_VALUE_COL_WIDTH);
+end;
+
+class function TBenchmarkReport.BuildHeaderRow(const AFirstColTitle: String;
+  const AColumnLabels: array of String; AValueColumnWidth: Int32): String;
+var
+  LIdx: Int32;
+  LCell: String;
+begin
+  Result := AFirstColTitle;
+  while System.Length(Result) < BENCH_LABEL_COL_WIDTH do
+    Result := Result + ' ';
+
+  for LIdx := System.Low(AColumnLabels) to System.High(AColumnLabels) do
+  begin
+    LCell := AColumnLabels[LIdx];
+    while System.Length(LCell) < AValueColumnWidth do
+      LCell := ' ' + LCell;
+    Result := Result + LCell;
+  end;
+end;
+
+class function TBenchmarkReport.BuildHeaderRowForBufferSizes(
+  const AFirstColTitle: String; const ABufferSizes: array of Int32): String;
+begin
+  Result := BuildHeaderRowForBufferSizes(AFirstColTitle, ABufferSizes,
+    BENCH_VALUE_COL_WIDTH);
+end;
+
+class function TBenchmarkReport.BuildHeaderRowForBufferSizes(
+  const AFirstColTitle: String; const ABufferSizes: array of Int32;
+  AValueColumnWidth: Int32): String;
+var
+  LIdx: Int32;
+  LLabels: array of String;
+begin
+  System.SetLength(LLabels, System.Length(ABufferSizes));
+  for LIdx := System.Low(ABufferSizes) to System.High(ABufferSizes) do
+    LLabels[LIdx] := TBenchmarkFormat.FormatBufferSize(ABufferSizes[LIdx]);
+  Result := BuildHeaderRow(AFirstColTitle, LLabels, AValueColumnWidth);
+end;
+
+class function TBenchmarkReport.BuildDataRow(const ARowLabel: String;
+  const ACells: array of String): String;
+begin
+  Result := BuildDataRow(ARowLabel, ACells, BENCH_VALUE_COL_WIDTH);
+end;
+
+class function TBenchmarkReport.BuildDataRow(const ARowLabel: String;
+  const ACells: array of String; AValueColumnWidth: Int32): String;
+var
+  LIdx: Int32;
+  LCell: String;
+begin
+  Result := ARowLabel;
+  while System.Length(Result) < BENCH_LABEL_COL_WIDTH do
+    Result := Result + ' ';
+
+  for LIdx := System.Low(ACells) to System.High(ACells) do
+  begin
+    LCell := ACells[LIdx];
+    while System.Length(LCell) < AValueColumnWidth do
+      LCell := ' ' + LCell;
+    Result := Result + LCell;
+  end;
+end;
+
+class function TBenchmarkReport.GetPlatformInfo: String;
+var
+  LOS, LCompiler, LCPU: String;
+begin
+{$IFDEF FPC}
+  {$IF DEFINED(MSWINDOWS)}
+  LOS := 'Windows';
+  {$ELSEIF DEFINED(LINUX)}
+  LOS := 'Linux';
+  {$ELSEIF DEFINED(DARWIN)}
+  LOS := 'macOS';
+  {$ELSE}
+  LOS := 'Unknown OS';
+  {$ENDIF}
+
+  {$IF DEFINED(CPUX86_64)}
+  LCPU := 'x86_64';
+  {$ELSEIF DEFINED(CPUI386)}
+  LCPU := 'i386';
+  {$ELSEIF DEFINED(CPUAARCH64)}
+  LCPU := 'AArch64';
+  {$ELSEIF DEFINED(CPUARM)}
+  LCPU := 'ARM';
+  {$ELSE}
+  LCPU := 'Unknown CPU';
+  {$ENDIF}
+{$ELSE}
+  {$IF DEFINED(MSWINDOWS)}
+  LOS := 'Windows';
+  {$ELSEIF DEFINED(ANDROID)}
+  LOS := 'Android';
+  {$ELSEIF DEFINED(IOS)}
+  LOS := 'iOS';
+  {$ELSEIF DEFINED(MACOS)}
+  LOS := 'macOS';
+  {$ELSEIF DEFINED(LINUX)}
+  LOS := 'Linux';
+  {$ELSE}
+  LOS := 'Unknown OS';
+  {$ENDIF}
+
+  {$IF DEFINED(CPUX64)}
+  LCPU := 'x86_64';
+  {$ELSEIF DEFINED(CPUX86)}
+  LCPU := 'i386';
+  {$ELSEIF DEFINED(CPUARM64)}
+  LCPU := 'AArch64';
+  {$ELSEIF DEFINED(CPUARM)}
+  LCPU := 'ARM';
+  {$ELSE}
+  LCPU := 'Unknown CPU';
+  {$ENDIF}
+{$ENDIF}
+
+{$IFDEF FPC}
+  LCompiler := 'FPC ' + {$I %FPCVERSION%};
+{$ELSE}
+  LCompiler := Format('Delphi (CompilerVersion %.1f)', [CompilerVersion]);
+{$ENDIF}
+
+  Result := Format('Platform: %s %s, %s', [LOS, LCPU, LCompiler]);
+end;
+
+class procedure TBenchmarkReport.WriteStandardFooter(ALogProc: TBenchmarkLogProc;
+  ATableWidth: Int32);
+begin
+  if ATableWidth < 40 then
+    ATableWidth := 40;
+  ALogProc(BuildSeparator(ATableWidth));
+  ALogProc('Benchmark complete.');
+  ALogProc(GetPlatformInfo);
+  ALogProc('Date: ' + FormatDateTime('yyyy-mm-dd', Now));
+end;
+
+class procedure TBenchmarkReport.WriteRunSummary(ALogProc: TBenchmarkLogProc);
+begin
+  ALogProc('Benchmark complete.');
+  ALogProc(GetPlatformInfo);
+  ALogProc('Date: ' + FormatDateTime('yyyy-mm-dd', Now));
+end;
+
+{ TBenchmarkFormat }
+
+class function TBenchmarkFormat.FormatBufferSize(ASize: Int32): String;
+begin
+  if ASize >= 1024 * 1024 then
+    Result := Format('%d MB', [ASize div (1024 * 1024)])
+  else if ASize >= 1024 then
+    Result := Format('%d KB', [ASize div 1024])
+  else
+    Result := Format('%d B', [ASize]);
+end;
+
+class function TBenchmarkFormat.FormatThroughputMbPerSec(ARate: Double): String;
+begin
+  Result := FormatFloat('#,##0.00', ARate, TBenchmarkReport.FloatFormat) + ' MB/s';
+end;
+
+class function TBenchmarkFormat.FormatThroughputEncDecMbPerPair(AEncMbPerSec,
+  ADecMbPerSec: Double): String;
+begin
+  Result := FormatThroughputMbPerSec(AEncMbPerSec) + ' / ' +
+    FormatThroughputMbPerSec(ADecMbPerSec);
+end;
+
+class function TBenchmarkFormat.FormatMeanMilliseconds(AMs: Double): String;
+begin
+  if not (AMs > 0.0) then
+    Result := '0.00 ms'
+  else
+    Result := FormatFloat('#,##0.00', AMs, TBenchmarkReport.FloatFormat) + ' ms';
+end;
+
+{ TBenchmarkTiming }
+
+class function TBenchmarkTiming.MeasureThroughputMbPerSec(
+  const RunOnePass: TBenchmarkTimedOpMethodProc; ABytesPerPass: Int64): Double;
+var
+  LRound: Int32;
+  LTotal: Int64;
+  LTickStart, LTickEnd, LElapsed: UInt32;
+begin
+  Result := 0.0;
+  for LRound := 1 to BENCH_ROUNDS do
+  begin
+    LTotal := 0;
+    LElapsed := 0;
+    while LElapsed <= BENCH_DURATION_MS do
+    begin
+      LTickStart := TThread.GetTickCount;
+      RunOnePass();
+      LTickEnd := TThread.GetTickCount;
+      LTotal := LTotal + ABytesPerPass;
+      LElapsed := LElapsed + (LTickEnd - LTickStart);
+    end;
+    if LElapsed > 0 then
+      Result := Math.Max(LTotal / (LElapsed / 1000.0) / 1024.0 / 1024.0, Result);
+  end;
+end;
+
+class function TBenchmarkTiming.MeasureMeanMillisecondsPerOp(
+  const RunOneOp: TBenchmarkTimedOpMethodProc): Double;
+var
+  LRound: Int32;
+  LCount: Int64;
+  LTickStart, LTickEnd, LElapsed: UInt32;
+  LMeanMs: Double;
+  LHaveAny: Boolean;
+begin
+  LHaveAny := False;
+  Result := 0.0;
+  for LRound := 1 to BENCH_ROUNDS do
+  begin
+    LCount := 0;
+    LElapsed := 0;
+    while LElapsed <= BENCH_DURATION_MS do
+    begin
+      LTickStart := TThread.GetTickCount;
+      RunOneOp();
+      LTickEnd := TThread.GetTickCount;
+      System.Inc(LCount);
+      LElapsed := LElapsed + (LTickEnd - LTickStart);
+    end;
+    if LCount > 0 then
+    begin
+      LMeanMs := LElapsed / LCount;
+      if (not LHaveAny) or (LMeanMs < Result) then
+      begin
+        Result := LMeanMs;
+        LHaveAny := True;
+      end;
+    end;
+  end;
+  if not LHaveAny then
+    Result := 0.0;
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/OpenSslBenchSupport.pas
+++ b/TlsLib.Benchmark/src/Core/OpenSslBenchSupport.pas
@@ -1,0 +1,151 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit OpenSslBenchSupport;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  mormot.core.base,
+  mormot.crypt.secure,
+  mormot.lib.openssl11,
+  TlsBenchmarkData;
+
+type
+  /// <summary>
+  /// Shared low-level OpenSSL setup for the benchmark peers, driven through mORMot's
+  /// binding: loading the libraries, reporting the exact version measured (so a run
+  /// records which OpenSSL produced the figures), building a client/server SSL_CTX with
+  /// the version, cipher list and supported-groups pinned to match the TlsLib peer, and
+  /// shuttling bytes between a pair of memory BIOs.
+  /// </summary>
+  TOpenSslBench = class sealed(TObject)
+  public
+    /// <summary>True when the OpenSSL libraries loaded.</summary>
+    class function Available: Boolean; static;
+    /// <summary>The loaded OpenSSL version string (empty when unavailable).</summary>
+    class function VersionString: string; static;
+    /// <summary>A client SSL_CTX with the version and (optional) cipher list / groups pinned.</summary>
+    class function NewClientCtx(AWireVersion: UInt16;
+      const ACipherList, AGroups: string): PSSL_CTX; static;
+    /// <summary>A server SSL_CTX as NewClientCtx plus the loaded EC leaf credential.</summary>
+    class function NewServerCtx(const ACredential: TTlsBenchmarkCredential;
+      AWireVersion: UInt16; const ACipherList, AGroups: string): PSSL_CTX; static;
+    /// <summary>Moves everything queued in ASource's memory BIO into ADestination's.</summary>
+    class procedure DrainBio(ASource, ADestination: PBIO; var AScratch: TBytes); static;
+  end;
+
+implementation
+
+const
+  // OpenSSL's SSL_CTRL_SET_GROUPS_LIST (ssl.h); mORMot exposes no typed groups setter, so
+  // the supported-groups list is pinned through the generic ctrl to match the TlsLib peer
+  SSL_CTRL_SET_GROUPS_LIST = 92;
+  // OpenSSL_version() selector for the human-readable version string (OPENSSL_VERSION)
+  OPENSSL_VERSION_STRING = 0;
+
+class function TOpenSslBench.Available: Boolean;
+begin
+  Result := OpenSslIsAvailable;
+end;
+
+class function TOpenSslBench.VersionString: string;
+begin
+  if OpenSslIsAvailable then
+    Result := string(OpenSSL_version(OPENSSL_VERSION_STRING))
+  else
+    Result := '';
+end;
+
+function DerBytesToPem(const ADer: TBytes; AKind: TPemKind): RawByteString;
+var
+  LDer: RawByteString;
+begin
+  SetString(LDer, PAnsiChar(@ADer[0]), System.Length(ADer));
+  Result := RawByteString(DerToPem(TCertDer(LDer), AKind));
+end;
+
+procedure PinGroups(ACtx: PSSL_CTX; const AGroups: string);
+var
+  LGroups: RawUtf8;
+begin
+  if AGroups = '' then
+    Exit;
+  LGroups := RawUtf8(AGroups);
+  if SSL_CTX_ctrl(ACtx, SSL_CTRL_SET_GROUPS_LIST, 0, PUtf8Char(LGroups)) <= 0 then
+    raise ETlsBenchmarkError.CreateFmt('OpenSSL rejected the groups list "%s"', [AGroups]);
+end;
+
+class function TOpenSslBench.NewClientCtx(AWireVersion: UInt16;
+  const ACipherList, AGroups: string): PSSL_CTX;
+begin
+  Result := SSL_CTX_new(TLS_client_method());
+  if Result = nil then
+    raise ETlsBenchmarkError.Create('OpenSSL could not create a client SSL context');
+  SSL_CTX_set_min_proto_version(Result, AWireVersion);
+  SSL_CTX_set_max_proto_version(Result, AWireVersion);
+  PinGroups(Result, AGroups);
+  if ACipherList <> '' then
+    SSL_CTX_set_cipher_list(Result, PUtf8Char(RawUtf8(ACipherList)));
+end;
+
+class function TOpenSslBench.NewServerCtx(const ACredential: TTlsBenchmarkCredential;
+  AWireVersion: UInt16; const ACipherList, AGroups: string): PSSL_CTX;
+var
+  LPem: RawByteString;
+  LBio: PBIO;
+  LCert: PX509;
+  LKey: PEVP_PKEY;
+begin
+  Result := SSL_CTX_new(TLS_server_method());
+  if Result = nil then
+    raise ETlsBenchmarkError.Create('OpenSSL could not create a server SSL context');
+  SSL_CTX_set_min_proto_version(Result, AWireVersion);
+  SSL_CTX_set_max_proto_version(Result, AWireVersion);
+  PinGroups(Result, AGroups);
+  if ACipherList <> '' then
+    SSL_CTX_set_cipher_list(Result, PUtf8Char(RawUtf8(ACipherList)));
+
+  LPem := DerBytesToPem(ACredential.LeafCertDer, pemCertificate);
+  LBio := BIO_new(BIO_s_mem());
+  BIO_write(LBio, PAnsiChar(LPem), System.Length(LPem));
+  LCert := PEM_read_bio_X509(LBio, nil, nil, nil);
+  BIO_free(LBio);
+  if (LCert = nil) or (SSL_CTX_use_certificate(Result, LCert) <> 1) then
+    raise ETlsBenchmarkError.Create('OpenSSL rejected the benchmark certificate');
+
+  LPem := DerBytesToPem(ACredential.LeafKeyDer, pemPrivateKey);
+  LBio := BIO_new(BIO_s_mem());
+  BIO_write(LBio, PAnsiChar(LPem), System.Length(LPem));
+  LKey := PEM_read_bio_PrivateKey(LBio, nil, nil, nil);
+  BIO_free(LBio);
+  if (LKey = nil) or (SSL_CTX_use_PrivateKey(Result, LKey) <> 1) then
+    raise ETlsBenchmarkError.Create('OpenSSL rejected the benchmark private key');
+end;
+
+class procedure TOpenSslBench.DrainBio(ASource, ADestination: PBIO;
+  var AScratch: TBytes);
+var
+  LGot: Int32;
+begin
+  repeat
+    LGot := BIO_read(ASource, @AScratch[0], System.Length(AScratch));
+    if LGot > 0 then
+      BIO_write(ADestination, @AScratch[0], LGot);
+  until LGot <= 0;
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/OpenSslHandshakePeer.pas
+++ b/TlsLib.Benchmark/src/Core/OpenSslHandshakePeer.pas
@@ -1,0 +1,146 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit OpenSslHandshakePeer;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  mormot.lib.openssl11,
+  OpenSslBenchSupport,
+  TlsBenchmarkData;
+
+type
+  /// <summary>
+  /// The OpenSSL reference side of the handshake benchmark, driven entirely in memory.
+  /// Two SSL_CTX (client + server) are built once with the version and supported groups
+  /// pinned and the EC credential loaded into the server, and each RunOneHandshake wires a
+  /// fresh SSL pair to a pair of memory BIOs and pumps a full handshake to completion,
+  /// mirroring the TlsLib peer. The client keeps OpenSSL's default (no peer verification).
+  /// </summary>
+  TOpenSslHandshakePeer = class sealed(TObject)
+  strict private
+  var
+    FClientCtx: PSSL_CTX;
+    FServerCtx: PSSL_CTX;
+    FScratch: TBytes;
+  public
+    /// <summary>True when the OpenSSL libraries loaded.</summary>
+    class function IsAvailable: Boolean; static;
+    constructor Create(const ACredential: TTlsBenchmarkCredential;
+      AWireVersion: UInt16; const AGroups: string);
+    destructor Destroy; override;
+    /// <summary>One complete client+server handshake; raises on a non-completing exchange.</summary>
+    procedure RunOneHandshake;
+  end;
+
+implementation
+
+const
+  CScratchBuffer = 16384;
+  CMaxRounds = 64;
+  // pin an ECDHE-ECDSA AEAD for the 1.2 rows so it uses the EC leaf (the 1.3 suite set is
+  // negotiated from the fixed 1.3 ciphers); the AEAD choice is irrelevant to handshake cost
+  CCipherTls12 = 'ECDHE-ECDSA-AES128-GCM-SHA256';
+
+class function TOpenSslHandshakePeer.IsAvailable: Boolean;
+begin
+  Result := TOpenSslBench.Available;
+end;
+
+constructor TOpenSslHandshakePeer.Create(const ACredential: TTlsBenchmarkCredential;
+  AWireVersion: UInt16; const AGroups: string);
+var
+  LCipher: string;
+begin
+  inherited Create;
+  if not TOpenSslBench.Available then
+    raise ETlsBenchmarkError.Create('OpenSSL libraries are not available');
+  SetLength(FScratch, CScratchBuffer);
+  if AWireVersion = TLS1_2_VERSION then
+    LCipher := CCipherTls12
+  else
+    LCipher := '';
+  FClientCtx := TOpenSslBench.NewClientCtx(AWireVersion, LCipher, AGroups);
+  FServerCtx := TOpenSslBench.NewServerCtx(ACredential, AWireVersion, LCipher, AGroups);
+end;
+
+destructor TOpenSslHandshakePeer.Destroy;
+begin
+  if FServerCtx <> nil then
+    SSL_CTX_free(FServerCtx);
+  if FClientCtx <> nil then
+    SSL_CTX_free(FClientCtx);
+  inherited Destroy;
+end;
+
+procedure TOpenSslHandshakePeer.RunOneHandshake;
+var
+  LClient, LServer: PSSL;
+  LClientRead, LClientWrite, LServerRead, LServerWrite: PBIO;
+  LRounds, LRet, LErr: Int32;
+  LClientDone, LServerDone: Boolean;
+
+  procedure Step(ASsl: PSSL; AConnect: Boolean; var ADone: Boolean);
+  begin
+    if AConnect then
+      LRet := SSL_connect(ASsl)
+    else
+      LRet := SSL_accept(ASsl);
+    if LRet = 1 then
+      ADone := True
+    else
+    begin
+      LErr := SSL_get_error(ASsl, LRet);
+      if (LErr <> SSL_ERROR_WANT_READ) and (LErr <> SSL_ERROR_WANT_WRITE) then
+        raise ETlsBenchmarkError.CreateFmt('OpenSSL handshake error (%d)', [LErr]);
+    end;
+  end;
+
+begin
+  LClient := SSL_new(FClientCtx);
+  LServer := SSL_new(FServerCtx);
+  LClientRead := BIO_new(BIO_s_mem());
+  LClientWrite := BIO_new(BIO_s_mem());
+  LServerRead := BIO_new(BIO_s_mem());
+  LServerWrite := BIO_new(BIO_s_mem());
+  // SSL_set_bio hands ownership of both BIOs to the SSL, so SSL_free frees them
+  SSL_set_bio(LClient, LClientRead, LClientWrite);
+  SSL_set_bio(LServer, LServerRead, LServerWrite);
+
+  LClientDone := False;
+  LServerDone := False;
+  LRounds := 0;
+  try
+    repeat
+      Inc(LRounds);
+      if not LClientDone then
+        Step(LClient, True, LClientDone);
+      TOpenSslBench.DrainBio(LClientWrite, LServerRead, FScratch); // client -> server
+      if not LServerDone then
+        Step(LServer, False, LServerDone);
+      TOpenSslBench.DrainBio(LServerWrite, LClientRead, FScratch); // server -> client
+    until (LClientDone and LServerDone) or (LRounds > CMaxRounds);
+
+    if not (LClientDone and LServerDone) then
+      raise ETlsBenchmarkError.Create('OpenSSL handshake did not complete');
+  finally
+    SSL_free(LClient);
+    SSL_free(LServer);
+  end;
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/OpenSslThroughputPeer.pas
+++ b/TlsLib.Benchmark/src/Core/OpenSslThroughputPeer.pas
@@ -1,0 +1,158 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit OpenSslThroughputPeer;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  mormot.lib.openssl11,
+  OpenSslBenchSupport,
+  TlsBenchmarkData;
+
+type
+  /// <summary>
+  /// The OpenSSL side of the record-throughput benchmark. One TLS 1.2 connection is
+  /// established up front (a single AEAD cipher pinned) over a pair of memory BIOs, then
+  /// each SendOnce SSL_writes a fixed payload on the client and SSL_reads it on the server
+  /// - the OpenSSL record layer's steady-state seal+open cost, mirroring the TlsLib peer.
+  /// </summary>
+  TOpenSslThroughputPeer = class sealed(TObject)
+  strict private
+  var
+    FClientCtx, FServerCtx: PSSL_CTX;
+    FClient, FServer: PSSL;
+    FClientWrite, FServerRead: PBIO;
+    FPayload, FRecv, FScratch: TBytes;
+    FRecordSize: Int32;
+  public
+    class function IsAvailable: Boolean; static;
+    constructor Create(const ACredential: TTlsBenchmarkCredential;
+      const ACipher, AGroups: string; ARecordSize, APayloadBytes: Int32);
+    destructor Destroy; override;
+    /// <summary>Seal + deliver + open one payload over the established connection.</summary>
+    procedure SendOnce;
+  end;
+
+implementation
+
+const
+  CScratchBuffer = 65536;
+  CMaxRounds = 64;
+
+class function TOpenSslThroughputPeer.IsAvailable: Boolean;
+begin
+  Result := TOpenSslBench.Available;
+end;
+
+constructor TOpenSslThroughputPeer.Create(const ACredential: TTlsBenchmarkCredential;
+  const ACipher, AGroups: string; ARecordSize, APayloadBytes: Int32);
+var
+  LClientRead, LServerWrite: PBIO;
+  LRounds, LRet, LErr: Int32;
+  LClientDone, LServerDone: Boolean;
+
+  procedure Step(ASsl: PSSL; AConnect: Boolean; var ADone: Boolean);
+  begin
+    if AConnect then
+      LRet := SSL_connect(ASsl)
+    else
+      LRet := SSL_accept(ASsl);
+    if LRet = 1 then
+      ADone := True
+    else
+    begin
+      LErr := SSL_get_error(ASsl, LRet);
+      if (LErr <> SSL_ERROR_WANT_READ) and (LErr <> SSL_ERROR_WANT_WRITE) then
+        raise ETlsBenchmarkError.CreateFmt('OpenSSL throughput handshake error (%d)', [LErr]);
+    end;
+  end;
+
+begin
+  inherited Create;
+  if not TOpenSslBench.Available then
+    raise ETlsBenchmarkError.Create('OpenSSL libraries are not available');
+  FRecordSize := ARecordSize;
+  SetLength(FScratch, CScratchBuffer);
+  SetLength(FRecv, CScratchBuffer);
+  SetLength(FPayload, APayloadBytes);
+
+  FClientCtx := TOpenSslBench.NewClientCtx(TLS1_2_VERSION, ACipher, AGroups);
+  FServerCtx := TOpenSslBench.NewServerCtx(ACredential, TLS1_2_VERSION, ACipher, AGroups);
+
+  FClient := SSL_new(FClientCtx);
+  FServer := SSL_new(FServerCtx);
+  LClientRead := BIO_new(BIO_s_mem());
+  FClientWrite := BIO_new(BIO_s_mem());
+  FServerRead := BIO_new(BIO_s_mem());
+  LServerWrite := BIO_new(BIO_s_mem());
+  SSL_set_bio(FClient, LClientRead, FClientWrite);
+  SSL_set_bio(FServer, FServerRead, LServerWrite);
+
+  LClientDone := False;
+  LServerDone := False;
+  LRounds := 0;
+  repeat
+    Inc(LRounds);
+    if not LClientDone then
+      Step(FClient, True, LClientDone);
+    TOpenSslBench.DrainBio(FClientWrite, FServerRead, FScratch);
+    if not LServerDone then
+      Step(FServer, False, LServerDone);
+    TOpenSslBench.DrainBio(LServerWrite, LClientRead, FScratch);
+  until (LClientDone and LServerDone) or (LRounds > CMaxRounds);
+
+  if not (LClientDone and LServerDone) then
+    raise ETlsBenchmarkError.Create('OpenSSL throughput handshake did not complete');
+end;
+
+destructor TOpenSslThroughputPeer.Destroy;
+begin
+  // SSL_free frees the BIOs it owns (set via SSL_set_bio)
+  if FClient <> nil then
+    SSL_free(FClient);
+  if FServer <> nil then
+    SSL_free(FServer);
+  if FServerCtx <> nil then
+    SSL_CTX_free(FServerCtx);
+  if FClientCtx <> nil then
+    SSL_CTX_free(FClientCtx);
+  inherited Destroy;
+end;
+
+procedure TOpenSslThroughputPeer.SendOnce;
+var
+  LOffset, LChunk, LGot: Int32;
+begin
+  // seal the payload as records of FRecordSize (one SSL_write -> one record), delivering
+  // each to the server as it is produced
+  LOffset := 0;
+  while LOffset < System.Length(FPayload) do
+  begin
+    LChunk := System.Length(FPayload) - LOffset;
+    if LChunk > FRecordSize then
+      LChunk := FRecordSize;
+    SSL_write(FClient, @FPayload[LOffset], LChunk);
+    Inc(LOffset, LChunk);
+    TOpenSslBench.DrainBio(FClientWrite, FServerRead, FScratch);
+  end;
+  // open (decrypt) every delivered record; SSL_read drains until WANT_READ (<= 0)
+  repeat
+    LGot := SSL_read(FServer, @FRecv[0], System.Length(FRecv));
+  until LGot <= 0;
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/TlsBenchmarkData.pas
+++ b/TlsLib.Benchmark/src/Core/TlsBenchmarkData.pas
@@ -1,0 +1,141 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit TlsBenchmarkData;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  Classes;
+
+type
+  /// <summary>A handshake-benchmark setup or run failure (missing data, unavailable
+  /// OpenSSL, a non-completing handshake).</summary>
+  ETlsBenchmarkError = class(Exception);
+
+  /// <summary>The EC P-256 test credential shared by both handshake peers: a leaf
+  /// certificate + its PKCS#8 private key (server side) and the issuing root (the
+  /// TlsLib client's trust anchor). DER bytes, decoded from the interop test vector.</summary>
+  TTlsBenchmarkCredential = record
+    LeafCertDer: TBytes;
+    LeafKeyDer: TBytes;
+    RootCertDer: TBytes;
+  end;
+
+  /// <summary>Locates and decodes the shared EC P-256 chain used by the handshake
+  /// benchmarks. Self-contained (no interop-harness dependency) so the benchmark's
+  /// only real dependencies are the TlsLib package and mORMot's OpenSSL binding.</summary>
+  TTlsBenchmarkData = class sealed(TObject)
+  strict private
+    class function DecodeHex(const AHex: string): TBytes; static;
+    class function LocateChainFile: string; static;
+  public
+    class function LoadEcP256: TTlsBenchmarkCredential; static;
+  end;
+
+implementation
+
+resourcestring
+  SChainFileNotFound =
+    'benchmark: could not locate EcP256Chain.txt (searched up from the executable)';
+  SMissingField = 'benchmark: EcP256Chain.txt is missing the "%s" field';
+
+const
+  // relative to a repository root; the first that resolves wins
+  CChainCandidates: array [0 .. 1] of string = (
+    'TlsLib.Interop' + PathDelim + 'Data' + PathDelim + 'Certs' + PathDelim + 'EcP256Chain.txt',
+    'TlsLib.Tests' + PathDelim + 'Data' + PathDelim + 'Certs' + PathDelim + 'EcP256Chain.txt');
+
+class function TTlsBenchmarkData.DecodeHex(const AHex: string): TBytes;
+var
+  LClean: string;
+  LI, LN: Int32;
+
+  function NibbleOf(AC: Char): Int32;
+  begin
+    case AC of
+      '0' .. '9': Result := Ord(AC) - Ord('0');
+      'a' .. 'f': Result := Ord(AC) - Ord('a') + 10;
+      'A' .. 'F': Result := Ord(AC) - Ord('A') + 10;
+    else
+      Result := -1;
+    end;
+  end;
+
+begin
+  // tolerate embedded whitespace so a wrapped or space-grouped hex field still decodes
+  LClean := '';
+  for LI := 1 to System.Length(AHex) do
+    if NibbleOf(AHex[LI]) >= 0 then
+      LClean := LClean + AHex[LI];
+
+  LN := System.Length(LClean) div 2;
+  Result := nil;
+  SetLength(Result, LN);
+  for LI := 0 to LN - 1 do
+    Result[LI] := Byte((NibbleOf(LClean[LI * 2 + 1]) shl 4)
+      or NibbleOf(LClean[LI * 2 + 2]));
+end;
+
+class function TTlsBenchmarkData.LocateChainFile: string;
+var
+  LDir, LCandidate: string;
+  LDepth, LI: Int32;
+begin
+  LDir := ExtractFilePath(ExpandFileName(ParamStr(0)));
+  for LDepth := 0 to 9 do
+  begin
+    for LI := System.Low(CChainCandidates) to System.High(CChainCandidates) do
+    begin
+      LCandidate := IncludeTrailingPathDelimiter(LDir) + CChainCandidates[LI];
+      if FileExists(LCandidate) then
+        Exit(LCandidate);
+    end;
+    LDir := ExtractFileDir(ExcludeTrailingPathDelimiter(LDir));
+    if LDir = '' then
+      Break;
+  end;
+  raise EFileNotFoundException.Create(SChainFileNotFound);
+end;
+
+class function TTlsBenchmarkData.LoadEcP256: TTlsBenchmarkCredential;
+var
+  LFields: TStringList;
+
+  function Field(const AName: string): TBytes;
+  var
+    LHex: string;
+  begin
+    if LFields.IndexOfName(AName) < 0 then
+      raise EArgumentException.CreateFmt(SMissingField, [AName]);
+    LHex := LFields.Values[AName];
+    Result := DecodeHex(LHex);
+  end;
+
+begin
+  LFields := TStringList.Create;
+  try
+    LFields.NameValueSeparator := '=';
+    LFields.LoadFromFile(LocateChainFile);
+    Result.LeafCertDer := Field('leaf_cert');
+    Result.LeafKeyDer := Field('leaf_key');
+    Result.RootCertDer := Field('root_cert');
+  finally
+    LFields.Free;
+  end;
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/TlsHandshakeBenchmark.pas
+++ b/TlsLib.Benchmark/src/Core/TlsHandshakeBenchmark.pas
@@ -1,0 +1,231 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit TlsHandshakeBenchmark;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  BenchmarkCommon;
+
+type
+  /// <summary>
+  /// Times full 1-RTT TLS handshakes for TlsLib against OpenSSL, in memory, across the
+  /// supported ECDHE groups (X25519 and the NIST P-256/384/521 curves) for both TLS 1.3
+  /// and hardened TLS 1.2 - X25519 and the classical curves are all version-agnostic
+  /// ECDHE groups per RFC 8422, usable in 1.2 and 1.3 alike. Each side also offers the
+  /// leaf certificate's own curve so it is present in supported_groups (RFC 8422 5.4),
+  /// and uses the same EC P-256 certificate with peer verification disabled, so the figure
+  /// reflects the handshake proper (ECDHE + the ECDSA CertificateVerify) rather than PKIX.
+  ///
+  /// Caveat by design: the handshake cost is dominated by the asymmetric crypto, which
+  /// TlsLib delegates to CryptoLib. This is therefore an end-to-end, user-facing figure
+  /// (how fast a connection is), not a measure of TlsLib's own orchestration - that
+  /// overhead is a thin slice on top of the EC operations.
+  /// </summary>
+  TTlsHandshakeBenchmark = class sealed(TObject)
+  public
+    /// <summary>Runs every scenario and returns the rendered table width.</summary>
+    class function Run(ALogProc: TBenchmarkLogProc): Int32; static;
+  end;
+
+implementation
+
+uses
+  StrUtils,
+  TlpTlsVersion,
+  TlpNegotiationTypes,
+  TlpCryptoAlgorithms,
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider,
+  TlsBenchmarkData,
+  TlsLibHandshakePeer,
+  OpenSslHandshakePeer;
+
+const
+  BENCH_HS_VALUE_COL_WIDTH = 16;
+  // fixed-cost handshakes ahead of measurement so the per-curve EC precomputation, the
+  // allocator and the code paths are warm - the measured window is then steady-state
+  BENCH_HS_WARMUP = 25;
+
+type
+  TBenchCurve = record
+    Code: UInt16;      // TlsLib named-group codepoint (the ECDHE group)
+    OsslName: string;  // the same curve as an OpenSSL groups-list token
+    Name: string;      // display label
+  end;
+
+  TBenchVersion = record
+    Wire: UInt16;
+    Name: string;
+  end;
+
+class function TTlsHandshakeBenchmark.Run(ALogProc: TBenchmarkLogProc): Int32;
+var
+  LProvider: ICryptoProvider;
+  LCredential: TTlsBenchmarkCredential;
+  LOpenSslAvailable: Boolean;
+  LDeferred: TArray<string>;
+  LCurves: array [0 .. 3] of TBenchCurve;
+  LVersions: array [0 .. 1] of TBenchVersion;
+  LCertCode: UInt16;
+  LCertOssl, LRowName, LOsslGroups: string;
+  LVi, LCi: Int32;
+  LTlsMs, LOslMs: Double;
+
+  function HsPerSec(AMs: Double): String;
+  begin
+    if AMs > 0.0 then
+      Result := FormatFloat('#,##0.00', 1000.0 / AMs, TBenchmarkReport.FloatFormat)
+    else
+      Result := 'ERROR';
+  end;
+
+  procedure Note(const AMessage: string);
+  begin
+    SetLength(LDeferred, System.Length(LDeferred) + 1);
+    LDeferred[System.High(LDeferred)] := AMessage;
+  end;
+
+  function OsslNameOf(ACode: UInt16): string;
+  var
+    LI: Int32;
+  begin
+    Result := '';
+    for LI := System.Low(LCurves) to System.High(LCurves) do
+      if LCurves[LI].Code = ACode then
+        Exit(LCurves[LI].OsslName);
+  end;
+
+  // the leaf's own curve, read from the certificate, so the OpenSSL groups list can include
+  // it (RFC 8422 5.4) exactly as the TlsLib peer does; 0 for a non-ECDSA leaf
+  function CertGroupCode: UInt16;
+  var
+    LKind: TCertKeyKind;
+    LCurve: UInt16;
+  begin
+    Result := 0;
+    if LProvider.CertificateKeyKind(LCredential.LeafCertDer, LKind, LCurve)
+      and (LKind = TCertKeyKind.Ecdsa) then
+      Result := LCurve;
+  end;
+
+  function MeasureTls(AWire, ACurve: UInt16; const AName: string): Double;
+  var
+    LPeer: TTlsLibHandshakePeer;
+    LWarm: Int32;
+  begin
+    Result := -1.0;
+    try
+      LPeer := TTlsLibHandshakePeer.Create(LProvider, LCredential, AWire, ACurve);
+      try
+        for LWarm := 1 to BENCH_HS_WARMUP do
+          LPeer.RunOneHandshake;
+        Result := TBenchmarkTiming.MeasureMeanMillisecondsPerOp(LPeer.RunOneHandshake);
+      finally
+        LPeer.Free;
+      end;
+    except
+      on E: Exception do
+        Note(AName + ' - TlsLib: ' + E.Message);
+    end;
+  end;
+
+  function MeasureOssl(AWire: UInt16; const AGroups, AName: string): Double;
+  var
+    LPeer: TOpenSslHandshakePeer;
+    LWarm: Int32;
+  begin
+    Result := -1.0;
+    if not LOpenSslAvailable then
+      Exit;
+    try
+      LPeer := TOpenSslHandshakePeer.Create(LCredential, AWire, AGroups);
+      try
+        for LWarm := 1 to BENCH_HS_WARMUP do
+          LPeer.RunOneHandshake;
+        Result := TBenchmarkTiming.MeasureMeanMillisecondsPerOp(LPeer.RunOneHandshake);
+      finally
+        LPeer.Free;
+      end;
+    except
+      on E: Exception do
+        Note(AName + ' - OpenSSL: ' + E.Message);
+    end;
+  end;
+
+begin
+  Result := BENCH_LABEL_COL_WIDTH + 5 * BENCH_HS_VALUE_COL_WIDTH;
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LCredential := TTlsBenchmarkData.LoadEcP256;
+  LOpenSslAvailable := TOpenSslHandshakePeer.IsAvailable;
+  LDeferred := nil;
+
+  LCurves[0].Code := TNamedGroupCatalog.X25519;    LCurves[0].OsslName := 'X25519'; LCurves[0].Name := 'X25519';
+  LCurves[1].Code := TNamedGroupCatalog.Secp256r1; LCurves[1].OsslName := 'P-256';  LCurves[1].Name := 'secp256r1';
+  LCurves[2].Code := TNamedGroupCatalog.Secp384r1; LCurves[2].OsslName := 'P-384';  LCurves[2].Name := 'secp384r1';
+  LCurves[3].Code := TNamedGroupCatalog.Secp521r1; LCurves[3].OsslName := 'P-521';  LCurves[3].Name := 'secp521r1';
+  LVersions[0].Wire := TlsWireVersionTls13; LVersions[0].Name := 'TLS 1.3';
+  LVersions[1].Wire := TlsWireVersionTls12; LVersions[1].Name := 'TLS 1.2';
+
+  LCertCode := CertGroupCode;
+  LCertOssl := OsslNameOf(LCertCode);
+
+  ALogProc('TLS handshake throughput - ECDHE per row, EC P-256 certificate, peer verification off');
+  ALogProc('reusable config / SSL_CTX built once; a fresh engine/SSL + full 1-RTT handshake is timed');
+  if not LOpenSslAvailable then
+    ALogProc('OpenSSL not loaded - reporting TlsLib only (put libssl / libcrypto next to the executable)');
+  ALogProc(TBenchmarkReport.BuildSeparator(Result));
+  ALogProc(TBenchmarkReport.BuildHeaderRow('Scenario',
+    ['TlsLib hs/s', 'OpenSSL hs/s', 'TlsLib ms', 'OpenSSL ms', 'TlsLib/OpenSSL'],
+    BENCH_HS_VALUE_COL_WIDTH));
+  ALogProc(TBenchmarkReport.BuildSeparator(Result));
+
+  for LVi := System.Low(LVersions) to System.High(LVersions) do
+  begin
+    if LVi > System.Low(LVersions) then
+      ALogProc('');
+    for LCi := System.Low(LCurves) to System.High(LCurves) do
+    begin
+      LRowName := LVersions[LVi].Name + ' (' + LCurves[LCi].Name + ')';
+
+      // the OpenSSL groups list: the ECDHE curve, plus the certificate's curve when it
+      // differs (TlsLib derives the same fallback from the certificate itself)
+      LOsslGroups := LCurves[LCi].OsslName;
+      if (LCertOssl <> '') and (LCertCode <> LCurves[LCi].Code) then
+        LOsslGroups := LOsslGroups + ':' + LCertOssl;
+
+      LTlsMs := MeasureTls(LVersions[LVi].Wire, LCurves[LCi].Code, LRowName);
+      LOslMs := MeasureOssl(LVersions[LVi].Wire, LOsslGroups, LRowName);
+
+      ALogProc(TBenchmarkReport.BuildDataRow(LRowName,
+        [HsPerSec(LTlsMs),
+         IfThen(LOpenSslAvailable, HsPerSec(LOslMs), 'N/A'),
+         TBenchmarkFormat.FormatMeanMilliseconds(LTlsMs),
+         IfThen(LOpenSslAvailable, TBenchmarkFormat.FormatMeanMilliseconds(LOslMs), 'N/A'),
+         IfThen((LTlsMs > 0.0) and (LOslMs > 0.0),
+           FormatFloat('0.00', LOslMs / LTlsMs, TBenchmarkReport.FloatFormat) + 'x', 'N/A')],
+        BENCH_HS_VALUE_COL_WIDTH));
+    end;
+  end;
+
+  for LVi := System.Low(LDeferred) to System.High(LDeferred) do
+    ALogProc('  ! ' + LDeferred[LVi]);
+
+  ALogProc(TBenchmarkReport.BuildSeparator(Result));
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/TlsLibHandshakePeer.pas
+++ b/TlsLib.Benchmark/src/Core/TlsLibHandshakePeer.pas
@@ -1,0 +1,156 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit TlsLibHandshakePeer;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  TlpICryptoProvider,
+  TlpTlsPresets,
+  TlpITlsConfigBuilder,
+  TlpITlsConfig,
+  TlpTlsEngineFactory,
+  TlpITlsEngine,
+  TlpCryptoAlgorithms,
+  TlsBenchmarkData;
+
+type
+  /// <summary>
+  /// The TlsLib side of the handshake benchmark. The two frozen configs (client +
+  /// server) are built once - the reusable, per-process setup, analogous to an OpenSSL
+  /// SSL_CTX - and each RunOneHandshake creates a fresh engine pair and drives a full
+  /// 1-RTT handshake to completion over an in-memory pump (no sockets), analogous to
+  /// SSL_new + the handshake. Peer-certificate PKIX validation is disabled on the client
+  /// (WithDangerousInsecureSkipVerify) so the measurement isolates the handshake proper -
+  /// the ECDHE key exchange plus the ECDSA-P256 CertificateVerify - matching the OpenSSL
+  /// peer's SSL_VERIFY_NONE. The offered version and ECDHE group are pinned on both ends.
+  /// </summary>
+  TTlsLibHandshakePeer = class sealed(TObject)
+  strict private
+  var
+    FClientConfig: ITlsClientConfig;
+    FServerConfig: ITlsServerConfig;
+    FScratch: TBytes;
+    /// <summary>The ECDHE group to benchmark, plus the leaf certificate's own curve when it
+    /// differs: an ECDSA leaf's curve must appear in supported_groups (RFC 8422 5.4) whatever
+    /// the negotiated ECDHE group. ACertGroup is 0 for a non-ECDSA leaf (no such constraint).</summary>
+    class function OfferedGroups(AGroupCode, ACertGroup: UInt16): TArray<UInt16>; static;
+    /// <summary>Drains everything ASrc has queued into ADst; True if any bytes moved.</summary>
+    function Pump(const ASrc, ADst: ITlsEngine): Boolean;
+  public
+    constructor Create(const AProvider: ICryptoProvider;
+      const ACredential: TTlsBenchmarkCredential; AWireVersion, AGroupCode: UInt16);
+    /// <summary>One complete client+server handshake; raises on a non-completing exchange.</summary>
+    procedure RunOneHandshake;
+  end;
+
+implementation
+
+const
+  // one TLS record's ciphertext never exceeds ~2^14 + overhead; a 16 KiB pull buffer
+  // takes each flight in as few TakeOutgoing calls as the record layer allows
+  CPumpBuffer = 16384;
+  // a completed 1-RTT handshake never needs anywhere near this many pump rounds; the cap
+  // only turns a hung exchange (a misconfiguration) into a raise instead of a spin
+  CMaxRounds = 64;
+
+class function TTlsLibHandshakePeer.OfferedGroups(AGroupCode,
+  ACertGroup: UInt16): TArray<UInt16>;
+begin
+  if (ACertGroup = 0) or (ACertGroup = AGroupCode) then
+    Result := TArray<UInt16>.Create(AGroupCode)
+  else
+    Result := TArray<UInt16>.Create(AGroupCode, ACertGroup);
+end;
+
+constructor TTlsLibHandshakePeer.Create(const AProvider: ICryptoProvider;
+  const ACredential: TTlsBenchmarkCredential; AWireVersion, AGroupCode: UInt16);
+var
+  LClientBuilder: ITlsConfigBuilder;
+  LServerBuilder: ITlsConfigBuilder;
+  LClient: ITlsClientConfigBuilder;
+  LServer: ITlsServerConfigBuilder;
+  LKind: TCertKeyKind;
+  LCertCurve, LCertGroup: UInt16;
+begin
+  inherited Create;
+  SetLength(FScratch, CPumpBuffer);
+
+  // the leaf's own curve (RFC 8422 5.4 fallback), read from the certificate so the peer is
+  // not tied to one curve; 0 (offer nothing extra) for a non-ECDSA leaf
+  LCertGroup := 0;
+  if AProvider.CertificateKeyKind(ACredential.LeafCertDer, LKind, LCertCurve)
+    and (LKind = TCertKeyKind.Ecdsa) then
+    LCertGroup := LCertCurve;
+
+  // hold the builder in an interface local while configuring: the facets keep only a raw
+  // back-reference, so a captured owner is what refcounts and frees it after Build
+  LClientBuilder := TTlsPresets.Compatible(AProvider);
+  LClient := LClientBuilder.Client;
+  LClient.WithSupportedVersions(TArray<UInt16>.Create(AWireVersion));
+  LClient.WithPreferredGroups(OfferedGroups(AGroupCode, LCertGroup));
+  LClient.WithDangerousInsecureSkipVerify(True);
+  LClient.WithTrustAnchors(ACredential.RootCertDer); // a trust source is still required by Build
+  FClientConfig := LClient.Build;
+
+  LServerBuilder := TTlsPresets.Compatible(AProvider);
+  LServer := LServerBuilder.Server;
+  LServer.WithSupportedVersions(TArray<UInt16>.Create(AWireVersion));
+  LServer.WithPreferredGroups(OfferedGroups(AGroupCode, LCertGroup)); // AGroupCode first -> negotiated
+  LServer.WithCredential(ACredential.LeafCertDer, ACredential.LeafKeyDer);
+  FServerConfig := LServer.Build;
+end;
+
+function TTlsLibHandshakePeer.Pump(const ASrc, ADst: ITlsEngine): Boolean;
+var
+  LGot: Int32;
+begin
+  Result := False;
+  repeat
+    LGot := ASrc.TakeOutgoing(FScratch, 0);
+    if LGot > 0 then
+    begin
+      Result := True;
+      if ADst.ProcessInput(FScratch, 0, LGot) = TTlsOutcome.Fatal then
+        raise ETlsBenchmarkError.Create('TlsLib handshake did not complete');
+    end;
+  until LGot = 0;
+end;
+
+procedure TTlsLibHandshakePeer.RunOneHandshake;
+var
+  LClient, LServer: ITlsEngine;
+  LRounds: Int32;
+  LMoved: Boolean;
+begin
+  LClient := TTlsEngineFactory.CreateClientEngine(FClientConfig, 'localhost');
+  LServer := TTlsEngineFactory.CreateServerEngine(FServerConfig);
+  LClient.StartHandshake;
+
+  LRounds := 0;
+  repeat
+    Inc(LRounds);
+    LMoved := Pump(LClient, LServer);
+    LMoved := Pump(LServer, LClient) or LMoved;
+  until ((not LClient.IsHandshaking) and (not LServer.IsHandshaking))
+    or (not LMoved) or (LRounds > CMaxRounds);
+
+  if LClient.IsHandshaking or LServer.IsHandshaking then
+    raise ETlsBenchmarkError.Create('TlsLib handshake did not complete');
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/TlsLibThroughputPeer.pas
+++ b/TlsLib.Benchmark/src/Core/TlsLibThroughputPeer.pas
@@ -1,0 +1,203 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit TlsLibThroughputPeer;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  TlpICryptoProvider,
+  TlpTlsPresets,
+  TlpTlsVersion,
+  TlpITlsConfigBuilder,
+  TlpITlsConfig,
+  TlpTlsEngineFactory,
+  TlpITlsEngine,
+  TlpINegotiation,
+  TlpCipherSuiteRegistry,
+  TlpNegotiationTypes,
+  TlpCryptoAlgorithms,
+  TlsBenchmarkData;
+
+type
+  /// <summary>
+  /// The TlsLib side of the record-throughput benchmark. One hardened TLS 1.2 connection
+  /// is established up front with a single AEAD suite pinned, then each SendOnce seals a
+  /// fixed application-data payload on the client and opens it on the server over an
+  /// in-memory pump - the record layer's steady-state seal+open cost for that suite.
+  /// </summary>
+  TTlsLibThroughputPeer = class sealed(TObject)
+  strict private
+  var
+    FClient: ITlsEngine;
+    FServer: ITlsEngine;
+    FPayload: TBytes;
+    FScratch: TBytes;
+    FRecordSize: Int32;
+    function BuildConfigs(const AProvider: ICryptoProvider;
+      const ACredential: TTlsBenchmarkCredential; ASuiteCode: UInt16;
+      out AClientConfig: ITlsClientConfig; out AServerConfig: ITlsServerConfig): Boolean;
+  public
+    constructor Create(const AProvider: ICryptoProvider;
+      const ACredential: TTlsBenchmarkCredential; ASuiteCode: UInt16;
+      ARecordSize, APayloadBytes: Int32);
+    /// <summary>Bytes of application data moved per SendOnce (the throughput pass size).</summary>
+    function PayloadBytes: Int64;
+    /// <summary>Seal + deliver + open one payload over the established connection.</summary>
+    procedure SendOnce;
+  end;
+
+implementation
+
+const
+  // a wide pull buffer keeps the seal->open pump to a few TakeOutgoing/ProcessInput calls
+  CScratchBuffer = 65536;
+
+function SingleSuiteRegistry(const AProvider: ICryptoProvider;
+  ASuiteCode: UInt16): ICipherSuiteRegistry;
+var
+  LAll: ICipherSuiteRegistry;
+  LSuite: TTlsCipherSuite;
+begin
+  LAll := TCipherSuiteRegistry.CreateDualVersion(AProvider);
+  Result := TCipherSuiteRegistry.Create;
+  if LAll.TryGet(ASuiteCode, LSuite) then
+    Result.Add(LSuite);
+end;
+
+function OfferedGroups(const AProvider: ICryptoProvider;
+  const ACredential: TTlsBenchmarkCredential): TArray<UInt16>;
+var
+  LKind: TCertKeyKind;
+  LCurve: UInt16;
+begin
+  // X25519 for the ECDHE key exchange, plus the ECDSA leaf's curve (RFC 8422 5.4)
+  if AProvider.CertificateKeyKind(ACredential.LeafCertDer, LKind, LCurve)
+    and (LKind = TCertKeyKind.Ecdsa) and (LCurve <> TNamedGroupCatalog.X25519) then
+    Result := TArray<UInt16>.Create(TNamedGroupCatalog.X25519, LCurve)
+  else
+    Result := TArray<UInt16>.Create(TNamedGroupCatalog.X25519);
+end;
+
+function TTlsLibThroughputPeer.BuildConfigs(const AProvider: ICryptoProvider;
+  const ACredential: TTlsBenchmarkCredential; ASuiteCode: UInt16;
+  out AClientConfig: ITlsClientConfig; out AServerConfig: ITlsServerConfig): Boolean;
+var
+  LClientBuilder, LServerBuilder: ITlsConfigBuilder;
+  LClient: ITlsClientConfigBuilder;
+  LServer: ITlsServerConfigBuilder;
+  LGroups: TArray<UInt16>;
+begin
+  LGroups := OfferedGroups(AProvider, ACredential);
+
+  LClientBuilder := TTlsPresets.Compatible(AProvider);
+  LClient := LClientBuilder.Client;
+  LClient.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  LClient.WithPreferredGroups(LGroups);
+  LClient.WithCipherSuites(SingleSuiteRegistry(AProvider, ASuiteCode));
+  LClient.WithDangerousInsecureSkipVerify(True);
+  LClient.WithTrustAnchors(ACredential.RootCertDer);
+  AClientConfig := LClient.Build;
+
+  LServerBuilder := TTlsPresets.Compatible(AProvider);
+  LServer := LServerBuilder.Server;
+  LServer.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  LServer.WithPreferredGroups(LGroups);
+  LServer.WithCipherSuites(SingleSuiteRegistry(AProvider, ASuiteCode));
+  LServer.WithCredential(ACredential.LeafCertDer, ACredential.LeafKeyDer);
+  AServerConfig := LServer.Build;
+  Result := True;
+end;
+
+constructor TTlsLibThroughputPeer.Create(const AProvider: ICryptoProvider;
+  const ACredential: TTlsBenchmarkCredential; ASuiteCode: UInt16;
+  ARecordSize, APayloadBytes: Int32);
+var
+  LClientConfig: ITlsClientConfig;
+  LServerConfig: ITlsServerConfig;
+  LGot, LRounds: Int32;
+  LMoved: Boolean;
+begin
+  inherited Create;
+  FRecordSize := ARecordSize;
+  SetLength(FScratch, CScratchBuffer);
+  SetLength(FPayload, APayloadBytes);
+
+  BuildConfigs(AProvider, ACredential, ASuiteCode, LClientConfig, LServerConfig);
+  FClient := TTlsEngineFactory.CreateClientEngine(LClientConfig, 'localhost');
+  FServer := TTlsEngineFactory.CreateServerEngine(LServerConfig);
+
+  // establish the connection once (handshake to completion) before any measured pass
+  FClient.StartHandshake;
+  LRounds := 0;
+  repeat
+    Inc(LRounds);
+    LMoved := False;
+    repeat
+      LGot := FClient.TakeOutgoing(FScratch, 0);
+      if LGot > 0 then
+      begin
+        LMoved := True;
+        FServer.ProcessInput(FScratch, 0, LGot);
+      end;
+    until LGot = 0;
+    repeat
+      LGot := FServer.TakeOutgoing(FScratch, 0);
+      if LGot > 0 then
+      begin
+        LMoved := True;
+        FClient.ProcessInput(FScratch, 0, LGot);
+      end;
+    until LGot = 0;
+  until ((not FClient.IsHandshaking) and (not FServer.IsHandshaking))
+    or (not LMoved) or (LRounds > 64);
+
+  if FClient.IsHandshaking or FServer.IsHandshaking then
+    raise ETlsBenchmarkError.Create('TlsLib throughput handshake did not complete');
+end;
+
+function TTlsLibThroughputPeer.PayloadBytes: Int64;
+begin
+  Result := System.Length(FPayload);
+end;
+
+procedure TTlsLibThroughputPeer.SendOnce;
+var
+  LOffset, LChunk, LGot: Int32;
+begin
+  // seal the payload as records of FRecordSize (one Write -> one record), delivering each
+  // to the server as it is produced so the outgoing buffer stays bounded
+  LOffset := 0;
+  while LOffset < System.Length(FPayload) do
+  begin
+    LChunk := System.Length(FPayload) - LOffset;
+    if LChunk > FRecordSize then
+      LChunk := FRecordSize;
+    FClient.Write(FPayload, LOffset, LChunk);
+    Inc(LOffset, LChunk);
+    repeat
+      LGot := FClient.TakeOutgoing(FScratch, 0);
+      if LGot > 0 then
+        FServer.ProcessInput(FScratch, 0, LGot);
+    until LGot = 0;
+  end;
+  // open (decrypt) every delivered record
+  repeat
+    LGot := FServer.ReadAppData(FScratch, 0, System.Length(FScratch));
+  until LGot = 0;
+end;
+
+end.

--- a/TlsLib.Benchmark/src/Core/TlsRecordThroughputBenchmark.pas
+++ b/TlsLib.Benchmark/src/Core/TlsRecordThroughputBenchmark.pas
@@ -1,0 +1,203 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit TlsRecordThroughputBenchmark;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+uses
+  SysUtils,
+  BenchmarkCommon;
+
+type
+  /// <summary>
+  /// Times application-data throughput (MB/s) through an established hardened TLS 1.2
+  /// connection for TlsLib against OpenSSL, per AEAD suite (AES-128-GCM, AES-256-GCM,
+  /// ChaCha20-Poly1305) and TLS record size (256 B / 1400 B / 16 KB). X25519 ECDHE and the
+  /// same EC P-256 certificate are used on both sides; the connection is handshaked once,
+  /// then a fixed payload is chunked into records of each size, sealed on the client and
+  /// opened on the server - the record layer's steady-state cost, and how a smaller record
+  /// spreads the per-record header + AEAD tag over less data.
+  ///
+  /// Caveat by design: throughput is dominated by the AEAD, which TlsLib delegates to
+  /// CryptoLib, so this is an end-to-end figure (the framing overhead TlsLib adds is a
+  /// thin slice on top of the cipher).
+  /// </summary>
+  TTlsRecordThroughputBenchmark = class sealed(TObject)
+  public
+    /// <summary>Runs every AEAD suite and returns the rendered table width.</summary>
+    class function Run(ALogProc: TBenchmarkLogProc): Int32; static;
+  end;
+
+implementation
+
+uses
+  StrUtils,
+  TlpNegotiationTypes,
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider,
+  TlsBenchmarkData,
+  TlsLibThroughputPeer,
+  OpenSslThroughputPeer;
+
+const
+  BENCH_TP_VALUE_COL_WIDTH = 18;
+  // one connection's application-data payload sealed+opened per pass; a multiple of the
+  // 16 KiB record ceiling so the per-pass overhead is amortised into steady-state throughput
+  BENCH_TP_PAYLOAD = 256 * 1024;
+  // X25519 for the key exchange, P-256 for the certificate's own curve (RFC 8422 5.4)
+  BENCH_TP_OSSL_GROUPS = 'X25519:P-256';
+  // the application-write (TLS record) sizes measured: a tiny record, an MTU-sized record
+  // and the 16 KiB record ceiling - the payload is chunked into records of each size, so a
+  // smaller record spreads the per-record header + AEAD tag over less data
+  BENCH_TP_RECORD_SIZES: array [0 .. 2] of Int32 = (256, 1400, 16384);
+
+type
+  TThroughputSuite = record
+    TlsCode: UInt16;    // TlsLib TLS 1.2 cipher-suite codepoint
+    OsslCipher: string; // OpenSSL cipher-list token for the same suite
+    Name: string;       // display label
+  end;
+
+class function TTlsRecordThroughputBenchmark.Run(ALogProc: TBenchmarkLogProc): Int32;
+var
+  LProvider: ICryptoProvider;
+  LCredential: TTlsBenchmarkCredential;
+  LOpenSslAvailable: Boolean;
+  LDeferred: TArray<string>;
+  LSuites: array [0 .. 2] of TThroughputSuite;
+  LIdx, LSi: Int32;
+  LRowName: string;
+  LTlsMbps, LOslMbps: Double;
+
+  procedure Note(const AMessage: string);
+  begin
+    SetLength(LDeferred, System.Length(LDeferred) + 1);
+    LDeferred[System.High(LDeferred)] := AMessage;
+  end;
+
+  function Mbps(AValue: Double): String;
+  begin
+    if AValue > 0.0 then
+      Result := TBenchmarkFormat.FormatThroughputMbPerSec(AValue)
+    else
+      Result := 'ERROR';
+  end;
+
+  // exact record-size label (unlike FormatBufferSize, an MTU-sized 1400 stays "1400 B")
+  function RecordSizeLabel(ASize: Int32): String;
+  begin
+    if (ASize >= 1024) and (ASize mod 1024 = 0) then
+      Result := IntToStr(ASize div 1024) + ' KB'
+    else
+      Result := IntToStr(ASize) + ' B';
+  end;
+
+  function MeasureTls(ASuiteCode: UInt16; ARecordSize: Int32;
+    const AName: string): Double;
+  var
+    LPeer: TTlsLibThroughputPeer;
+  begin
+    Result := -1.0;
+    try
+      LPeer := TTlsLibThroughputPeer.Create(LProvider, LCredential, ASuiteCode,
+        ARecordSize, BENCH_TP_PAYLOAD);
+      try
+        Result := TBenchmarkTiming.MeasureThroughputMbPerSec(LPeer.SendOnce, LPeer.PayloadBytes);
+      finally
+        LPeer.Free;
+      end;
+    except
+      on E: Exception do
+        Note(AName + ' - TlsLib: ' + E.Message);
+    end;
+  end;
+
+  function MeasureOssl(const ACipher: string; ARecordSize: Int32;
+    const AName: string): Double;
+  var
+    LPeer: TOpenSslThroughputPeer;
+  begin
+    Result := -1.0;
+    if not LOpenSslAvailable then
+      Exit;
+    try
+      LPeer := TOpenSslThroughputPeer.Create(LCredential, ACipher, BENCH_TP_OSSL_GROUPS,
+        ARecordSize, BENCH_TP_PAYLOAD);
+      try
+        Result := TBenchmarkTiming.MeasureThroughputMbPerSec(LPeer.SendOnce, BENCH_TP_PAYLOAD);
+      finally
+        LPeer.Free;
+      end;
+    except
+      on E: Exception do
+        Note(AName + ' - OpenSSL: ' + E.Message);
+    end;
+  end;
+
+begin
+  Result := BENCH_LABEL_COL_WIDTH + 3 * BENCH_TP_VALUE_COL_WIDTH;
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LCredential := TTlsBenchmarkData.LoadEcP256;
+  LOpenSslAvailable := TOpenSslThroughputPeer.IsAvailable;
+  LDeferred := nil;
+
+  LSuites[0].TlsCode := TCipherSuites12.EcdheEcdsaAes128GcmSha256;
+  LSuites[0].OsslCipher := 'ECDHE-ECDSA-AES128-GCM-SHA256';
+  LSuites[0].Name := 'AES-128-GCM';
+  LSuites[1].TlsCode := TCipherSuites12.EcdheEcdsaAes256GcmSha384;
+  LSuites[1].OsslCipher := 'ECDHE-ECDSA-AES256-GCM-SHA384';
+  LSuites[1].Name := 'AES-256-GCM';
+  LSuites[2].TlsCode := TCipherSuites12.EcdheEcdsaChaCha20Poly1305Sha256;
+  LSuites[2].OsslCipher := 'ECDHE-ECDSA-CHACHA20-POLY1305';
+  LSuites[2].Name := 'ChaCha20-Poly1305';
+
+  ALogProc('TLS record throughput - TLS 1.2 ECDHE-ECDSA over X25519, ' +
+    TBenchmarkFormat.FormatBufferSize(BENCH_TP_PAYLOAD) + ' payloads, peer verification off');
+  ALogProc('one connection handshaked once, then application data is sealed + opened each pass');
+  if not LOpenSslAvailable then
+    ALogProc('OpenSSL not loaded - reporting TlsLib only');
+  ALogProc(TBenchmarkReport.BuildSeparator(Result));
+  ALogProc(TBenchmarkReport.BuildHeaderRow('AEAD suite',
+    ['TlsLib', 'OpenSSL', 'TlsLib/OpenSSL'], BENCH_TP_VALUE_COL_WIDTH));
+  ALogProc(TBenchmarkReport.BuildSeparator(Result));
+
+  for LIdx := System.Low(LSuites) to System.High(LSuites) do
+  begin
+    if LIdx > System.Low(LSuites) then
+      ALogProc('');
+    for LSi := System.Low(BENCH_TP_RECORD_SIZES) to System.High(BENCH_TP_RECORD_SIZES) do
+    begin
+      LRowName := LSuites[LIdx].Name + ' @ ' +
+        RecordSizeLabel(BENCH_TP_RECORD_SIZES[LSi]);
+      LTlsMbps := MeasureTls(LSuites[LIdx].TlsCode, BENCH_TP_RECORD_SIZES[LSi], LRowName);
+      LOslMbps := MeasureOssl(LSuites[LIdx].OsslCipher, BENCH_TP_RECORD_SIZES[LSi], LRowName);
+
+      ALogProc(TBenchmarkReport.BuildDataRow(LRowName,
+        [Mbps(LTlsMbps),
+         IfThen(LOpenSslAvailable, Mbps(LOslMbps), 'N/A'),
+         IfThen((LTlsMbps > 0.0) and (LOslMbps > 0.0),
+           FormatFloat('0.00', LTlsMbps / LOslMbps, TBenchmarkReport.FloatFormat) + 'x', 'N/A')],
+        BENCH_TP_VALUE_COL_WIDTH));
+    end;
+  end;
+
+  for LIdx := System.Low(LDeferred) to System.High(LDeferred) do
+    ALogProc('  ! ' + LDeferred[LIdx]);
+
+  ALogProc(TBenchmarkReport.BuildSeparator(Result));
+end;
+
+end.


### PR DESCRIPTION
A console benchmark comparing TlsLib against OpenSSL entirely in memory (no sockets), so the figures reflect library cost rather than the OS/network.

Handshake throughput: full 1-RTT handshakes/sec across X25519 and the NIST P-256/384/521 curves for both TLS 1.3 and hardened TLS 1.2. Record throughput: application-data MB/s per AEAD suite (AES-128/256-GCM, ChaCha20-Poly1305) and TLS record size (256 B / 1400 B / 16 KB), over one established TLS 1.2 connection.

Both sides pin the same version, ECDHE curve and AEAD, use the same EC P-256 certificate with peer verification off, and offer the leaf's curve so it is present in supported_groups (RFC 8422 5.4). Reusable config/SSL_CTX are built once; only the per-connection object + work is timed, after warm-up passes.

The OpenSSL peer is driven through mORMot's binding over memory BIOs (via the mormot2 package; DER->PEM through mormot.crypt.secure so it also builds under Delphi), and the exact OpenSSL version measured is printed. Timing and table formatting use a self-contained benchmark harness.

Note: the numbers are end-to-end and crypto-dominated - TlsLib delegates the EC and AEAD to CryptoLib, so this measures how fast a connection is, not TlsLib's orchestration in isolation.