### PR TITLE
Add configurable cipher-suite preference + config-in across the adapters

### DIFF
--- a/TlsLib.Adapters/FclNet/Adapter/TlsLibFclNetTls.pas
+++ b/TlsLib.Adapters/FclNet/Adapter/TlsLibFclNetTls.pas
@@ -113,9 +113,14 @@ type
     FVerifyCallback: TTlsCertificateVerifyCallback;
     FVerdictResolver: TTlsVerdictResolver;
     FVerdictDeadlineMs: Cardinal;
+    FClientConfig: ITlsClientConfig;
+    FServerConfig: ITlsServerConfig;
     function LoadFileBytes(const APath: string): TBytes;
     function SSLDataBytes(const AData: TSSLData): TBytes;
     function HasTrustSource: Boolean;
+    /// <summary>Raises when a supplied config is set together with cert/trust properties a
+    /// fully-built config replaces (APropertyName names the config property in the message).</summary>
+    procedure GuardNoConflict(const APropertyName: string);
     procedure ApplyClientTrust(const ABuilder: ITlsClientConfigBuilder);
     procedure ApplyServerClientAuth(const ABuilder: ITlsServerConfigBuilder);
     function BuildClientEngine(const AHost: string): ITlsEngine;
@@ -134,6 +139,8 @@ type
     function BytesAvailable: Integer; override;
     /// <summary>The negotiated protocol version once the handshake completes.</summary>
     function NegotiatedVersion: TTlsVersion;
+    /// <summary>The negotiated cipher-suite wire codepoint once the handshake completes (0 if none).</summary>
+    function NegotiatedCipherSuite: UInt16;
     /// <summary>A human-readable description of the last Connect/Accept/Send/Recv failure.</summary>
     property LastErrorDesc: string read FLastErrorDesc;
     /// <summary>Opt into the OS system-trust anchors (Windows crypt32 / macOS SecTrust / Unix
@@ -168,6 +175,16 @@ type
     /// <summary>The advisory deadline (ms) for an awaited verdict; 0 leaves it to the resolver.</summary>
     property VerdictDeadlineMs: Cardinal read FVerdictDeadlineMs
       write FVerdictDeadlineMs;
+    /// <summary>A fully-built client config that REPLACES the property-driven build: when set, the
+    /// cert/trust properties (CertificateData trust/cert, UseSystemTrust, a custom store/verifier,
+    /// ALPN) are not allowed alongside it (the handler raises). VerdictResolver still applies - it is
+    /// a runtime stream hook, not part of the frozen config. The escape hatch to the full builder API
+    /// - cipher order, groups, resumption. For a stock TFPHTTPClient, set it in an OnGetSocketHandler
+    /// hook.</summary>
+    property ClientConfig: ITlsClientConfig read FClientConfig write FClientConfig;
+    /// <summary>A fully-built server config that REPLACES the property-driven build (the server-side
+    /// counterpart of ClientConfig; same conflict rule).</summary>
+    property ServerConfig: ITlsServerConfig read FServerConfig write FServerConfig;
   end;
 
 var
@@ -196,6 +213,8 @@ resourcestring
   SNoHostForNameCheck = 'CheckHostName is on but the socket carries no host to verify the ' +
     'certificate identity against (RFC 6125); connect through a TInetSocket that carries the ' +
     'host, or set CheckHostName := False to verify the chain only';
+  SConfigAndOptionsConflict = '%s is set together with cert/trust properties that a fully-built ' +
+    'config replaces; supply either the config or the cert/trust properties, not both';
 
 { TFclNetSocketTransport }
 
@@ -301,6 +320,17 @@ begin
     (FCustomTrustStore <> nil);
 end;
 
+procedure TTlsLibSocketHandler.GuardNoConflict(const APropertyName: string);
+begin
+  // a supplied config owns trust/credential entirely; naming these alongside it would be silently
+  // dropped, so fail loud. VerdictResolver is excluded: it is a runtime stream hook (not part of
+  // the frozen config) and still applies with a supplied config.
+  if HasTrustSource or (not CertificateData.Certificate.Empty) or
+    (System.Length(FAlpnProtocols) > 0) or Assigned(FVerifyCallback) then
+    raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+      Format(SConfigAndOptionsConflict, [APropertyName]));
+end;
+
 procedure TTlsLibSocketHandler.ApplyClientTrust(
   const ABuilder: ITlsClientConfigBuilder);
 begin
@@ -338,6 +368,13 @@ function TTlsLibSocketHandler.BuildClientEngine(const AHost: string): ITlsEngine
 var
   LClient: ITlsClientConfigBuilder;
 begin
+  // a fully-built config supplied by the app REPLACES the property-driven build outright; naming
+  // cert/trust properties alongside it fails loud rather than dropping them silently
+  if FClientConfig <> nil then
+  begin
+    GuardNoConflict('ClientConfig');
+    Exit(TTlsEngineFactory.CreateClientEngine(FClientConfig, AHost));
+  end;
   FProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
   LClient := TTlsPresets.Compatible(FProvider).Client;
   // VerifyPeerCert is fcl-net's native verify switch: True runs real verification (and fails closed
@@ -380,6 +417,13 @@ function TTlsLibSocketHandler.BuildServerEngine: ITlsEngine;
 var
   LServer: ITlsServerConfigBuilder;
 begin
+  // a fully-built config supplied by the app REPLACES the property-driven build outright; naming
+  // cert/trust properties alongside it fails loud rather than dropping them silently
+  if FServerConfig <> nil then
+  begin
+    GuardNoConflict('ServerConfig');
+    Exit(TTlsEngineFactory.CreateServerEngine(FServerConfig));
+  end;
   // a clear message when no cert is configured, rather than an opaque file-open error
   // (DriveHandshake wraps this into FLastError/FLastErrorDesc - no exception escapes)
   if CertificateData.Certificate.Empty then
@@ -527,6 +571,14 @@ begin
     Result := FStream.ConnectionInfo.NegotiatedVersion
   else
     Result := TTlsVersion.Create(0);
+end;
+
+function TTlsLibSocketHandler.NegotiatedCipherSuite: UInt16;
+begin
+  if FStream <> nil then
+    Result := FStream.ConnectionInfo.CipherSuite
+  else
+    Result := 0;
 end;
 
 initialization

--- a/TlsLib.Adapters/FclNet/Examples/Lazarus/FclNetAdvancedConfig.lpi
+++ b/TlsLib.Adapters/FclNet/Examples/Lazarus/FclNetAdvancedConfig.lpi
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="FclNetAdvancedConfig"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RequiredPackages Count="2">
+      <Item1>
+        <PackageName Value="TlsLib.Adapter.FclNet"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="FCL"/>
+      </Item2>
+    </RequiredPackages>
+    <Units Count="2">
+      <Unit0>
+        <Filename Value="FclNetAdvancedConfig.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+      <Unit1>
+        <Filename Value="..\src\FclNetAdvancedConfigExample.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value=".\bin\FclNetAdvancedConfig"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\src"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+  </CompilerOptions>
+</CONFIG>

