### PR TITLE
Inject the crypto provider into the default session ticket keys

### DIFF
--- a/TlsLib.Adapters/FclNet/Adapter/TlsLibFclNetTls.pas
+++ b/TlsLib.Adapters/FclNet/Adapter/TlsLibFclNetTls.pas
@@ -47,7 +47,6 @@ uses
   TlpITlsConfigMemo,
   TlpTlsConfigMemo,
   TlpTlsSignatureBuilder,
-  TlpSessionTicketKeys,
   TlpInMemorySessionCache,
   TlpITlsTransport,
   TlpTlsStreamPump,
@@ -517,7 +516,7 @@ begin
   if FSessionResumption then
   begin
     LServer.WithResumption(True);
-    LServer.WithSessionTicketKeys(TStekTicketKeyManager.Shared);
+    LServer.WithDefaultSessionTicketKeys;
   end
   else
     LServer.WithResumption(False);

--- a/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
+++ b/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
@@ -50,7 +50,6 @@ uses
   TlpITlsConfigMemo,
   TlpTlsConfigMemo,
   TlpTlsSignatureBuilder,
-  TlpSessionTicketKeys,
   TlpInMemorySessionCache,
   TlpITlsTransport,
   TlpTlsStreamPump,
@@ -533,7 +532,7 @@ begin
   if FOptions.SessionResumption then
   begin
     LServer.WithResumption(True);
-    LServer.WithSessionTicketKeys(TStekTicketKeyManager.Shared);
+    LServer.WithDefaultSessionTicketKeys;
   end
   else
     LServer.WithResumption(False);
@@ -610,15 +609,16 @@ begin
     FOptions.GuardNoConflict('ServerConfig');
     Exit(TTlsEngineFactory.CreateServerEngine(FOptions.ServerConfig));
   end;
-  // a server peer reuses the listener's shared memo, so all peers bind to one config identity
-  if FServerMemo <> nil then
-  begin
-    LSig := ServerSignature;
-    if not FServerMemo.TryGet(LSig, LServerCfg) then
-      LServerCfg := FServerMemo.StoreOrAdopt(LSig, BuildServerConfig);
-    Exit(TTlsEngineFactory.CreateServerEngine(LServerCfg));
-  end;
-  Exit(TTlsEngineFactory.CreateServerEngine(BuildServerConfig));
+  // a server peer reuses the listener's shared memo so all peers bind to one config identity; a
+  // standalone handler doing its own accepts (no TTlsLibServerIOHandler listener) lazily owns one,
+  // like it already owns FClientMemo, so its config - and the default STEK minted into it - stay
+  // stable across the connections it serves (this is serialized by the handshake lock)
+  if FServerMemo = nil then
+    FServerMemo := NewTlsServerConfigMemo;
+  LSig := ServerSignature;
+  if not FServerMemo.TryGet(LSig, LServerCfg) then
+    LServerCfg := FServerMemo.StoreOrAdopt(LSig, BuildServerConfig);
+  Exit(TTlsEngineFactory.CreateServerEngine(LServerCfg));
 end;
 
 procedure TTlsLibIOHandlerSocket.DoHandshake;

--- a/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
+++ b/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
@@ -48,7 +48,6 @@ uses
   TlpITlsConfigMemo,
   TlpTlsConfigMemo,
   TlpTlsSignatureBuilder,
-  TlpSessionTicketKeys,
   TlpInMemorySessionCache,
   TlpITlsTransport,
   TlpTlsStreamPump,
@@ -388,7 +387,7 @@ begin
   if FSessionResumption then
   begin
     LServer.WithResumption(True);
-    LServer.WithSessionTicketKeys(TStekTicketKeyManager.Shared);
+    LServer.WithDefaultSessionTicketKeys;
   end
   else
     LServer.WithResumption(False);

--- a/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
+++ b/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
@@ -47,7 +47,6 @@ uses
   TlpITlsConfigMemo,
   TlpTlsConfigMemo,
   TlpTlsSignatureBuilder,
-  TlpSessionTicketKeys,
   TlpInMemorySessionCache,
   TlpITlsTransport,
   TlpTlsStreamPump,
@@ -424,7 +423,7 @@ begin
   if GSessionResumption then
   begin
     LServer.WithResumption(True);
-    LServer.WithSessionTicketKeys(TStekTicketKeyManager.Shared);
+    LServer.WithDefaultSessionTicketKeys;
   end
   else
     LServer.WithResumption(False);

--- a/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
+++ b/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
@@ -36,6 +36,7 @@ uses
   TlpIClock,
   TlpClock,
   TlpSession,
+  TlpSessionTicketKeys,
   TlpITlsConfig,
   TlpITlsConfigBuilder;
 
@@ -91,6 +92,7 @@ type
     FClientEarlyData: Boolean;
     FSessionStore: ISessionStore;
     FSessionTicketKeys: ISessionTicketKeyManager;
+    FWantDefaultSessionTicketKeys: Boolean;
     FAntiReplay: IAntiReplayStrategy;
     FTicketLifetimeSeconds: UInt32;
     FTicketCount: Int32;
