### PR TITLE
Build packages at -O4

### DIFF
--- a/TlsLib.Adapters/FclNet/Packages/FPC/TlsLib.Adapter.FclNet.lpk
+++ b/TlsLib.Adapters/FclNet/Packages/FPC/TlsLib.Adapter.FclNet.lpk
@@ -12,6 +12,11 @@
         <OtherUnitFiles Value="..\..\Adapter"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <CodeGeneration>
+        <Optimizations>
+          <OptimizationLevel Value="4"/>
+        </Optimizations>
+      </CodeGeneration>
     </CompilerOptions>
     <Description Value="fcl-net TSSLSocketHandler adapter for TlsLib4Pascal (managed TLS for TFPHTTPClient / TInetSocket)"/>
     <License Value="MIT License"/>

--- a/TlsLib.Adapters/Indy/Packages/FPC/TlsLib.Adapter.Indy.lpk
+++ b/TlsLib.Adapters/Indy/Packages/FPC/TlsLib.Adapter.Indy.lpk
@@ -12,6 +12,11 @@
         <OtherUnitFiles Value="..\..\Adapter"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <CodeGeneration>
+        <Optimizations>
+          <OptimizationLevel Value="4"/>
+        </Optimizations>
+      </CodeGeneration>
     </CompilerOptions>
     <Description Value="Indy IOHandler adapter for TlsLib4Pascal"/>
     <License Value="MIT License"/>

--- a/TlsLib.Adapters/Synapse/Packages/FPC/TlsLib.Adapter.Synapse.lpk
+++ b/TlsLib.Adapters/Synapse/Packages/FPC/TlsLib.Adapter.Synapse.lpk
@@ -12,6 +12,11 @@
         <OtherUnitFiles Value="..\..\Adapter"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <CodeGeneration>
+        <Optimizations>
+          <OptimizationLevel Value="4"/>
+        </Optimizations>
+      </CodeGeneration>
     </CompilerOptions>
     <Description Value="Synapse TCustomSSL plugin adapter for TlsLib4Pascal (one SSL plugin per project)"/>
     <License Value="MIT License"/>

--- a/TlsLib.Adapters/mORMot/Packages/FPC/TlsLib.Adapter.mORMot.lpk
+++ b/TlsLib.Adapters/mORMot/Packages/FPC/TlsLib.Adapter.mORMot.lpk
@@ -12,6 +12,11 @@
         <OtherUnitFiles Value="..\..\Adapter"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <CodeGeneration>
+        <Optimizations>
+          <OptimizationLevel Value="4"/>
+        </Optimizations>
+      </CodeGeneration>
     </CompilerOptions>
     <Description Value="mORMot INetTls adapter for TlsLib4Pascal"/>
     <License Value="MIT License"/>

--- a/TlsLib.Trust.Bundle/Packages/FPC/TlsLib.Trust.Bundle.lpk
+++ b/TlsLib.Trust.Bundle/Packages/FPC/TlsLib.Trust.Bundle.lpk
@@ -12,6 +12,11 @@
         <OtherUnitFiles Value="..\..\src"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <CodeGeneration>
+        <Optimizations>
+          <OptimizationLevel Value="4"/>
+        </Optimizations>
+      </CodeGeneration>
     </CompilerOptions>
     <Description Value="Optional PEM CA-bundle trust source for TlsLib4Pascal"/>
     <License Value="MIT License"/>

--- a/TlsLib.Trust.System/Packages/FPC/TlsLib.Trust.System.lpk
+++ b/TlsLib.Trust.System/Packages/FPC/TlsLib.Trust.System.lpk
@@ -12,6 +12,11 @@
         <OtherUnitFiles Value="..\..\src"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <CodeGeneration>
+        <Optimizations>
+          <OptimizationLevel Value="4"/>
+        </Optimizations>
+      </CodeGeneration>
     </CompilerOptions>
     <Description Value="Optional OS system-trust sources (anchors + delegate) for TlsLib4Pascal"/>
     <License Value="MIT License"/>

--- a/TlsLib/src/Packages/FPC/TlsLib4PascalPackage.lpk
+++ b/TlsLib/src/Packages/FPC/TlsLib4PascalPackage.lpk
@@ -15,7 +15,7 @@
       </SearchPaths>
       <CodeGeneration>
         <Optimizations>
-          <OptimizationLevel Value="3"/>
+          <OptimizationLevel Value="4"/>
         </Optimizations>
       </CodeGeneration>
       <Other>


### PR DESCRIPTION
Pin every package's optimization level to 4. The four adapter packages and both trust packages had no optimization setting, inheriting the IDE default.