--- a/TlsLib.Adapters/FclNet/Examples/Lazarus/FclNetAdvancedConfig.lpr
+++ b/TlsLib.Adapters/FclNet/Examples/Lazarus/FclNetAdvancedConfig.lpr
@@ -1,0 +1,16 @@
+program FclNetAdvancedConfig;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+{$APPTYPE CONSOLE}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  FclNetAdvancedConfigExample in '..\src\FclNetAdvancedConfigExample.pas';
+
+begin
+  Halt(TFclNetAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/FclNet/Examples/src/FclNetAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/FclNet/Examples/src/FclNetAdvancedConfigExample.pas
@@ -1,0 +1,294 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+/// <summary>
+/// Advanced configuration over the fcl-net adapter: instead of the handler's cert/trust
+/// properties, the app hands it fully-built TlsLib configs through the ClientConfig /
+/// ServerConfig escape hatch. The injected configs pin an ordered, bound cipher-suite
+/// preference and TLS 1.2 only - so this loopback negotiating TLS 1.2 (the Compatible preset
+/// would pick 1.3) proves the app's config replaced the adapter's built-in build. The same
+/// seam exposes the whole builder API (groups, resumption, ALPN, ...).
+/// </summary>
+unit FclNetAdvancedConfigExample;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+type
+  TFclNetAdvancedConfigExample = class sealed(TObject)
+  public
+    /// <summary>Runs the loopback; returns 0 on success, 1 on failure.</summary>
+    class function Run: Integer; static;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+  Classes,
+  SyncObjs,
+  ssockets,
+  TlpDataEncoding,
+  TlpTlsVersion,
+  TlpNegotiationTypes,
+  TlpINegotiation,
+  TlpCipherSuiteRegistry,
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider,
+  TlpITlsConfig,
+  TlpITlsConfigBuilder,
+  TlpTlsPresets,
+  TlsLibFclNetTls;
+
+const
+  PORT = 28447;
+  PING = 'ping from the fclnet advanced-config client';
+
+var
+  GLeafDer, GKeyDer, GRootDer: TBytes;
+  GVector: string;
+
+function LocateVector: string;
+const
+  REL = 'TlsLib.Tests' + PathDelim + 'Data' + PathDelim + 'Certs' + PathDelim +
+    'EcP256Chain.txt';
+var
+  LDir, LTry: string;
+  LI: Integer;
+begin
+  Result := '';
+  LDir := ExtractFilePath(ParamStr(0));
+  for LI := 0 to 8 do
+  begin
+    LTry := IncludeTrailingPathDelimiter(LDir) + REL;
+    if FileExists(LTry) then
+      Exit(LTry);
+    LDir := ExtractFileDir(ExcludeTrailingPathDelimiter(LDir));
+    if LDir = '' then
+      Break;
+  end;
+  if Result = '' then
+    raise Exception.Create('EcP256Chain.txt vector not found (searched up from the exe)');
+end;
+
+function FieldDer(const AName: string): TBytes;
+var
+  LLines: TStringList;
+  LI: Integer;
+  LPrefix: string;
+begin
+  Result := nil;
+  LPrefix := AName + '=';
+  LLines := TStringList.Create;
+  try
+    LLines.LoadFromFile(GVector);
+    for LI := 0 to LLines.Count - 1 do
+      if Pos(LPrefix, LLines[LI]) = 1 then
+        Exit(TDataEncoding.HexDecode(Copy(LLines[LI], System.Length(LPrefix) + 1, MaxInt)));
+  finally
+    LLines.Free;
+  end;
+end;
+
+// an ordered, bound TLS 1.2 cipher-suite preference: only these suites may be negotiated and the
+// Add order is the preference order (server-preference is the model, so the server's order wins)
+function OrderedSuites(const AProvider: ICryptoProvider): ICipherSuiteRegistry;
+var
+  LAll, LOrdered: ICipherSuiteRegistry;
+  LSuite: TTlsCipherSuite;
+begin
+  LAll := TCipherSuiteRegistry.CreateDualVersion(AProvider);
+  LOrdered := TCipherSuiteRegistry.Create;
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaAes256GcmSha384, LSuite) then LOrdered.Add(LSuite);
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaChaCha20Poly1305Sha256, LSuite) then LOrdered.Add(LSuite);
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaAes128GcmSha256, LSuite) then LOrdered.Add(LSuite);
+  Result := LOrdered;
+end;
+
+function BuildClientConfig: ITlsClientConfig;
+var
+  LProvider: ICryptoProvider;
+  LClient: ITlsClientConfigBuilder;
+begin
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LClient := TTlsPresets.Compatible(LProvider).Client;
+  LClient.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  // X25519 for the ECDHE, plus the leaf's P-256 curve (RFC 8422 5.4)
+  LClient.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519,
+    TNamedGroupCatalog.Secp256r1));
+  LClient.WithCipherSuites(OrderedSuites(LProvider));
+  LClient.WithTrustAnchors(GRootDer);
+  Result := LClient.Build;
+end;
+
+function BuildServerConfig: ITlsServerConfig;
+var
+  LProvider: ICryptoProvider;
+  LServer: ITlsServerConfigBuilder;
+begin
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LServer := TTlsPresets.Compatible(LProvider).Server;
+  LServer.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  LServer.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519,
+    TNamedGroupCatalog.Secp256r1));
+  LServer.WithCipherSuites(OrderedSuites(LProvider));
+  LServer.WithCredential(GLeafDer, GKeyDer);
+  Result := LServer.Build;
+end;
+
+type
+  TServerThread = class(TThread)
+  strict private
+    FError: string;
+    FReady: TEvent;
+    procedure MakeHandler(Sender: TObject; out AHandler: TSocketHandler);
+    procedure HandleConnect(Sender: TObject; AStream: TSocketStream);
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(AReady: TEvent);
+    property Error: string read FError;
+  end;
+
+constructor TServerThread.Create(AReady: TEvent);
+begin
+  inherited Create(True);
+  FreeOnTerminate := False;
+  FReady := AReady;
+end;
+
+procedure TServerThread.MakeHandler(Sender: TObject; out AHandler: TSocketHandler);
+var
+  LHandler: TTlsLibSocketHandler;
+begin
+  LHandler := TTlsLibSocketHandler.Create;
+  LHandler.ServerConfig := BuildServerConfig; // the escape hatch: use our config verbatim
+  AHandler := LHandler;
+end;
+
+procedure TServerThread.HandleConnect(Sender: TObject; AStream: TSocketStream);
+var
+  LBuf: TBytes;
+  LN: Integer;
+begin
+  try
+    LBuf := nil;
+    SetLength(LBuf, 1024);
+    LN := AStream.Read(LBuf[0], System.Length(LBuf));
+    if LN > 0 then
+      AStream.Write(LBuf[0], LN);
+  except
+    on E: Exception do
+      FError := 'server connection: ' + E.Message;
+  end;
+  AStream.Free;
+end;
+
+procedure TServerThread.Execute;
+var
+  LServer: TInetServer;
+begin
+  LServer := TInetServer.Create('127.0.0.1', PORT);
+  try
+    try
+      LServer.ReuseAddress := True;
+      LServer.MaxConnections := 1;
+      LServer.OnCreateClientSocketHandler := MakeHandler;
+      LServer.OnConnect := HandleConnect;
+      LServer.Listen;
+      FReady.SetEvent;
+      LServer.StartAccepting;
+    except
+      on E: Exception do
+      begin
+        FError := 'server: ' + E.Message;
+        FReady.SetEvent;
+      end;
+    end;
+  finally
+    LServer.Free;
+  end;
+end;
+
+class function TFclNetAdvancedConfigExample.Run: Integer;
+var
+  LServer: TServerThread;
+  LSock: TInetSocket;
+  LHandler: TTlsLibSocketHandler;
+  LReady: TEvent;
+  LEcho: string;
+  LOut: AnsiString;
+  LBuf: TBytes;
+  LN: Integer;
+  LVersion: TTlsVersion;
+begin
+  Result := 1;
+  LEcho := '';
+  GVector := LocateVector;
+  GLeafDer := FieldDer('leaf_cert');
+  GKeyDer := FieldDer('leaf_key');
+  GRootDer := FieldDer('root_cert');
+  LReady := TEvent.Create(nil, True, False, '');
+  try
+    LServer := TServerThread.Create(LReady);
+    try
+      LServer.Start;
+      LReady.WaitFor(5000);
+      if LServer.Error <> '' then
+        raise Exception.Create(LServer.Error);
+
+      LHandler := TTlsLibSocketHandler.Create;
+      LHandler.ClientConfig := BuildClientConfig; // the escape hatch: use our config verbatim
+      LSock := TInetSocket.Create('localhost', PORT, LHandler);
+      try
+        try
+          LSock.Connect;
+        except
+          on E: ESocketError do
+            raise Exception.Create('handshake failed: ' + LHandler.LastErrorDesc);
+        end;
+        LVersion := LHandler.NegotiatedVersion;
+        LOut := AnsiString(PING);
+        LSock.Write(LOut[1], System.Length(LOut));
+        LBuf := nil;
+        SetLength(LBuf, 1024);
+        LN := LSock.Read(LBuf[0], System.Length(LBuf));
+        if LN > 0 then
+          SetString(LEcho, PAnsiChar(@LBuf[0]), LN);
+      finally
+        LSock.Free;
+      end;
+      LServer.WaitFor;
+      if LServer.Error <> '' then
+        raise Exception.Create(LServer.Error);
+    finally
+      LServer.Free;
+    end;
+
+    if (LEcho = PING) and (LVersion.WireValue = TlsWireVersionTls12) then
+    begin
+      Writeln('FclNet advanced-config PASS: injected config pinned TLS 1.2 + ordered ciphers, echo ok');
+      Result := 0;
+    end
+    else
+      Writeln('FclNet advanced-config FAIL: echo="', LEcho, '" version=$',
+        IntToHex(LVersion.WireValue, 4));
+  except
+    on E: Exception do
+      Writeln('FclNet advanced-config FAIL: ', E.ClassName, ': ', E.Message);
+  end;
+  LReady.Free;
+end;
+
+end.

--- a/TlsLib.Adapters/FclNet/README.md
+++ b/TlsLib.Adapters/FclNet/README.md
@@ -138,3 +138,10 @@ certificate verification, real HTTP over our records, zero OpenSSL. It runs twic
 `AfterSocketHandlerCreate`, leg B uses the OS system-trust store via `OnGetSocketHandler`.
 `KeepConnection` reuses **one** TLS connection for both verbs. It is a **network-gated demo,
 not a test gate**: it needs outbound HTTPS and exits 0 (PASS) / 2 (SKIP, offline) / 1 (FAIL).
+
+`Examples/` also carries an **advanced-config** demo (`src/FclNetAdvancedConfigExample.pas`,
+`Lazarus/FclNetAdvancedConfig.lpi`): instead of the `CertificateData` cert/trust slots, it hands
+each handler a fully-built config through `ServerConfig` / `ClientConfig` — an ordered, bound
+cipher-suite preference pinned to TLS 1.2, so the negotiated 1.2 (the preset would pick 1.3) proves
+the injected config replaced the built-in build. This is the escape hatch to the whole builder API
+(cipher order, groups, resumption, ALPN, …).

--- a/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
+++ b/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
@@ -73,9 +73,25 @@ type
     FVerifyCallback: TTlsCertificateVerifyCallback;
     FVerdictResolver: TTlsVerdictResolver;
     FVerdictDeadlineMs: Cardinal;
+    FClientConfig: ITlsClientConfig;
+    FServerConfig: ITlsServerConfig;
+  private
+    /// <summary>Raises when a supplied config is set together with cert/trust options a fully-built
+    /// config would replace (APropertyName names the config property in the message). The IOHandler
+    /// calls it at build time so a silently-dropped source fails loud.</summary>
+    procedure GuardNoConflict(const APropertyName: string);
   public
     constructor Create;
     procedure Assign(ASource: TPersistent); override;
+    /// <summary>A fully-built client config that REPLACES the options-driven build: when set, the
+    /// cert/trust options here are not allowed alongside it (the adapter raises). VerdictResolver/
+    /// VerdictDeadlineMs are the exception - a runtime stream hook, not part of the frozen config -
+    /// and still apply (arm them with WithAsyncCertificateVerdict). The escape hatch to the full
+    /// builder API (cipher order, groups, resumption, ALPN, ...).</summary>
+    property ClientConfig: ITlsClientConfig read FClientConfig write FClientConfig;
+    /// <summary>A fully-built server config that REPLACES the options-driven build (the server-side
+    /// counterpart of ClientConfig; same conflict rule).</summary>
+    property ServerConfig: ITlsServerConfig read FServerConfig write FServerConfig;
     /// <summary>An augment-only peer-certificate hook: it runs after the built-in pipeline and
     /// can only additionally reject (never loosen it). The neutral bridge for an app's own
     /// verify rule.</summary>
@@ -155,6 +171,8 @@ type
     procedure AfterAccept; override;
     /// <summary>The negotiated protocol version once the handshake completes.</summary>
     function NegotiatedVersion: TTlsVersion;
+    /// <summary>The negotiated cipher-suite wire codepoint once the handshake completes (0 if none).</summary>
+    function NegotiatedCipherSuite: UInt16;
   published
     property SSLOptions: TTlsLibSSLOptions read FOptions;
   end;
@@ -185,6 +203,8 @@ resourcestring
   SNoClientTrust = 'VerifyPeer is on but no trust source was named; set a RootCertFile bundle, ' +
     'UseSystemTrust, or a CustomTrustStore/CustomVerifier (system trust is never implicit), or ' +
     'set VerifyPeer := False to skip verification';
+  SConfigAndOptionsConflict = 'SSLOptions.%s is set together with cert/trust options that a ' +
+    'fully-built config replaces; supply either the config or the cert/trust options, not both';
 
 { TTlsLibSSLOptions }
 
@@ -215,9 +235,22 @@ begin
     FVerifyCallback := LSrc.FVerifyCallback;
     FVerdictResolver := LSrc.FVerdictResolver;
     FVerdictDeadlineMs := LSrc.FVerdictDeadlineMs;
+    FClientConfig := LSrc.FClientConfig;
+    FServerConfig := LSrc.FServerConfig;
   end
   else
     inherited Assign(ASource);
+end;
+
+procedure TTlsLibSSLOptions.GuardNoConflict(const APropertyName: string);
+begin
+  // a supplied config owns trust/credential entirely; naming these alongside it would be silently
+  // dropped, so fail loud. VerdictResolver is deliberately excluded: it is a runtime stream hook
+  // (not part of the frozen config) and still applies with a supplied config.
+  if (FCertFile <> '') or (FKeyFile <> '') or (FRootCertFile <> '') or FUseSystemTrust or
+    (FCustomVerifier <> nil) or (FCustomTrustStore <> nil) or Assigned(FVerifyCallback) then
+    raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+      Format(SConfigAndOptionsConflict, [APropertyName]));
 end;
 
 { TIndySocketTransport }
@@ -307,6 +340,18 @@ var
   end;
 
 begin
+  // a fully-built config supplied by the app REPLACES the options-driven build outright; naming
+  // cert/trust options alongside it fails loud rather than dropping them silently
+  if AIsClient and (FOptions.ClientConfig <> nil) then
+  begin
+    FOptions.GuardNoConflict('ClientConfig');
+    Exit(TTlsEngineFactory.CreateClientEngine(FOptions.ClientConfig, Host));
+  end;
+  if (not AIsClient) and (FOptions.ServerConfig <> nil) then
+  begin
+    FOptions.GuardNoConflict('ServerConfig');
+    Exit(TTlsEngineFactory.CreateServerEngine(FOptions.ServerConfig));
+  end;
   LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
   if AIsClient then
   begin
@@ -470,6 +515,14 @@ begin
     Result := FStream.ConnectionInfo.NegotiatedVersion
   else
     Result := TTlsVersion.Create(0);
+end;
+
+function TTlsLibIOHandlerSocket.NegotiatedCipherSuite: UInt16;
+begin
+  if FStream <> nil then
+    Result := FStream.ConnectionInfo.CipherSuite
+  else
+    Result := 0;
 end;
 
 function TTlsLibIOHandlerSocket.Clone: TIdSSLIOHandlerSocketBase;