@@ -167,6 +169,7 @@ type
     function WithClock(const AClock: ITlsClock): TTlsConfigBuilder;
     function WithSessionStore(const AStore: ISessionStore): TTlsConfigBuilder;
     function WithSessionTicketKeys(const AKeys: ISessionTicketKeyManager): TTlsConfigBuilder;
+    function WithDefaultSessionTicketKeys: TTlsConfigBuilder;
     function WithTicketLifetime(ASeconds: UInt32): TTlsConfigBuilder;
     function WithTicketCount(ACount: Int32): TTlsConfigBuilder;
     function WithClientEarlyData(AEnabled: Boolean): TTlsConfigBuilder;
@@ -417,6 +420,7 @@ type
       const APsks: TArray<TExternalPsk>): ITlsServerConfigBuilder;
     function WithSessionStore(const AStore: ISessionStore): ITlsServerConfigBuilder;
     function WithSessionTicketKeys(const AKeys: ISessionTicketKeyManager): ITlsServerConfigBuilder;
+    function WithDefaultSessionTicketKeys: ITlsServerConfigBuilder;
     function WithClock(const AClock: ITlsClock): ITlsServerConfigBuilder;
     function WithTicketLifetime(ASeconds: UInt32): ITlsServerConfigBuilder;
     function WithTicketCount(ACount: Int32): ITlsServerConfigBuilder;
@@ -1077,6 +1081,12 @@ begin
   Result := Self;
 end;
 
+function TTlsServerConfigBuilder.WithDefaultSessionTicketKeys: ITlsServerConfigBuilder;
+begin
+  FOwner.WithDefaultSessionTicketKeys;
+  Result := Self;
+end;
+
 function TTlsServerConfigBuilder.WithClock(
   const AClock: ITlsClock): ITlsServerConfigBuilder;
 begin
@@ -1644,6 +1654,15 @@ begin
   Result := Self;
 end;
 
+function TTlsConfigBuilder.WithDefaultSessionTicketKeys: TTlsConfigBuilder;
+begin
+  GuardMutable;
+  // request a default STEK minted from THIS builder's provider + clock at BuildServer time;
+  // an explicit WithSessionTicketKeys always wins (resolved in BuildServer, order-insensitive)
+  FWantDefaultSessionTicketKeys := True;
+  Result := Self;
+end;
+
 function TTlsConfigBuilder.WithTicketLifetime(ASeconds: UInt32): TTlsConfigBuilder;
 begin
   GuardMutable;
@@ -1827,7 +1846,12 @@ begin
   LConfig.FClock := FClock;
   LConfig.FClientAuth := FClientAuth;
   LConfig.FSessionStore := FSessionStore;
-  LConfig.FSessionTicketKeys := FSessionTicketKeys;
+  // explicit keys always win; otherwise mint the requested default STEK from THIS builder's
+  // injected provider + clock (never a concrete default provider), scoped to the config's life
+  if FSessionTicketKeys <> nil then
+    LConfig.FSessionTicketKeys := FSessionTicketKeys
+  else if FWantDefaultSessionTicketKeys then
+    LConfig.FSessionTicketKeys := TStekTicketKeyManager.CreateDefault(FProvider, FClock);
   LConfig.FAntiReplay := FAntiReplay;
   LConfig.FTicketLifetimeSeconds := FTicketLifetimeSeconds;
   LConfig.FTicketCount := FTicketCount;

--- a/TlsLib/src/Engine/TlpTlsConfigMemo.pas
+++ b/TlsLib/src/Engine/TlpTlsConfigMemo.pas
@@ -84,9 +84,10 @@ begin
 end;
 
 const
-  // enough distinct configs for a multi-listener process without unbounded growth; the oldest
-  // entry is evicted when full and simply rebuilt if seen again
-  MemoCapacity = 8;
+  // enough distinct configs for a multi-listener / multi-cert process without unbounded growth;
+  // the oldest entry is evicted when full and simply rebuilt if seen again. A rebuild now also
+  // mints a fresh default STEK, so headroom here reduces needless ticket-key churn under load.
+  MemoCapacity = 16;
 
 { TTlsServerConfigMemo }
 

--- a/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
+++ b/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
@@ -274,6 +274,12 @@ type
     function WithSessionStore(const AStore: ISessionStore): ITlsServerConfigBuilder;
     /// <summary>The session-ticket encryption keys for stateless (STEK) tickets.</summary>
     function WithSessionTicketKeys(const AKeys: ISessionTicketKeyManager): ITlsServerConfigBuilder;
+    /// <summary>Requests a default STEK, minted at build time from this configuration's own
+    /// provider RNG and clock, so stateless tickets honor an injected crypto provider rather than
+    /// any concrete default. An explicit WithSessionTicketKeys always overrides this. The keys are
+    /// scoped to the built config's lifetime; share a STEK across servers/a fleet via a manager's
+    /// InstallKey (e.g. from a KMS).</summary>
+    function WithDefaultSessionTicketKeys: ITlsServerConfigBuilder;
     /// <summary>The clock the server reads for ticket issue time, 0-RTT anti-replay windows and
     /// certificate/OCSP freshness; nil (the default) uses the system clock. Injectable primarily
     /// so tests can drive a deterministic time.</summary>