--- a/TlsLib.Adapters/Indy/Examples/Delphi/IndyAdvancedConfig.dpr
+++ b/TlsLib.Adapters/Indy/Examples/Delphi/IndyAdvancedConfig.dpr
@@ -1,0 +1,12 @@
+program IndyAdvancedConfig;
+
+{$APPTYPE CONSOLE}
+{$R *.res}
+
+uses
+  SysUtils,
+  IndyAdvancedConfigExample in '..\src\IndyAdvancedConfigExample.pas';
+
+begin
+  Halt(TIndyAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/Indy/Examples/Lazarus/IndyAdvancedConfig.lpi
+++ b/TlsLib.Adapters/Indy/Examples/Lazarus/IndyAdvancedConfig.lpi
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="IndyAdvancedConfig"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RequiredPackages Count="2">
+      <Item1>
+        <PackageName Value="TlsLib.Adapter.Indy"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="FCL"/>
+      </Item2>
+    </RequiredPackages>
+    <Units Count="2">
+      <Unit0>
+        <Filename Value="IndyAdvancedConfig.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+      <Unit1>
+        <Filename Value="..\src\IndyAdvancedConfigExample.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value=".\bin\IndyAdvancedConfig"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\src"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+  </CompilerOptions>
+</CONFIG>

--- a/TlsLib.Adapters/Indy/Examples/Lazarus/IndyAdvancedConfig.lpr
+++ b/TlsLib.Adapters/Indy/Examples/Lazarus/IndyAdvancedConfig.lpr
@@ -1,0 +1,16 @@
+program IndyAdvancedConfig;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+{$APPTYPE CONSOLE}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  IndyAdvancedConfigExample in '..\src\IndyAdvancedConfigExample.pas';
+
+begin
+  Halt(TIndyAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/Indy/Examples/src/IndyAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/Indy/Examples/src/IndyAdvancedConfigExample.pas
@@ -1,0 +1,267 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+/// <summary>
+/// Advanced configuration over the Indy adapter, demonstrating cipher-suite preference. The app
+/// hands the IOHandlers fully-built configs through SSLOptions.ServerConfig / ClientConfig, and
+/// controls WHICH suite is negotiated via the server's WithCipherSuitePreference: ServerOrder
+/// (the default) imposes the server's order, ClientOrder honors the client's. The client offers
+/// AES-256 then AES-128 (or the reverse), and the example reads back the negotiated suite through
+/// the adapter's NegotiatedCipherSuite accessor. It asserts:
+///   - ClientOrder: the client's most-preferred offered suite always wins (flipping the client's
+///     order flips the negotiated suite);
+///   - ServerOrder: the negotiated suite is stable regardless of the client's order (the server's
+///     preference decides).
+/// This proves - through the real adapter - that only the server guides selection, and that the
+/// server can defer to the client's order when it chooses to.
+/// </summary>
+unit IndyAdvancedConfigExample;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+type
+  TIndyAdvancedConfigExample = class sealed(TObject)
+  public
+    /// <summary>Runs the demonstration; returns 0 on success, 1 on failure.</summary>
+    class function Run: Integer; static;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+  Classes,
+  IdContext,
+  IdTCPServer,
+  IdTCPClient,
+  TlpDataEncoding,
+  TlpTlsVersion,
+  TlpNegotiationTypes,
+  TlpINegotiation,
+  TlpCipherSuiteRegistry,
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider,
+  TlpITlsConfig,
+  TlpITlsConfigBuilder,
+  TlpTlsPresets,
+  TlsLibIndyTls;
+
+const
+  PORTBASE = 28452;
+  PING = 'ping';
+
+var
+  GServerError: string;
+  GVector: string;
+  GLeafDer, GKeyDer, GRootDer: TBytes;
+  GProvider: ICryptoProvider;
+
+function LocateVector: string;
+const
+  REL = 'TlsLib.Tests' + PathDelim + 'Data' + PathDelim + 'Certs' + PathDelim +
+    'EcP256Chain.txt';
+var
+  LDir, LTry: string;
+  LI: Integer;
+begin
+  Result := '';
+  LDir := ExtractFilePath(ParamStr(0));
+  for LI := 0 to 8 do
+  begin
+    LTry := IncludeTrailingPathDelimiter(LDir) + REL;
+    if FileExists(LTry) then
+      Exit(LTry);
+    LDir := ExtractFileDir(ExcludeTrailingPathDelimiter(LDir));
+    if LDir = '' then
+      Break;
+  end;
+  if Result = '' then
+    raise Exception.Create('EcP256Chain.txt vector not found (searched up from the exe)');
+end;
+
+function FieldDer(const AName: string): TBytes;
+var
+  LLines: TStringList;
+  LI: Integer;
+  LPrefix: string;
+begin
+  Result := nil;
+  LPrefix := AName + '=';
+  LLines := TStringList.Create;
+  try
+    LLines.LoadFromFile(GVector);
+    for LI := 0 to LLines.Count - 1 do
+      if Pos(LPrefix, LLines[LI]) = 1 then
+        Exit(TDataEncoding.HexDecode(Copy(LLines[LI], System.Length(LPrefix) + 1, MaxInt)));
+  finally
+    LLines.Free;
+  end;
+end;
+
+// a registry holding exactly ACodes, in that order; the client offers suites in registry order,
+// so this controls the client's advertised preference
+function OrderedRegistry(const ACodes: array of UInt16): ICipherSuiteRegistry;
+var
+  LAll, LReg: ICipherSuiteRegistry;
+  LSuite: TTlsCipherSuite;
+  LI: Integer;
+begin
+  LAll := TCipherSuiteRegistry.CreateDualVersion(GProvider);
+  LReg := TCipherSuiteRegistry.Create;
+  for LI := System.Low(ACodes) to System.High(ACodes) do
+    if LAll.TryGet(ACodes[LI], LSuite) then
+      LReg.Add(LSuite);
+  Result := LReg;
+end;
+
+function BuildServerConfig(APreference: TServerCipherPreference): ITlsServerConfig;
+var
+  LServer: ITlsServerConfigBuilder;
+begin
+  LServer := TTlsPresets.Compatible(GProvider).Server;
+  LServer.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls13));
+  LServer.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519));
+  // the server offers both AES suites; its selection strategy is the knob under test
+  LServer.WithCipherSuites(OrderedRegistry([TCipherSuites13.Aes128GcmSha256,
+    TCipherSuites13.Aes256GcmSha384]));
+  LServer.WithCipherSuitePreference(APreference);
+  LServer.WithCredential(GLeafDer, GKeyDer);
+  Result := LServer.Build;
+end;
+
+function BuildClientConfig(const AClientOrder: array of UInt16): ITlsClientConfig;
+var
+  LClient: ITlsClientConfigBuilder;
+begin
+  LClient := TTlsPresets.Compatible(GProvider).Client;
+  LClient.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls13));
+  LClient.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519));
+  LClient.WithCipherSuites(OrderedRegistry(AClientOrder)); // the client's advertised order
+  LClient.WithTrustAnchors(GRootDer);
+  Result := LClient.Build;
+end;
+
+type
+  TEchoHandler = class sealed(TObject)
+  public
+    procedure DoExecute(AContext: TIdContext);
+  end;
+
+procedure TEchoHandler.DoExecute(AContext: TIdContext);
+var
+  LLine: string;
+begin
+  try
+    LLine := AContext.Connection.IOHandler.ReadLn;
+    AContext.Connection.IOHandler.WriteLn(LLine);
+  except
+    on E: Exception do
+      GServerError := E.ClassName + ': ' + E.Message;
+  end;
+end;
+
+// one full Indy handshake with the given server preference and client-offered order; returns the
+// negotiated cipher-suite codepoint the client observed through the adapter accessor
+function Negotiate(APreference: TServerCipherPreference;
+  const AClientOrder: array of UInt16; APort: Integer): UInt16;
+var
+  LServer: TIdTCPServer;
+  LServerIO: TTlsLibServerIOHandler;
+  LClient: TIdTCPClient;
+  LClientIO: TTlsLibIOHandlerSocket;
+  LEchoHandler: TEchoHandler;
+begin
+  Result := 0;
+  LEchoHandler := TEchoHandler.Create;
+  LServer := TIdTCPServer.Create(nil);
+  LClient := TIdTCPClient.Create(nil);
+  try
+    LServerIO := TTlsLibServerIOHandler.Create(LServer);
+    LServerIO.SSLOptions.ServerConfig := BuildServerConfig(APreference);
+    LServer.IOHandler := LServerIO;
+    LServer.DefaultPort := APort;
+    LServer.OnExecute := LEchoHandler.DoExecute;
+    LServer.Active := True;
+
+    LClientIO := TTlsLibIOHandlerSocket.Create(LClient);
+    LClientIO.SSLOptions.ClientConfig := BuildClientConfig(AClientOrder);
+    LClient.IOHandler := LClientIO;
+    LClient.Host := 'localhost'; // verify the leaf for its 'localhost' SAN
+    LClient.Port := APort;
+    LClient.Connect;
+    try
+      LClientIO.WriteLn(PING);
+      LClientIO.ReadLn;
+      Result := LClientIO.NegotiatedCipherSuite; // the adapter's read-only accessor
+    finally
+      LClient.Disconnect;
+    end;
+    LServer.Active := False;
+  finally
+    LClient.Free;
+    LServer.Free;
+    LEchoHandler.Free;
+  end;
+end;
+
+class function TIndyAdvancedConfigExample.Run: Integer;
+var
+  LClientPref256, LClientPref128, LServerA, LServerB: UInt16;
+  LOk: Boolean;
+begin
+  Result := 1;
+  GServerError := '';
+  GVector := LocateVector;
+  GLeafDer := FieldDer('leaf_cert');
+  GKeyDer := FieldDer('leaf_key');
+  GRootDer := FieldDer('root_cert');
+  GProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  try
+    // ClientOrder: the server honors the client's advertised order, so the client's first suite wins
+    LClientPref256 := Negotiate(TServerCipherPreference.ClientOrder,
+      [TCipherSuites13.Aes256GcmSha384, TCipherSuites13.Aes128GcmSha256], PORTBASE);
+    LClientPref128 := Negotiate(TServerCipherPreference.ClientOrder,
+      [TCipherSuites13.Aes128GcmSha256, TCipherSuites13.Aes256GcmSha384], PORTBASE + 1);
+    // ServerOrder (default): the server's own preference decides, independent of the client's order
+    LServerA := Negotiate(TServerCipherPreference.ServerOrder,
+      [TCipherSuites13.Aes256GcmSha384, TCipherSuites13.Aes128GcmSha256], PORTBASE + 2);
+    LServerB := Negotiate(TServerCipherPreference.ServerOrder,
+      [TCipherSuites13.Aes128GcmSha256, TCipherSuites13.Aes256GcmSha384], PORTBASE + 3);
+
+    // the negotiated suites are the signal: correct, non-zero values prove each handshake
+    // completed (a post-exchange truncation on the client's abrupt disconnect is benign, as in
+    // the loopback example, so GServerError is diagnostic only - not a pass/fail gate)
+    LOk := (LClientPref256 = TCipherSuites13.Aes256GcmSha384) and
+      (LClientPref128 = TCipherSuites13.Aes128GcmSha256) and (LServerA = LServerB) and
+      (LServerA <> 0);
+    if LOk then
+    begin
+      Writeln('Indy advanced-config PASS: ClientOrder honors the client (',
+        IntToHex(LClientPref256, 4), ' then ', IntToHex(LClientPref128, 4),
+        '); ServerOrder is stable regardless of client order (', IntToHex(LServerA, 4), ')');
+      Result := 0;
+    end
+    else
+      Writeln('Indy advanced-config FAIL: clientPref=', IntToHex(LClientPref256, 4), '/',
+        IntToHex(LClientPref128, 4), ' serverStable=', IntToHex(LServerA, 4), '/',
+        IntToHex(LServerB, 4), ' server="', GServerError, '"');
+  except
+    on E: Exception do
+      Writeln('Indy advanced-config FAIL: ', E.ClassName, ': ', E.Message,
+        ' server="', GServerError, '"');
+  end;
+end;
+
+end.

--- a/TlsLib.Adapters/Indy/README.md
+++ b/TlsLib.Adapters/Indy/README.md
@@ -98,3 +98,14 @@ outbound HTTPS and exits 0 (PASS) / 2 (SKIP, offline) / 1 (FAIL). One `TIdHTTP` 
 the adapter handshakes each connection Indy opens, so the second request works whether Indy keeps
 the socket alive or reconnects (`ConnectClient` discards the prior TLS session so a reconnect
 re-handshakes rather than reusing the closed session's keys).
+
+`Examples/` also carries an **advanced-config** demo (`src/IndyAdvancedConfigExample.pas`,
+`Lazarus/IndyAdvancedConfig.lpi` / `Delphi/IndyAdvancedConfig.dproj`): it hands the IOHandlers
+fully-built configs through `SSLOptions.ServerConfig` / `SSLOptions.ClientConfig` — the escape
+hatch to the whole builder API (cipher order, groups, resumption, ALPN, …) — and drives the
+server's `WithCipherSuitePreference` both ways: `ServerOrder` (default) imposes the server's own
+order, `ClientOrder` honors the client's. It reads the result back through the adapter's
+`NegotiatedCipherSuite` accessor and asserts that under `ClientOrder` the client's most-preferred
+suite always wins (flip the client's order, flip the result), while under `ServerOrder` the
+negotiated suite is stable regardless of the client's order — proving, through the real handshake,
+that only the server guides selection and can defer to the client when it chooses to.

--- a/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
+++ b/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
@@ -89,9 +89,14 @@ type
     FEngine: ITlsEngine;
     FProvider: ICryptoProvider;
     FUseSystemTrust: Boolean;
+    FClientConfig: ITlsClientConfig;
+    FServerConfig: ITlsServerConfig;
     function LoadFileBytes(const APath: string): TBytes;
     function BuildClientEngine: ITlsEngine;
     function BuildServerEngine: ITlsEngine;
+    /// <summary>Raises when a supplied config is set together with cert/trust properties a
+    /// fully-built config replaces (APropertyName names the config property in the message).</summary>
+    procedure GuardNoConflict(const APropertyName: string);
     function DriveHandshake(AIsClient: Boolean; const AHost: string): Boolean;
     /// <summary>The peer leaf certificate (DER), or empty when none was presented.</summary>
     function PeerLeaf: TBytes;
@@ -112,6 +117,9 @@ type
     function WaitingData: Integer; override;
     function GetSSLVersion: string; override;
     function GetCipherName: string; override;
+    /// <summary>The negotiated cipher-suite wire codepoint once the handshake completes (0 if none).
+    /// Synapse's TCustomSSL has no such accessor, so cast Sock.SSL to TSSLTlsLib to read it.</summary>
+    function NegotiatedCipherSuite: UInt16;
     // native peer-certificate accessors an OnVerifyCert handler reads (no OpenSSL type)
     function GetPeerSubject: string; override;
     function GetPeerIssuer: string; override;
@@ -125,6 +133,14 @@ type
     /// name a source (this or CertCAFile) or the build fails closed. Per-connection (never a
     /// process-wide global), so it composes and stays thread-safe.</summary>
     property UseSystemTrust: Boolean read FUseSystemTrust write FUseSystemTrust;
+    /// <summary>A fully-built client config that REPLACES the property-driven build: when set, the
+    /// cert/trust properties (CertCAFile, CertificateFile, UseSystemTrust) are not allowed alongside
+    /// it (the plugin raises). The escape hatch to the full builder API - cipher order, groups,
+    /// resumption, ALPN. Cast Sock.SSL to TSSLTlsLib to set it.</summary>
+    property ClientConfig: ITlsClientConfig read FClientConfig write FClientConfig;
+    /// <summary>A fully-built server config that REPLACES the property-driven build (the server-side
+    /// counterpart of ClientConfig; same conflict rule).</summary>
+    property ServerConfig: ITlsServerConfig read FServerConfig write FServerConfig;
   end;
 
 implementation
@@ -134,6 +150,8 @@ resourcestring
   SPeerVerifyRejected = 'the OnVerifyCert handler rejected the peer certificate';
   SNoTrustSource = 'VerifyCert is on but no trust source was named; set a CertCAFile bundle ' +
     'and/or UseSystemTrust (system trust is never implicit), or set VerifyCert := False to skip';
+  SConfigAndOptionsConflict = '%s is set together with cert/trust properties that a fully-built ' +
+    'config replaces; supply either the config or the cert/trust properties, not both';
 
 var
   // process-wide neutral hooks the per-socket plugin threads into each client handshake
@@ -229,11 +247,29 @@ begin
   end;
 end;
 
+procedure TSSLTlsLib.GuardNoConflict(const APropertyName: string);
+begin
+  // a supplied config owns trust/credential entirely; naming these alongside it would be silently
+  // dropped, so fail loud. The native OnVerifyCert hook and the process-wide verdict resolver are
+  // runtime hooks (not part of the frozen config) and still apply, so they are not conflicts.
+  if (FCertificateFile <> '') or (FPrivateKeyFile <> '') or (FCertCAFile <> '') or
+    FUseSystemTrust then
+    raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+      Format(SConfigAndOptionsConflict, [APropertyName]));
+end;
+
 function TSSLTlsLib.BuildClientEngine: ITlsEngine;
 var
   LClient: ITlsClientConfigBuilder;
 begin
   FProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  // a fully-built config supplied by the app REPLACES the property-driven build outright; naming
+  // cert/trust properties alongside it fails loud rather than dropping them silently
+  if FClientConfig <> nil then
+  begin
+    GuardNoConflict('ClientConfig');
+    Exit(TTlsEngineFactory.CreateClientEngine(FClientConfig, FSNIHost));
+  end;
   LClient := TTlsPresets.Compatible(FProvider).Client;
   // Synapse exposes no dedicated system-trust switch, so we compose peer trust from the props it
   // already has (CertCAFile + VerifyCert) plus our per-connection UseSystemTrust. System trust is
@@ -275,11 +311,18 @@ function TSSLTlsLib.BuildServerEngine: ITlsEngine;
 var
   LServer: ITlsServerConfigBuilder;
 begin
+  FProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  // a fully-built config supplied by the app REPLACES the property-driven build outright; naming
+  // cert/trust properties alongside it fails loud rather than dropping them silently
+  if FServerConfig <> nil then
+  begin
+    GuardNoConflict('ServerConfig');
+    Exit(TTlsEngineFactory.CreateServerEngine(FServerConfig));
+  end;
   // a clear message when no cert is configured, rather than an opaque file-open error
   // (DriveHandshake wraps this into FLastError/FLastErrorDesc - no exception escapes)
   if FCertificateFile = '' then
     raise ETlsStreamError.Create(TTlsAlertDescription.InternalError, SNoServerCredential);
-  FProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
   LServer := TTlsPresets.Compatible(FProvider).Server
     .WithCredential(LoadFileBytes(FCertificateFile), LoadFileBytes(FPrivateKeyFile),
     FKeyPassword);
@@ -432,6 +475,14 @@ end;
 function TSSLTlsLib.GetCipherName: string;
 begin
   Result := GetSSLVersion;
+end;
+
+function TSSLTlsLib.NegotiatedCipherSuite: UInt16;
+begin
+  if FStream <> nil then
+    Result := FEngine.NegotiatedCipherSuite
+  else
+    Result := 0;
 end;
 
 function TSSLTlsLib.GetPeerSubject: string;

--- a/TlsLib.Adapters/Synapse/Examples/Delphi/SynapseAdvancedConfig.dpr
+++ b/TlsLib.Adapters/Synapse/Examples/Delphi/SynapseAdvancedConfig.dpr
@@ -1,0 +1,12 @@
+program SynapseAdvancedConfig;
+
+{$APPTYPE CONSOLE}
+{$R *.res}
+
+uses
+  SysUtils,
+  SynapseAdvancedConfigExample in '..\src\SynapseAdvancedConfigExample.pas';
+
+begin
+  Halt(TSynapseAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/Synapse/Examples/Lazarus/SynapseAdvancedConfig.lpi
+++ b/TlsLib.Adapters/Synapse/Examples/Lazarus/SynapseAdvancedConfig.lpi
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="SynapseAdvancedConfig"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RequiredPackages Count="2">
+      <Item1>
+        <PackageName Value="TlsLib.Adapter.Synapse"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="FCL"/>
+      </Item2>
+    </RequiredPackages>
+    <Units Count="2">
+      <Unit0>
+        <Filename Value="SynapseAdvancedConfig.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+      <Unit1>
+        <Filename Value="..\src\SynapseAdvancedConfigExample.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value=".\bin\SynapseAdvancedConfig"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\src"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+  </CompilerOptions>
+</CONFIG>

--- a/TlsLib.Adapters/Synapse/Examples/Lazarus/SynapseAdvancedConfig.lpr
+++ b/TlsLib.Adapters/Synapse/Examples/Lazarus/SynapseAdvancedConfig.lpr
@@ -1,0 +1,16 @@
+program SynapseAdvancedConfig;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+{$APPTYPE CONSOLE}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  SynapseAdvancedConfigExample in '..\src\SynapseAdvancedConfigExample.pas';
+
+begin
+  Halt(TSynapseAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/Synapse/Examples/src/SynapseAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/Synapse/Examples/src/SynapseAdvancedConfigExample.pas
@@ -1,0 +1,256 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+/// <summary>
+/// Advanced configuration over the Synapse plugin: instead of the TCustomSSL cert/CA
+/// properties, the app hands each socket a fully-built TlsLib config through the
+/// (Sock.SSL as TSSLTlsLib).ClientConfig / ServerConfig escape hatch. The injected configs
+/// pin an ordered, bound cipher-suite preference and TLS 1.2 only - so this loopback
+/// negotiating TLS 1.2 (the Compatible preset would pick 1.3) proves the app's config replaced
+/// the plugin's built-in build. The same seam exposes the whole builder API (groups,
+/// resumption, ALPN, ...).
+/// </summary>
+unit SynapseAdvancedConfigExample;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+type
+  TSynapseAdvancedConfigExample = class sealed(TObject)
+  public
+    /// <summary>Runs the loopback; returns 0 on success, 1 on failure.</summary>
+    class function Run: Integer; static;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+  Classes,
+  SyncObjs,
+  blcksock,
+  TlpDataEncoding,
+  TlpTlsVersion,
+  TlpNegotiationTypes,
+  TlpINegotiation,
+  TlpCipherSuiteRegistry,
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider,
+  TlpITlsConfig,
+  TlpITlsConfigBuilder,
+  TlpTlsPresets,
+  TlsLibSynapseTls;
+
+const
+  PORT = '28450';
+  CRLF = #13#10;
+  PING = 'ping from the synapse advanced-config client';
+
+var
+  GReady: TEvent;
+  GServerError: string;
+  GVector: string;
+  GLeafDer, GKeyDer, GRootDer: TBytes;
+
+function LocateVector: string;
+const
+  REL = 'TlsLib.Tests' + PathDelim + 'Data' + PathDelim + 'Certs' + PathDelim +
+    'EcP256Chain.txt';
+var
+  LDir, LTry: string;
+  LI: Integer;
+begin
+  Result := '';
+  LDir := ExtractFilePath(ParamStr(0));
+  for LI := 0 to 8 do
+  begin
+    LTry := IncludeTrailingPathDelimiter(LDir) + REL;
+    if FileExists(LTry) then
+      Exit(LTry);
+    LDir := ExtractFileDir(ExcludeTrailingPathDelimiter(LDir));
+    if LDir = '' then
+      Break;
+  end;
+  if Result = '' then
+    raise Exception.Create('EcP256Chain.txt vector not found (searched up from the exe)');
+end;
+
+function FieldDer(const AName: string): TBytes;
+var
+  LLines: TStringList;
+  LI: Integer;
+  LPrefix: string;
+begin
+  Result := nil;
+  LPrefix := AName + '=';
+  LLines := TStringList.Create;
+  try
+    LLines.LoadFromFile(GVector);
+    for LI := 0 to LLines.Count - 1 do
+      if Pos(LPrefix, LLines[LI]) = 1 then
+        Exit(TDataEncoding.HexDecode(Copy(LLines[LI], System.Length(LPrefix) + 1, MaxInt)));
+  finally
+    LLines.Free;
+  end;
+end;
+
+// an ordered, bound TLS 1.2 cipher-suite preference: only these suites may be negotiated and the
+// Add order is the preference order (server-preference is the model, so the server's order wins)
+function OrderedSuites(const AProvider: ICryptoProvider): ICipherSuiteRegistry;
+var
+  LAll, LOrdered: ICipherSuiteRegistry;
+  LSuite: TTlsCipherSuite;
+begin
+  LAll := TCipherSuiteRegistry.CreateDualVersion(AProvider);
+  LOrdered := TCipherSuiteRegistry.Create;
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaAes256GcmSha384, LSuite) then LOrdered.Add(LSuite);
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaChaCha20Poly1305Sha256, LSuite) then LOrdered.Add(LSuite);
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaAes128GcmSha256, LSuite) then LOrdered.Add(LSuite);
+  Result := LOrdered;
+end;
+
+function BuildClientConfig: ITlsClientConfig;
+var
+  LProvider: ICryptoProvider;
+  LClient: ITlsClientConfigBuilder;
+begin
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LClient := TTlsPresets.Compatible(LProvider).Client;
+  LClient.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  // X25519 for the ECDHE, plus the leaf's P-256 curve (RFC 8422 5.4)
+  LClient.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519,
+    TNamedGroupCatalog.Secp256r1));
+  LClient.WithCipherSuites(OrderedSuites(LProvider));
+  LClient.WithTrustAnchors(GRootDer);
+  Result := LClient.Build;
+end;
+
+function BuildServerConfig: ITlsServerConfig;
+var
+  LProvider: ICryptoProvider;
+  LServer: ITlsServerConfigBuilder;
+begin
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LServer := TTlsPresets.Compatible(LProvider).Server;
+  LServer.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  LServer.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519,
+    TNamedGroupCatalog.Secp256r1));
+  LServer.WithCipherSuites(OrderedSuites(LProvider));
+  LServer.WithCredential(GLeafDer, GKeyDer);
+  Result := LServer.Build;
+end;
+
+type
+  TServerThread = class(TThread)
+  protected
+    procedure Execute; override;
+  end;
+
+procedure TServerThread.Execute;
+var
+  LListener, LClient: TTCPBlockSocket;
+  LLine: string;
+begin
+  LListener := TTCPBlockSocket.Create;
+  try
+    try
+      LListener.CreateSocket;
+      LListener.SetLinger(True, 1000);
+      LListener.Bind('127.0.0.1', PORT);
+      LListener.Listen;
+      GReady.SetEvent;
+      if LListener.CanRead(5000) then
+      begin
+        LClient := TTCPBlockSocket.CreateWithSSL(SSLImplementation);
+        try
+          LClient.Socket := LListener.Accept;
+          (LClient.SSL as TSSLTlsLib).ServerConfig := BuildServerConfig; // the escape hatch
+          if not LClient.SSLAcceptConnection then
+            raise Exception.Create('ssl accept failed: ' + LClient.SSL.LastErrorDesc);
+          LLine := LClient.RecvString(5000);
+          LClient.SendString(LLine + CRLF);
+        finally
+          LClient.Free;
+        end;
+      end;
+    except
+      on E: Exception do
+      begin
+        GServerError := E.ClassName + ': ' + E.Message;
+        GReady.SetEvent;
+      end;
+    end;
+  finally
+    LListener.Free;
+  end;
+end;
+
+class function TSynapseAdvancedConfigExample.Run: Integer;
+var
+  LServer: TServerThread;
+  LClient: TTCPBlockSocket;
+  LEcho, LVersion: string;
+begin
+  Result := 1;
+  GServerError := '';
+  GVector := LocateVector;
+  GLeafDer := FieldDer('leaf_cert');
+  GKeyDer := FieldDer('leaf_key');
+  GRootDer := FieldDer('root_cert');
+  GReady := TEvent.Create(nil, True, False, '');
+  try
+    LServer := TServerThread.Create(True);
+    LServer.FreeOnTerminate := False;
+    LServer.Start;
+    GReady.WaitFor(5000);
+    if GServerError <> '' then
+      raise Exception.Create('server: ' + GServerError);
+
+    LClient := TTCPBlockSocket.CreateWithSSL(SSLImplementation);
+    try
+      (LClient.SSL as TSSLTlsLib).ClientConfig := BuildClientConfig; // the escape hatch
+      LClient.SSL.SNIHost := 'localhost'; // verify the leaf for its 'localhost' SAN
+      LClient.Connect('127.0.0.1', PORT);
+      if LClient.LastError <> 0 then
+        raise Exception.Create('tcp connect failed');
+      LClient.SSLDoConnect;
+      if not LClient.SSL.SSLEnabled then
+        raise Exception.Create('ssl connect failed: ' + LClient.SSL.LastErrorDesc);
+      LVersion := LClient.SSL.GetSSLVersion;
+      LClient.SendString(PING + CRLF);
+      LEcho := LClient.RecvString(5000);
+    finally
+      LClient.Free;
+    end;
+
+    LServer.WaitFor;
+    if GServerError <> '' then
+      raise Exception.Create('server: ' + GServerError);
+
+    if (LEcho = PING) and (LVersion = 'TLSv1.2') then
+    begin
+      Writeln('Synapse advanced-config PASS: injected config pinned TLS 1.2 + ordered ciphers, echo ok');
+      Result := 0;
+    end
+    else
+      Writeln('Synapse advanced-config FAIL: echo="', LEcho, '" version="', LVersion, '"');
+    LServer.Free;
+  except
+    on E: Exception do
+      Writeln('Synapse advanced-config FAIL: ', E.ClassName, ': ', E.Message);
+  end;
+  GReady.Free;
+end;
+
+end.