--- a/TlsLib/src/Session/TlpSessionTicketKeys.pas
+++ b/TlsLib/src/Session/TlpSessionTicketKeys.pas
@@ -21,9 +21,7 @@ uses
   Generics.Collections,
   TlpArrayUtilities,
   TlpICryptoProvider,
-  TlpDefaultCryptoProvider,
   TlpIClock,
-  TlpClock,
   TlpISecretBuffer,
   TlpSecretBuffer,
   TlpSecureMemory,
@@ -59,16 +57,14 @@ type
     procedure TrimToWindow;
     procedure RotateLocked; // adds a fresh current key + trims; caller holds FLock
     procedure MaybeRotateLocked; // rotates if the auto-rotation interval has elapsed; FLock held
-  class var
-    FShared: ISessionTicketKeyManager;
-    FSharedLock: TCriticalSection;
   public
-    class constructor Create;
-    class destructor Destroy;
-    /// <summary>A process-wide, lazily-created STEK manager keyed from the shared default
-    /// provider's RNG - the default server ticket key for the adapters, stable for the process
-    /// so tickets issued on one connection resume on another; auto-rotates on a bounded interval.</summary>
-    class function Shared: ISessionTicketKeyManager; static;
+    /// <summary>A default STEK manager built from a caller-supplied provider's RNG and clock: a
+    /// fresh current key, the default decrypt window, and time-based auto-rotation on the default
+    /// interval. The natural per-config default server ticket key - it honors whatever provider
+    /// and clock the caller injected, with no tie to any concrete default provider. Tickets are
+    /// scoped to this manager's lifetime; share a STEK across servers/a fleet with InstallKey.</summary>
+    class function CreateDefault(const AProvider: ICryptoProvider;
+      const AClock: ITlsClock): ISessionTicketKeyManager; static;
     /// <summary>A manager with a fresh current key and an AWindowSize decrypt window (a default
     /// applies when 0 or less). Never auto-rotates.</summary>
     constructor Create(const ARandom: IRandom; AWindowSize: Int32 = 0); overload;
@@ -94,35 +90,17 @@ const
   StekKeyNameLength = Int32(16);
   StekKeyLength = Int32(32); // AES-256-GCM
   DefaultDecryptWindow = Int32(3);
-  // the shared STEK rotates about once per ticket lifetime (RFC 8446 4.6.1 default), which with
+  // the default STEK rotates about once per ticket lifetime (RFC 8446 4.6.1 default), which with
   // the decrypt window bounds the forgery exposure of a leaked key to a small number of intervals
-  SharedRotateIntervalSeconds = UInt32(7200);
+  DefaultStekRotateSeconds = UInt32(7200);
 
 { TStekTicketKeyManager }
 
-class constructor TStekTicketKeyManager.Create;
+class function TStekTicketKeyManager.CreateDefault(const AProvider: ICryptoProvider;
+  const AClock: ITlsClock): ISessionTicketKeyManager;
 begin
-  FSharedLock := TCriticalSection.Create;
-end;
-
-class destructor TStekTicketKeyManager.Destroy;
-begin
-  FShared := nil;
-  FSharedLock.Free;
-end;
-
-class function TStekTicketKeyManager.Shared: ISessionTicketKeyManager;
-begin
-  FSharedLock.Acquire;
-  try
-    if FShared = nil then
-      FShared := TStekTicketKeyManager.Create(
-        TDefaultCryptoProvider.Shared.GetRandom, 0,
-        TSystemClock.Create, SharedRotateIntervalSeconds) as ISessionTicketKeyManager;
-    Result := FShared;
-  finally
-    FSharedLock.Release;
-  end;
+  Result := TStekTicketKeyManager.Create(AProvider.GetRandom, 0, AClock,
+    DefaultStekRotateSeconds) as ISessionTicketKeyManager;
 end;
 
 constructor TStekTicketKeyManager.Create(const ARandom: IRandom;


### PR DESCRIPTION
Core no longer depends on the concrete default provider for STEK generation. TStekTicketKeyManager.Shared hardcoded TDefaultCryptoProvider and the system clock, and all four adapters used it, so a server's ticket-key RNG and clock ignored an injected provider (a real FIPS/HSM leak).

Replace it with a provider-agnostic CreateDefault(provider, clock) factory (interfaces only), minted at build time from the config's own injected provider and clock via a new server-builder WithDefaultSessionTicketKeys; an explicit WithSessionTicketKeys still wins, resolved order-insensitively in BuildServer. The default STEK is now scoped per config object, ("one ticketer per config object"); fleet sharing remains available via InstallKey or a shared ServerConfig.

Bump the shared config-memo capacity 8->16 to reduce needless ticket-key churn on rebuilds, and give Indy's standalone (no-listener) server path a lazily self-owned memo so it keeps a stable STEK across the connections it serves without introducing a process global.