--- a/TlsLib.Adapters/Synapse/README.md
+++ b/TlsLib.Adapters/Synapse/README.md
@@ -101,3 +101,11 @@ against a **pinned** root (`data/isrg-roots.pem`, the self-signed ISRG roots; **
 test gate**: it needs outbound HTTPS and exits 0 (PASS) / 2 (SKIP, offline) / 1 (FAIL). `THTTPSend`
 keeps the socket alive, so both verbs run over **one reused TLS connection** — exercising the
 adapter's connection-reuse path end to end.
+
+`Examples/` also carries an **advanced-config** demo (`src/SynapseAdvancedConfigExample.pas`,
+`Lazarus/SynapseAdvancedConfig.lpi` / `Delphi/SynapseAdvancedConfig.dproj`): instead of the
+`TCustomSSL` cert/CA properties, it hands each socket a fully-built config through
+`(Sock.SSL as TSSLTlsLib).ServerConfig` / `ClientConfig` — an ordered, bound cipher-suite
+preference pinned to TLS 1.2, so the negotiated 1.2 (the preset would pick 1.3) proves the injected
+config replaced the built-in build. This is the escape hatch to the whole builder API (cipher
+order, groups, resumption, ALPN, …).

--- a/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
+++ b/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
@@ -59,6 +59,13 @@ procedure SetTlsLibMormotVerifyCallback(const ACallback: TTlsCertificateVerifyCa
 /// ADeadlineMs is advisory. nil clears it.</summary>
 procedure SetTlsLibMormotVerdictResolver(const AResolver: TTlsVerdictResolver;
   ADeadlineMs: Cardinal);
+/// <summary>Sets a process-wide, fully-built client config that REPLACES the context-driven build:
+/// when set, every client handshake uses it as-is (the TNetTlsContext trust/cert fields are ignored).
+/// The escape hatch to the full builder API - cipher order, groups, resumption, ALPN. nil clears it.</summary>
+procedure SetTlsLibMormotClientConfig(const AConfig: ITlsClientConfig);
+/// <summary>Sets a process-wide, fully-built server config that REPLACES the context-driven build
+/// (the server-side counterpart of SetTlsLibMormotClientConfig). nil clears it.</summary>
+procedure SetTlsLibMormotServerConfig(const AConfig: ITlsServerConfig);
 
 type
   /// <summary>An ITlsTransport over a mORMot TNetSocket: raw ciphertext moves through the
@@ -87,6 +94,9 @@ type
     FEngine: ITlsEngine;
     FServerName: string;
     class function LoadFile(const APath: RawUtf8): TBytes; static;
+    /// <summary>Whether the context names any cert/trust field a process-wide config would replace.</summary>
+    class function ContextCarriesTrustOrCredential(
+      const AContext: TNetTlsContext): Boolean; static;
     class function BuildClientEngine(var AContext: TNetTlsContext;
       const AHost: string): ITlsEngine; static;
     class function BuildServerEngine(const AContext: TNetTlsContext): ITlsEngine; static;
@@ -123,12 +133,18 @@ resourcestring
   SCARawUnsupported = 'the mORMot TLS context supplies CACertificatesRaw (in-memory OpenSSL ' +
     'X509 handles); TlsLib4Pascal is OpenSSL-free and cannot consume them - pass the CA chain ' +
     'as a PEM/DER file via CACertificatesFile, or use TSystemTrust for the OS anchors';
+  SConfigAndContextConflict = 'a process-wide config installed via %s is used together with a ' +
+    'TNetTlsContext that carries cert/trust fields; use either the process-wide config or the ' +
+    'context fields, not both';
 
 var
   // process-wide neutral hooks the per-connection adapter threads into each client handshake
   GVerifyCallback: TTlsCertificateVerifyCallback;
   GVerdictResolver: TTlsVerdictResolver;
   GVerdictDeadlineMs: Cardinal;
+  // process-wide fully-built configs that, when set, REPLACE the context-driven build
+  GClientConfig: ITlsClientConfig;
+  GServerConfig: ITlsServerConfig;
 
 procedure SetTlsLibMormotVerifyCallback(
   const ACallback: TTlsCertificateVerifyCallback);
@@ -141,6 +157,16 @@ procedure SetTlsLibMormotVerdictResolver(const AResolver: TTlsVerdictResolver;
 begin
   GVerdictResolver := AResolver;
   GVerdictDeadlineMs := ADeadlineMs;
+end;
+
+procedure SetTlsLibMormotClientConfig(const AConfig: ITlsClientConfig);
+begin
+  GClientConfig := AConfig;
+end;
+
+procedure SetTlsLibMormotServerConfig(const AConfig: ITlsServerConfig);
+begin
+  GServerConfig := AConfig;
 end;
 
 { TMormotSocketTransport }
@@ -227,6 +253,14 @@ begin
   end;
 end;
 
+class function TTlsLibNetTls.ContextCarriesTrustOrCredential(
+  const AContext: TNetTlsContext): Boolean;
+begin
+  Result := (AContext.CertificateFile <> '') or (AContext.PrivateKeyFile <> '') or
+    (AContext.CACertificatesFile <> '') or (AContext.CASystemStores <> []) or
+    (AContext.CACertificatesRaw <> nil);
+end;
+
 class function TTlsLibNetTls.BuildClientEngine(var AContext: TNetTlsContext;
   const AHost: string): ITlsEngine;
 var
@@ -234,6 +268,17 @@ var
   LClient: ITlsClientConfigBuilder;
   LHasTrust: Boolean;
 begin
+  // a process-wide fully-built config REPLACES the context-driven build outright; a context that
+  // also carries cert/trust fields fails loud rather than dropping them silently (the verify
+  // callback and verdict resolver are runtime hooks and still apply)
+  if GClientConfig <> nil then
+  begin
+    if ContextCarriesTrustOrCredential(AContext) then
+      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+        Format(SConfigAndContextConflict, ['SetTlsLibMormotClientConfig']));
+    AContext.Enabled := True;
+    Exit(TTlsEngineFactory.CreateClientEngine(GClientConfig, AHost));
+  end;
   LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
   LClient := TTlsPresets.Compatible(LProvider).Client;
   LHasTrust := False;
@@ -288,6 +333,14 @@ var
   LProvider: ICryptoProvider;
   LServer: ITlsServerConfigBuilder;
 begin
+  // a context that also carries cert/trust fields fails loud rather than being dropped silently
+  if GServerConfig <> nil then
+  begin
+    if ContextCarriesTrustOrCredential(AContext) then
+      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+        Format(SConfigAndContextConflict, ['SetTlsLibMormotServerConfig']));
+    Exit(TTlsEngineFactory.CreateServerEngine(GServerConfig));
+  end;
   LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
   LServer := TTlsPresets.Compatible(LProvider).Server;
   // as on the client: we cannot consume in-memory OpenSSL X509 handles

--- a/TlsLib.Adapters/mORMot/Examples/Delphi/MormotAdvancedConfig.dpr
+++ b/TlsLib.Adapters/mORMot/Examples/Delphi/MormotAdvancedConfig.dpr
@@ -1,0 +1,12 @@
+program MormotAdvancedConfig;
+
+{$APPTYPE CONSOLE}
+{$R *.res}
+
+uses
+  SysUtils,
+  MormotAdvancedConfigExample in '..\src\MormotAdvancedConfigExample.pas';
+
+begin
+  Halt(TMormotAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/mORMot/Examples/Lazarus/MormotAdvancedConfig.lpi
+++ b/TlsLib.Adapters/mORMot/Examples/Lazarus/MormotAdvancedConfig.lpi
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="MormotAdvancedConfig"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RequiredPackages Count="2">
+      <Item1>
+        <PackageName Value="TlsLib.Adapter.mORMot"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="FCL"/>
+      </Item2>
+    </RequiredPackages>
+    <Units Count="2">
+      <Unit0>
+        <Filename Value="MormotAdvancedConfig.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+      <Unit1>
+        <Filename Value="..\src\MormotAdvancedConfigExample.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value=".\bin\MormotAdvancedConfig"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\src"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+  </CompilerOptions>
+</CONFIG>

--- a/TlsLib.Adapters/mORMot/Examples/Lazarus/MormotAdvancedConfig.lpr
+++ b/TlsLib.Adapters/mORMot/Examples/Lazarus/MormotAdvancedConfig.lpr
@@ -1,0 +1,16 @@
+program MormotAdvancedConfig;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+{$APPTYPE CONSOLE}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  SysUtils,
+  MormotAdvancedConfigExample in '..\src\MormotAdvancedConfigExample.pas';
+
+begin
+  Halt(TMormotAdvancedConfigExample.Run);
+end.

--- a/TlsLib.Adapters/mORMot/Examples/src/MormotAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/mORMot/Examples/src/MormotAdvancedConfigExample.pas
@@ -1,0 +1,267 @@
+{ *********************************************************************************** }
+{ *                                 TlsLib Library                                  * }
+{ *                          Author - Ugochukwu Mmaduekwe                           * }
+{ *                  Github Repository <https://github.com/Xor-el>                  * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+/// <summary>
+/// Advanced configuration over the mORMot adapter: instead of the TNetTlsContext cert/trust
+/// fields, the app installs fully-built TlsLib configs process-wide through
+/// SetTlsLibMormotClientConfig / SetTlsLibMormotServerConfig (mORMot builds an INetTls per
+/// connection via a global factory, so its neutral hooks are unit-level setters). The injected
+/// configs pin an ordered, bound cipher-suite preference and TLS 1.2 only - so this loopback
+/// negotiating TLS 1.2 (the Compatible preset would pick 1.3) proves the app's config replaced
+/// the adapter's built-in build. The same seam exposes the whole builder API (groups,
+/// resumption, ALPN, ...).
+/// </summary>
+unit MormotAdvancedConfigExample;
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+interface
+
+type
+  TMormotAdvancedConfigExample = class sealed(TObject)
+  public
+    /// <summary>Runs the loopback; returns 0 on success, 1 on failure.</summary>
+    class function Run: Integer; static;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+  Classes,
+  SyncObjs,
+  mormot.core.base,
+  mormot.core.unicode,
+  mormot.net.sock,
+  TlpDataEncoding,
+  TlpTlsVersion,
+  TlpNegotiationTypes,
+  TlpINegotiation,
+  TlpCipherSuiteRegistry,
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider,
+  TlpITlsConfig,
+  TlpITlsConfigBuilder,
+  TlpTlsPresets,
+  TlsLibMormotTls;
+
+const
+  PORT = '28449';
+  HOST = '127.0.0.1';
+  PINGHEX = '70696e672066726f6d20746865206d6f724d6f742061632063';
+
+var
+  GReady: TEvent;
+  GServerError: string;
+  GVector: string;
+  GLeafDer, GKeyDer, GRootDer: TBytes;
+
+function LocateVector: string;
+const
+  REL = 'TlsLib.Tests' + PathDelim + 'Data' + PathDelim + 'Certs' + PathDelim +
+    'EcP256Chain.txt';
+var
+  LDir, LTry: string;
+  LI: Integer;
+begin
+  Result := '';
+  LDir := ExtractFilePath(ParamStr(0));
+  for LI := 0 to 8 do
+  begin
+    LTry := IncludeTrailingPathDelimiter(LDir) + REL;
+    if FileExists(LTry) then
+      Exit(LTry);
+    LDir := ExtractFileDir(ExcludeTrailingPathDelimiter(LDir));
+    if LDir = '' then
+      Break;
+  end;
+  if Result = '' then
+    raise Exception.Create('EcP256Chain.txt vector not found (searched up from the exe)');
+end;
+
+function FieldDer(const AName: string): TBytes;
+var
+  LLines: TStringList;
+  LI: Integer;
+  LPrefix: string;
+begin
+  Result := nil;
+  LPrefix := AName + '=';
+  LLines := TStringList.Create;
+  try
+    LLines.LoadFromFile(GVector);
+    for LI := 0 to LLines.Count - 1 do
+      if Pos(LPrefix, LLines[LI]) = 1 then
+        Exit(TDataEncoding.HexDecode(Copy(LLines[LI], System.Length(LPrefix) + 1, MaxInt)));
+  finally
+    LLines.Free;
+  end;
+end;
+
+// an ordered, bound TLS 1.2 cipher-suite preference: only these suites may be negotiated and the
+// Add order is the preference order (server-preference is the model, so the server's order wins)
+function OrderedSuites(const AProvider: ICryptoProvider): ICipherSuiteRegistry;
+var
+  LAll, LOrdered: ICipherSuiteRegistry;
+  LSuite: TTlsCipherSuite;
+begin
+  LAll := TCipherSuiteRegistry.CreateDualVersion(AProvider);
+  LOrdered := TCipherSuiteRegistry.Create;
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaAes256GcmSha384, LSuite) then LOrdered.Add(LSuite);
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaChaCha20Poly1305Sha256, LSuite) then LOrdered.Add(LSuite);
+  if LAll.TryGet(TCipherSuites12.EcdheEcdsaAes128GcmSha256, LSuite) then LOrdered.Add(LSuite);
+  Result := LOrdered;
+end;
+
+function BuildClientConfig: ITlsClientConfig;
+var
+  LProvider: ICryptoProvider;
+  LClient: ITlsClientConfigBuilder;
+begin
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LClient := TTlsPresets.Compatible(LProvider).Client;
+  LClient.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  // X25519 for the ECDHE, plus the leaf's P-256 curve (RFC 8422 5.4)
+  LClient.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519,
+    TNamedGroupCatalog.Secp256r1));
+  LClient.WithCipherSuites(OrderedSuites(LProvider));
+  LClient.WithTrustAnchors(GRootDer);
+  Result := LClient.Build;
+end;
+
+function BuildServerConfig: ITlsServerConfig;
+var
+  LProvider: ICryptoProvider;
+  LServer: ITlsServerConfigBuilder;
+begin
+  LProvider := TDefaultCryptoProvider.Create as ICryptoProvider;
+  LServer := TTlsPresets.Compatible(LProvider).Server;
+  LServer.WithSupportedVersions(TArray<UInt16>.Create(TlsWireVersionTls12));
+  LServer.WithPreferredGroups(TArray<UInt16>.Create(TNamedGroupCatalog.X25519,
+    TNamedGroupCatalog.Secp256r1));
+  LServer.WithCipherSuites(OrderedSuites(LProvider));
+  LServer.WithCredential(GLeafDer, GKeyDer);
+  Result := LServer.Build;
+end;
+
+type
+  TServerThread = class(TThread)
+  protected
+    procedure Execute; override;
+  end;
+
+procedure TServerThread.Execute;
+var
+  LListener, LClient: TNetSocket;
+  LAddr: TNetAddr;
+  LCtx: TNetTlsContext;
+  LTls: INetTls;
+  LLastErr, LCipher: RawUtf8;
+  LBuf: TBytes;
+  LLen: Integer;
+begin
+  try
+    FillCharFast(LCtx, SizeOf(LCtx), 0); // the config is installed process-wide, so the context is empty
+    if NewSocket(HOST, PORT, nlTcp, {dobind=}True, 3000, 3000, 3000, 0,
+      LListener) <> nrOK then
+      raise Exception.Create('server bind failed');
+    GReady.SetEvent;
+    if LListener.Accept(LClient, LAddr, {async=}False) <> nrOK then
+      raise Exception.Create('accept failed');
+    LTls := NewTlsLib4PascalTls;
+    LTls.AfterAccept(LClient, LCtx, @LLastErr, @LCipher);
+    LBuf := nil;
+    SetLength(LBuf, 4096);
+    LLen := System.Length(LBuf);
+    if LTls.Receive(@LBuf[0], LLen) = nrOK then
+      LTls.Send(@LBuf[0], LLen);
+  except
+    on E: Exception do
+    begin
+      GServerError := E.ClassName + ': ' + E.Message;
+      GReady.SetEvent;
+    end;
+  end;
+end;
+
+class function TMormotAdvancedConfigExample.Run: Integer;
+var
+  LServer: TServerThread;
+  LCtx: TNetTlsContext;
+  LSock: TNetSocket;
+  LTls: INetTls;
+  LPing, LEcho: TBytes;
+  LLen: Integer;
+  LOk: Boolean;
+begin
+  Result := 1;
+  GServerError := '';
+  GVector := LocateVector;
+  GLeafDer := FieldDer('leaf_cert');
+  GKeyDer := FieldDer('leaf_key');
+  GRootDer := FieldDer('root_cert');
+  GReady := TEvent.Create(nil, True, False, '');
+  try
+    // install the fully-built configs process-wide; every handshake now uses them verbatim
+    SetTlsLibMormotServerConfig(BuildServerConfig);
+    SetTlsLibMormotClientConfig(BuildClientConfig);
+    try
+      LServer := TServerThread.Create(True);
+      LServer.FreeOnTerminate := False;
+      LServer.Start;
+      GReady.WaitFor(5000);
+      if GServerError <> '' then
+        raise Exception.Create('server: ' + GServerError);
+
+      FillCharFast(LCtx, SizeOf(LCtx), 0);
+      if NewSocket(HOST, PORT, nlTcp, {dobind=}False, 3000, 3000, 3000, 0, LSock) <> nrOK then
+        raise Exception.Create('client connect failed');
+      LTls := NewTlsLib4PascalTls;
+      // connect to 127.0.0.1 but verify the certificate for 'localhost' (its SAN)
+      LTls.AfterConnection(LSock, LCtx, 'localhost');
+
+      LPing := TDataEncoding.HexDecode(PINGHEX);
+      LLen := System.Length(LPing);
+      LTls.Send(@LPing[0], LLen);
+      LEcho := nil;
+      SetLength(LEcho, 4096);
+      LLen := System.Length(LEcho);
+      LTls.Receive(@LEcho[0], LLen);
+
+      LServer.WaitFor;
+      if GServerError <> '' then
+        raise Exception.Create('server: ' + GServerError);
+
+      LOk := (LLen = System.Length(LPing)) and CompareMem(@LEcho[0], @LPing[0], LLen)
+        and (LTls.GetCipherName = 'TLSv1.2');
+      if LOk then
+      begin
+        Writeln('mORMot advanced-config PASS: injected config pinned TLS 1.2 + ordered ciphers, echo ok');
+        Result := 0;
+      end
+      else
+        Writeln('mORMot advanced-config FAIL: echo/version mismatch (', LTls.GetCipherName, ')');
+      LServer.Free;
+    finally
+      // clear the process-wide configs so later work in the same process is unaffected
+      SetTlsLibMormotServerConfig(nil);
+      SetTlsLibMormotClientConfig(nil);
+    end;
+  except
+    on E: Exception do
+      Writeln('mORMot advanced-config FAIL: ', E.ClassName, ': ', E.Message);
+  end;
+  GReady.Free;
+end;
+
+end.

--- a/TlsLib.Adapters/mORMot/README.md
+++ b/TlsLib.Adapters/mORMot/README.md
@@ -90,3 +90,11 @@ verification against a **pinned** root (`data/isrg-roots.pem`, the self-signed I
 `Client.TLS.CACertificatesFile`, and drives both verbs with a keep-alive `Get`/`Post` over **one
 reused TLS connection**. It is a **network-gated demo, not a test gate**: it needs outbound HTTPS
 and exits 0 (PASS) / 2 (SKIP, offline) / 1 (FAIL).
+
+`Examples/` also carries an **advanced-config** demo (`src/MormotAdvancedConfigExample.pas`,
+`Lazarus/MormotAdvancedConfig.lpi` / `Delphi/MormotAdvancedConfig.dproj`): instead of the
+`TNetTlsContext` cert/trust fields, it installs fully-built configs process-wide via
+`SetTlsLibMormotServerConfig` / `SetTlsLibMormotClientConfig` — an ordered, bound cipher-suite
+preference pinned to TLS 1.2, so the negotiated 1.2 (the preset would pick 1.3) proves the injected
+config replaced the built-in build. This is the escape hatch to the whole builder API (cipher
+order, groups, resumption, ALPN, …).

--- a/TlsLib.Tests/src/NegotiationTests.pas
+++ b/TlsLib.Tests/src/NegotiationTests.pas
@@ -49,6 +49,8 @@ type
       ADescription: TTlsAlertDescription): Boolean;
   published
     procedure TestCipherSuiteServerPreferenceHonored;
+    procedure TestCipherSuiteHonorClientOrderWhenEnabled;
+    procedure TestClientOrderOverridesHardwareAesTiebreak;
     procedure TestCpuAdaptiveTiebreakPrefersAesWithHardware;
     procedure TestCpuAdaptiveTiebreakPrefersChaChaWithoutHardware;
     procedure TestSuitePreferenceOrderUnifiedAcrossProtocols;
@@ -96,6 +98,49 @@ begin
   CheckEquals(TCipherSuites13.Aes128GcmSha256,
     LPolicy.SelectCipherSuite(TArray<UInt16>.Create(TCipherSuites13.Aes256GcmSha384,
     TCipherSuites13.Aes128GcmSha256), TlsWireVersionTls13), 'server prefers AES-128-GCM');
+end;
+
+procedure TTestNegotiation.TestCipherSuiteHonorClientOrderWhenEnabled;
+var
+  LProvider: ICryptoProvider;
+  LPolicy: INegotiationPolicy;
+begin
+  // same hardware-AES setup as above (server order prefers AES-128), but with honor-client-order
+  // on: the client's most-preferred suite (AES-256) wins instead of the server's AES-128
+  LProvider := TFixedAesProvider.Create(Provider, True);
+  LPolicy := TNegotiationPolicy.Create(LProvider,
+    TCipherSuiteRegistry.CreateDefault(LProvider),
+    TNamedGroups.CreateDefaultRegistry(LProvider),
+    TSignatureSchemeRegistry.CreateDefault,
+    TArray<UInt16>.Create(TNamedGroupCatalog.X25519, TNamedGroupCatalog.Secp256r1),
+    TArray<UInt16>.Create(TlsWireVersionTls13),
+    TServerCipherPreference.ClientOrder);
+  CheckEquals(TCipherSuites13.Aes256GcmSha384,
+    LPolicy.SelectCipherSuite(TArray<UInt16>.Create(TCipherSuites13.Aes256GcmSha384,
+    TCipherSuites13.Aes128GcmSha256), TlsWireVersionTls13),
+    'honor-client-order: the client''s AES-256 preference wins over the server''s AES-128');
+end;
+
+procedure TTestNegotiation.TestClientOrderOverridesHardwareAesTiebreak;
+var
+  LProvider: ICryptoProvider;
+  LPolicy: INegotiationPolicy;
+begin
+  // the hardware-AES tiebreak lives in the SERVER's order (AES-GCM ahead of ChaCha with hardware
+  // AES). Under ClientOrder the client's order decides and that tiebreak is bypassed: a ChaCha-
+  // first client gets ChaCha even from a hardware-AES server (the mobile-client case)
+  LProvider := TFixedAesProvider.Create(Provider, True);
+  LPolicy := TNegotiationPolicy.Create(LProvider,
+    TCipherSuiteRegistry.CreateDefault(LProvider),
+    TNamedGroups.CreateDefaultRegistry(LProvider),
+    TSignatureSchemeRegistry.CreateDefault,
+    TArray<UInt16>.Create(TNamedGroupCatalog.X25519, TNamedGroupCatalog.Secp256r1),
+    TArray<UInt16>.Create(TlsWireVersionTls13),
+    TServerCipherPreference.ClientOrder);
+  CheckEquals(TCipherSuites13.ChaCha20Poly1305Sha256,
+    LPolicy.SelectCipherSuite(TArray<UInt16>.Create(TCipherSuites13.ChaCha20Poly1305Sha256,
+    TCipherSuites13.Aes128GcmSha256), TlsWireVersionTls13),
+    'ClientOrder overrides the hardware-AES tiebreak: a ChaCha-first client gets ChaCha');
 end;
 
 procedure TTestNegotiation.TestCpuAdaptiveTiebreakPrefersAesWithHardware;
@@ -211,7 +256,7 @@ begin
     TNamedGroups.CreateDefaultRegistry(Provider),
     TSignatureSchemeRegistry.CreateDefault,
     TArray<UInt16>.Create(TNamedGroupCatalog.X25519),
-    TArray<UInt16>.Create(TlsWireVersionTls13));
+    TArray<UInt16>.Create(TlsWireVersionTls13), TServerCipherPreference.ServerOrder);
   CheckTrue(SelectSuiteRaises(LPolicy, TArray<UInt16>.Create(TCipherSuites13.Aes128GcmSha256),
     TTlsAlertDescription.HandshakeFailure), 'a pruned suite is no longer negotiable');
 end;
@@ -312,7 +357,7 @@ begin
     TCipherSuiteRegistry.CreateDualVersion(Provider), LGroups,
     TSignatureSchemeRegistry.CreateDefault,
     TArray<UInt16>.Create(TNamedGroupCatalog.X25519MlKem768, TNamedGroupCatalog.Secp256r1),
-    TArray<UInt16>.Create(TlsWireVersionTls13, TlsWireVersionTls12));
+    TArray<UInt16>.Create(TlsWireVersionTls13, TlsWireVersionTls12), TServerCipherPreference.ServerOrder);
   LSelected := LPolicy.SelectGroup(TArray<UInt16>.Create(
     TNamedGroupCatalog.X25519MlKem768, TNamedGroupCatalog.Secp256r1), TlsWireVersionTls12);
   CheckTrue(LSelected <> TNamedGroupCatalog.X25519MlKem768,
@@ -335,7 +380,7 @@ begin
     TNamedGroups.CreateDefaultRegistry(Provider),
     TSignatureSchemeRegistry.CreateDefault,
     TArray<UInt16>.Create(TNamedGroupCatalog.Secp256r1),
-    TArray<UInt16>.Create(TlsWireVersionTls13, TlsWireVersionTls12));
+    TArray<UInt16>.Create(TlsWireVersionTls13, TlsWireVersionTls12), TServerCipherPreference.ServerOrder);
   LSelected := LPolicy.SelectCipherSuite(TArray<UInt16>.Create(
     TCipherSuites13.Aes128GcmSha256, TCipherSuites12.EcdheEcdsaAes128GcmSha256),
     TlsWireVersionTls12);

--- a/TlsLib.Tests/src/Tls12DualVersionTests.pas
+++ b/TlsLib.Tests/src/Tls12DualVersionTests.pas
@@ -213,7 +213,7 @@ begin
     TNamedGroups.CreateDefaultRegistry(Provider),
     TSignatureSchemeRegistry.CreateDefault,
     TArray<UInt16>.Create(TNamedGroupCatalog.X25519),
-    TArray<UInt16>.Create(TlsWireVersionTls13, TlsWireVersionTls12));
+    TArray<UInt16>.Create(TlsWireVersionTls13, TlsWireVersionTls12), TServerCipherPreference.ServerOrder);
   Result.CipherSuites := TCipherSuiteRegistry.CreateDualVersion(Provider);
   Result.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   Result.Group := TNamedGroups.CreateX25519(Provider);

--- a/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
+++ b/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
@@ -23,6 +23,7 @@ uses
   TlpICryptoProvider,
   TlpINamedGroup,
   TlpINegotiation,
+  TlpNegotiationTypes,
   TlpICertificateTrust,
   TlpCertificateVerifier,
   TlpICertificateCompression,
@@ -78,6 +79,7 @@ type
     FCertificateCompressionCache: ICertificateCompressionCache;
     FRequireExtendedMasterSecret: Boolean;
     FServerNameAck: Boolean;
+    FCipherPreference: TServerCipherPreference;
     FAlpnRejectAll: Boolean;
     FClientCertificateAuthorities: TArray<TBytes>;
     FGrease: Boolean;
@@ -143,6 +145,7 @@ type
       const ACache: ICertificateCompressionCache): TTlsConfigBuilder;
     function WithExtendedMasterSecret(ARequire: Boolean): TTlsConfigBuilder;
     function WithServerNameAcknowledgement(ASend: Boolean): TTlsConfigBuilder;
+    function WithCipherSuitePreference(APreference: TServerCipherPreference): TTlsConfigBuilder;
     function WithAlpnRejection(AReject: Boolean): TTlsConfigBuilder;
     function WithClientCertificateAuthorities(const AAuthorities: TArray<TBytes>): TTlsConfigBuilder;
     function WithGrease(AEnable: Boolean): TTlsConfigBuilder;
@@ -235,6 +238,7 @@ type
     FAsyncVerdict: TAsyncCertificateVerdict;
     FRequireExtendedMasterSecret: Boolean;
     FServerNameAck: Boolean;
+    FCipherPreference: TServerCipherPreference;
     FAlpnRejectAll: Boolean;
     FClientCertificateAuthorities: TArray<TBytes>;
     FGrease: Boolean;
@@ -262,6 +266,7 @@ type
     function AsyncCertificateVerdict: TAsyncCertificateVerdict;
     function RequireExtendedMasterSecret: Boolean;
     function ServerNameAcknowledgement: Boolean;
+    function CipherSuitePreference: TServerCipherPreference;
     function AlpnRejectAll: Boolean;
     function ClientCertificateAuthorities: TArray<TBytes>;
     function Grease: Boolean;
@@ -375,6 +380,7 @@ type
     function WithPreferredGroups(const AGroups: TArray<UInt16>): ITlsServerConfigBuilder;
     function WithAlpnProtocols(const AProtocols: TArray<string>): ITlsServerConfigBuilder;
     function WithServerNameAcknowledgement(ASend: Boolean): ITlsServerConfigBuilder;
+    function WithCipherSuitePreference(APreference: TServerCipherPreference): ITlsServerConfigBuilder;
     function WithAlpnRejection(AReject: Boolean): ITlsServerConfigBuilder;
     function WithClientCertificateAuthorities(const AAuthorities: TArray<TBytes>): ITlsServerConfigBuilder;
     function WithTrustStore(const AStore: ITrustAnchorStore): ITlsServerConfigBuilder;
@@ -565,6 +571,11 @@ end;
 function TFrozenCommonConfig.ServerNameAcknowledgement: Boolean;
 begin
   Result := FServerNameAck;
+end;
+
+function TFrozenCommonConfig.CipherSuitePreference: TServerCipherPreference;
+begin
+  Result := FCipherPreference;
 end;
 
 function TFrozenCommonConfig.AlpnRejectAll: Boolean;
@@ -926,6 +937,13 @@ begin
   Result := Self;
 end;
 
+function TTlsServerConfigBuilder.WithCipherSuitePreference(
+  APreference: TServerCipherPreference): ITlsServerConfigBuilder;
+begin
+  FOwner.WithCipherSuitePreference(APreference);
+  Result := Self;
+end;
+
 function TTlsServerConfigBuilder.WithAlpnRejection(
   AReject: Boolean): ITlsServerConfigBuilder;
 begin
@@ -1248,6 +1266,8 @@ begin
   // (RFC 6066) by default; both are optional and a caller may turn them off
   FGrease := True;
   FServerNameAck := True;
+  // server-preference cipher selection by default; a caller may opt into honoring the client's order
+  FCipherPreference := TServerCipherPreference.ServerOrder;
   // configuring an external PSK is an explicit "authenticate with this key" statement, so a
   // non-PSK server response is refused by default; a caller may opt into a certificate fallback
   FExternalPskRequired := True;
@@ -1473,6 +1493,14 @@ function TTlsConfigBuilder.WithServerNameAcknowledgement(
 begin
   GuardMutable;
   FServerNameAck := ASend;
+  Result := Self;
+end;
+
+function TTlsConfigBuilder.WithCipherSuitePreference(
+  APreference: TServerCipherPreference): TTlsConfigBuilder;
+begin
+  GuardMutable;
+  FCipherPreference := APreference;
   Result := Self;
 end;
 
@@ -1728,6 +1756,7 @@ begin
   LConfig.FAsyncVerdict := FAsyncVerdict;
   LConfig.FRequireExtendedMasterSecret := FRequireExtendedMasterSecret;
   LConfig.FServerNameAck := FServerNameAck;
+  LConfig.FCipherPreference := FCipherPreference;
   LConfig.FAlpnRejectAll := FAlpnRejectAll;
   LConfig.FClientCertificateAuthorities := FClientCertificateAuthorities;
   LConfig.FGrease := FGrease;
@@ -1789,6 +1818,7 @@ begin
   LConfig.FAsyncVerdict := FAsyncVerdict;
   LConfig.FRequireExtendedMasterSecret := FRequireExtendedMasterSecret;
   LConfig.FServerNameAck := FServerNameAck;
+  LConfig.FCipherPreference := FCipherPreference;
   LConfig.FAlpnRejectAll := FAlpnRejectAll;
   LConfig.FClientCertificateAuthorities := FClientCertificateAuthorities;
   LConfig.FGrease := FGrease;

--- a/TlsLib/src/Engine/TlpTlsEngineFactory.pas
+++ b/TlsLib/src/Engine/TlpTlsEngineFactory.pas
@@ -318,7 +318,7 @@ begin
   L13.Clock := AConfig.Clock;
   L13.Policy := TNegotiationPolicy.Create(AConfig.Provider, AConfig.CipherSuites,
     AConfig.NamedGroups, AConfig.SignatureSchemes, AConfig.PreferredGroups,
-    AConfig.SupportedVersions);
+    AConfig.SupportedVersions, AConfig.CipherSuitePreference);
   L13.CipherSuites := AConfig.CipherSuites;
   L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   // the server offers all its preferred groups and selects one the client offered (RFC 8446

--- a/TlsLib/src/Interfaces/Engine/TlpITlsConfig.pas
+++ b/TlsLib/src/Interfaces/Engine/TlpITlsConfig.pas
@@ -20,6 +20,7 @@ uses
   TlpICryptoProvider,
   TlpINamedGroup,
   TlpINegotiation,
+  TlpNegotiationTypes,
   TlpICertificateTrust,
   TlpICertificateCompression,
   TlpICertificateCompressionCache,
@@ -85,6 +86,10 @@ type
     /// <summary>Whether a server that received a server_name (SNI) echoes the empty
     /// server_name acknowledgement (RFC 6066 3); default True.</summary>
     function ServerNameAcknowledgement: Boolean;
+    /// <summary>How the server resolves the cipher suite: ServerOrder (default) imposes the
+    /// server's own preference; ClientOrder honors the client's offered order. Server-only; a
+    /// client config ignores it.</summary>
+    function CipherSuitePreference: TServerCipherPreference;
     /// <summary>Whether a server rejects ALPN unconditionally: on any client ALPN offer it
     /// aborts with no_application_protocol (RFC 7301) rather than selecting or declining;
     /// default False.</summary>

--- a/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
+++ b/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
@@ -19,6 +19,7 @@ uses
   SysUtils,
   TlpINamedGroup,
   TlpINegotiation,
+  TlpNegotiationTypes,
   TlpICertificateTrust,
   TlpICertificateCompression,
   TlpICertificateCompressionCache,
@@ -202,6 +203,10 @@ type
     /// <summary>Whether the server echoes an empty server_name acknowledgement (RFC 6066 3)
     /// when the client offered a host_name. Default True; pass False to omit it.</summary>
     function WithServerNameAcknowledgement(ASend: Boolean): ITlsServerConfigBuilder;
+    /// <summary>How the server resolves the cipher suite when more than one is mutually supported.
+    /// TServerCipherPreference.ServerOrder (the default) imposes the server's own preference;
+    /// TServerCipherPreference.ClientOrder selects the client's most-preferred suite instead.</summary>
+    function WithCipherSuitePreference(APreference: TServerCipherPreference): ITlsServerConfigBuilder;
     /// <summary>Reject ALPN unconditionally: on any client ALPN offer the server aborts with
     /// no_application_protocol (RFC 7301 3.2) instead of selecting or declining. Default False.</summary>
     function WithAlpnRejection(AReject: Boolean): ITlsServerConfigBuilder;

--- a/TlsLib/src/Negotiation/TlpNegotiationPolicy.pas
+++ b/TlsLib/src/Negotiation/TlpNegotiationPolicy.pas
@@ -48,6 +48,7 @@ type
     FSignatureSchemes: ISignatureSchemeRegistry;
     FPreferredGroups: TArray<UInt16>;
     FSupportedVersions: TArray<UInt16>;
+    FCipherPreference: TServerCipherPreference;
     /// <summary>The offered suites for ANegotiatedVersion in preference order (the
     /// hardware-AES tiebreak applied), filtered to that version's protocol.</summary>
     function EffectiveSuiteOrder(ANegotiatedVersion: UInt16): TArray<UInt16>;
@@ -56,7 +57,8 @@ type
     constructor Create(const AProvider: ICryptoProvider;
       const ACipherSuites: ICipherSuiteRegistry; const AGroups: INamedGroupRegistry;
       const ASignatureSchemes: ISignatureSchemeRegistry;
-      const APreferredGroups, ASupportedVersions: TArray<UInt16>);
+      const APreferredGroups, ASupportedVersions: TArray<UInt16>;
+      ACipherPreference: TServerCipherPreference);
 
     function SelectVersion(const AClientVersions: TArray<UInt16>): UInt16;
     function SelectCipherSuite(const AClientSuites: TArray<UInt16>;
@@ -120,7 +122,8 @@ resourcestring
 constructor TNegotiationPolicy.Create(const AProvider: ICryptoProvider;
   const ACipherSuites: ICipherSuiteRegistry; const AGroups: INamedGroupRegistry;
   const ASignatureSchemes: ISignatureSchemeRegistry;
-  const APreferredGroups, ASupportedVersions: TArray<UInt16>);
+  const APreferredGroups, ASupportedVersions: TArray<UInt16>;
+  ACipherPreference: TServerCipherPreference);
 begin
   inherited Create;
   FProvider := AProvider;
@@ -129,6 +132,7 @@ begin
   FSignatureSchemes := ASignatureSchemes;
   FPreferredGroups := APreferredGroups;
   FSupportedVersions := ASupportedVersions;
+  FCipherPreference := ACipherPreference;
 end;
 
 class function TNegotiationPolicy.ProtocolOf(
@@ -198,10 +202,23 @@ function TNegotiationPolicy.SelectCipherSuite(
   const AClientSuites: TArray<UInt16>; ANegotiatedVersion: UInt16): UInt16;
 var
   LCode: UInt16;
+  LServerOrder: TArray<UInt16>;
 begin
-  for LCode in EffectiveSuiteOrder(ANegotiatedVersion) do
-    if TArrayUtilities.Contains<UInt16>(AClientSuites, LCode) then
-      Exit(LCode);
+  LServerOrder := EffectiveSuiteOrder(ANegotiatedVersion);
+  if FCipherPreference = TServerCipherPreference.ClientOrder then
+  begin
+    // honor the client's preference: the client's most-preferred suite the server also offers
+    for LCode in AClientSuites do
+      if TArrayUtilities.Contains<UInt16>(LServerOrder, LCode) then
+        Exit(LCode);
+  end
+  else
+  begin
+    // server preference (default): the server's most-preferred suite the client also offered
+    for LCode in LServerOrder do
+      if TArrayUtilities.Contains<UInt16>(AClientSuites, LCode) then
+        Exit(LCode);
+  end;
   raise EFatalAlertTlsLibException.CreateRes(TTlsAlertDescription.HandshakeFailure,
     @SNoCommonSuite);
 end;
@@ -245,7 +262,7 @@ begin
     TSignatureSchemeRegistry.CreateDefault,
     TArray<UInt16>.Create(TNamedGroupCatalog.X25519MlKem768, TNamedGroupCatalog.X25519, TNamedGroupCatalog.Secp256r1,
     TNamedGroupCatalog.Secp384r1, TNamedGroupCatalog.Secp521r1),
-    TArray<UInt16>.Create(TlsWireVersionTls13));
+    TArray<UInt16>.Create(TlsWireVersionTls13), TServerCipherPreference.ServerOrder);
 end;
 
 { THelloRetryRequest }

--- a/TlsLib/src/Negotiation/TlpNegotiationTypes.pas
+++ b/TlsLib/src/Negotiation/TlpNegotiationTypes.pas
@@ -20,6 +20,11 @@ uses
   TlpCryptoAlgorithms;
 
 type
+  /// <summary>How a server resolves the cipher suite when more than one is mutually supported:
+  /// ServerOrder (the default) imposes the server's own preference order; ClientOrder honors the
+  /// client's offered order, selecting the client's most-preferred mutually supported suite.</summary>
+  TServerCipherPreference = (ServerOrder, ClientOrder);
+
   /// <summary>TLS 1.3 cipher-suite wire codepoints (RFC 8446 B.4).</summary>
   TCipherSuites13 = class sealed(TObject)
   public const


### PR DESCRIPTION
Server cipher-suite selection gains a policy knob: WithCipherSuitePreference on the server builder, taking a TServerCipherPreference enum (ServerOrder | ClientOrder), default ServerOrder (unchanged behavior). ClientOrder makes the server honor the client's offered order instead of imposing its own — the case OpenSSL covers by
leaving SSL_OP_CIPHER_SERVER_PREFERENCE unset. Threaded end to end: builder ->
frozen config getter CipherSuitePreference -> factory -> TNegotiationPolicy (explicit ctor arg, no hidden default) -> SelectCipherSuite. Server-only, so it lives on the server facet (the client never selects a suite). The CPU-adaptive AES/ChaCha tiebreak is unchanged and still governs the ServerOrder path; under ClientOrder the client's order decides. Covered by new negotiation tests for both modes and for ClientOrder overriding the hardware-AES tiebreak.

Expose the outcome: NegotiatedCipherSuite read accessors on the Indy, Synapse and fcl-net handler classes (mORMot's INetTls has no class surface for it).

Adapters also gain a config-in escape hatch — supply a fully-built ITlsClientConfig/ITlsServerConfig and the adapter uses it verbatim, skipping its options-driven build (Indy SSLOptions.ServerConfig/ClientConfig; Synapse & fcl-net per-connection props; mORMot SetTlsLibMormot{Client,Server}Config setters). When a config is injected alongside explicitly-set cert/trust options, the adapter fails loud ("supply either the config or the cert/trust options, not both") rather than silently dropping them — matching the library's fail-closed posture. The runtime verdict resolver is deliberately exempt (it is not part of the frozen config), so it still composes with a supplied config.