### PR TITLE
Rename the adapter units to the Tlp prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ end;
 Swap in TlsLib4Pascal through that stack's own SSL seam -- often one line. For example, mORMot:
 
 ```pascal
-uses TlsLibMormotTls;
+uses TlpMormotTls;
 RegisterTlsLib4PascalTls;   // every mORMot connection now uses TlsLib4Pascal
 ```
 

--- a/TlsLib.Adapters/FclNet/Adapter/TlpFclNetTls.pas
+++ b/TlsLib.Adapters/FclNet/Adapter/TlpFclNetTls.pas
@@ -16,7 +16,7 @@
 /// initialization block registers TTlsLibSocketHandler as fcl-net's default SSL handler class.
 /// This is the only place our types and fcl-net's types meet. Free Pascal only.
 /// </summary>
-unit TlsLibFclNetTls;
+unit TlpFclNetTls;
 
 {$IFDEF FPC}
 {$MODE DELPHI}

--- a/TlsLib.Adapters/FclNet/Examples/src/FclNetAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/FclNet/Examples/src/FclNetAdvancedConfigExample.pas
@@ -49,7 +49,7 @@ uses
   TlpITlsConfig,
   TlpITlsConfigBuilder,
   TlpTlsPresets,
-  TlsLibFclNetTls;
+  TlpFclNetTls;
 
 const
   PORT = 28447;

--- a/TlsLib.Adapters/FclNet/Examples/src/FclNetLoopbackExample.pas
+++ b/TlsLib.Adapters/FclNet/Examples/src/FclNetLoopbackExample.pas
@@ -44,7 +44,7 @@ uses
   SyncObjs,
   ssockets,
   TlpDataEncoding,
-  TlsLibFclNetTls;
+  TlpFclNetTls;
 
 const
   PORT = 28446;

--- a/TlsLib.Adapters/FclNet/Examples/src/FclNetRealWorldExample.pas
+++ b/TlsLib.Adapters/FclNet/Examples/src/FclNetRealWorldExample.pas
@@ -58,7 +58,7 @@ uses
   SysUtils,
   ssockets,
   fphttpclient,
-  TlsLibFclNetTls;
+  TlpFclNetTls;
 
 type
   /// <summary>TFPHTTPClient re-publishes OnGetSocketHandler but leaves AfterSocketHandlerCreate
@@ -174,7 +174,7 @@ begin
   Result := 1;
   LGetBody := '';
   LPostBody := '';
-  // uses TlsLibFclNetTls has registered our TSSLSocketHandler class, so the socket TFPHTTPClient
+  // uses TlpFclNetTls has registered our TSSLSocketHandler class, so the socket TFPHTTPClient
   // creates for an https:// URL carries TlsLib4Pascal TLS. We feed trust through the two fcl-net
   // hooks: OnGetSocketHandler (supply a ready handler) for system trust, AfterSocketHandlerCreate
   // (tweak the created one) for the pinned root.

--- a/TlsLib.Adapters/FclNet/Packages/FPC/TlsLib.Adapter.FclNet.lpk
+++ b/TlsLib.Adapters/FclNet/Packages/FPC/TlsLib.Adapter.FclNet.lpk
@@ -23,8 +23,8 @@
     <Version Major="1"/>
     <Files Count="1">
       <Item1>
-        <Filename Value="..\..\Adapter\TlsLibFclNetTls.pas"/>
-        <UnitName Value="TlsLibFclNetTls"/>
+        <Filename Value="..\..\Adapter\TlpFclNetTls.pas"/>
+        <UnitName Value="TlpFclNetTls"/>
       </Item1>
     </Files>
     <RequiredPkgs Count="3">

--- a/TlsLib.Adapters/FclNet/Packages/FPC/TlsLib.Adapter.FclNet.pas
+++ b/TlsLib.Adapters/FclNet/Packages/FPC/TlsLib.Adapter.FclNet.pas
@@ -8,7 +8,7 @@ unit TlsLib.Adapter.FclNet;
 interface
 
 uses
-  TlsLibFclNetTls;
+  TlpFclNetTls;
 
 implementation
 

--- a/TlsLib.Adapters/FclNet/README.md
+++ b/TlsLib.Adapters/FclNet/README.md
@@ -15,7 +15,7 @@ also link `opensslsockets` (its `initialization` would register the OpenSSL hand
 whichever unit initialises last wins).
 
 ```pascal
-uses fphttpclient, TlsLibFclNetTls;   // registers TTlsLibSocketHandler as fcl-net's default
+uses fphttpclient, TlpFclNetTls;   // registers TTlsLibSocketHandler as fcl-net's default
 ```
 
 Because fcl-net **auto-creates** the handler and `TFPHTTPClient` gives you no handler to pass or
@@ -25,7 +25,7 @@ set (the socket owns and frees it per connection), you have two ways in.
 `TFPHTTPClient` verifies against the system-trust store with nothing else:
 
 ```pascal
-uses fphttpclient, TlsLibFclNetTls;
+uses fphttpclient, TlpFclNetTls;
 
 TlsLibFclNetTrustDefaults.UseSystemTrust := True;      // once, at startup (off by default)
 body := TFPHTTPClient.SimpleGet('https://example.com'); // just works, verified against OS trust

--- a/TlsLib.Adapters/Indy/Adapter/TlpIndyTls.pas
+++ b/TlsLib.Adapters/Indy/Adapter/TlpIndyTls.pas
@@ -16,7 +16,7 @@
 /// TIdTCPServer.IOHandler) and existing code gets our managed TLS - no OpenSSL. This unit
 /// is the only place our types and Indy's types meet.
 /// </summary>
-unit TlsLibIndyTls;
+unit TlpIndyTls;
 
 {$IFDEF FPC}
 {$MODE DELPHI}

--- a/TlsLib.Adapters/Indy/Examples/src/IndyAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/Indy/Examples/src/IndyAdvancedConfigExample.pas
@@ -56,7 +56,7 @@ uses
   TlpITlsConfig,
   TlpITlsConfigBuilder,
   TlpTlsPresets,
-  TlsLibIndyTls;
+  TlpIndyTls;
 
 const
   PORTBASE = 28452;

--- a/TlsLib.Adapters/Indy/Examples/src/IndyCustomizationExample.pas
+++ b/TlsLib.Adapters/Indy/Examples/src/IndyCustomizationExample.pas
@@ -72,7 +72,7 @@ uses
   TlpITlsConfig,
   TlpITlsConfigBuilder,
   TlpTlsPresets,
-  TlsLibIndyTls;
+  TlpIndyTls;
 
 const
   PORT_A = 28470;

--- a/TlsLib.Adapters/Indy/Examples/src/IndyLoopbackExample.pas
+++ b/TlsLib.Adapters/Indy/Examples/src/IndyLoopbackExample.pas
@@ -40,7 +40,7 @@ uses
   IdTCPClient,
   TlpTlsVersion,
   TlpDataEncoding,
-  TlsLibIndyTls;
+  TlpIndyTls;
 
 const
   PORT = 28444;

--- a/TlsLib.Adapters/Indy/Examples/src/IndyRealWorldExample.pas
+++ b/TlsLib.Adapters/Indy/Examples/src/IndyRealWorldExample.pas
@@ -61,7 +61,7 @@ uses
   IdHTTP,
   IdStack,
   TlpTlsStreamPump,
-  TlsLibIndyTls;
+  TlpIndyTls;
 
 { TIndyRealWorldExample }
 

--- a/TlsLib.Adapters/Indy/Packages/Delphi/TlsLib.Adapter.Indy.dpk
+++ b/TlsLib.Adapters/Indy/Packages/Delphi/TlsLib.Adapter.Indy.dpk
@@ -38,6 +38,6 @@ requires
   TlsLib.Trust.System;
 
 contains
-  TlsLibIndyTls in '..\..\Adapter\TlsLibIndyTls.pas';
+  TlpIndyTls in '..\..\Adapter\TlpIndyTls.pas';
 
 end.

--- a/TlsLib.Adapters/Indy/Packages/FPC/TlsLib.Adapter.Indy.lpk
+++ b/TlsLib.Adapters/Indy/Packages/FPC/TlsLib.Adapter.Indy.lpk
@@ -23,8 +23,8 @@
     <Version Major="1"/>
     <Files Count="1">
       <Item1>
-        <Filename Value="..\..\Adapter\TlsLibIndyTls.pas"/>
-        <UnitName Value="TlsLibIndyTls"/>
+        <Filename Value="..\..\Adapter\TlpIndyTls.pas"/>
+        <UnitName Value="TlpIndyTls"/>
       </Item1>
     </Files>
     <RequiredPkgs Count="4">

--- a/TlsLib.Adapters/Indy/Packages/FPC/TlsLib.Adapter.Indy.pas
+++ b/TlsLib.Adapters/Indy/Packages/FPC/TlsLib.Adapter.Indy.pas
@@ -8,7 +8,7 @@ unit TlsLib.Adapter.Indy;
 interface
 
 uses
-  TlsLibIndyTls;
+  TlpIndyTls;
 
 implementation
 

--- a/TlsLib.Adapters/Indy/README.md
+++ b/TlsLib.Adapters/Indy/README.md
@@ -10,7 +10,7 @@ Replace your OpenSSL IOHandler with ours — it is a drop-in `TIdIOHandler`.
 **Client** (`TIdTCPClient`, or any Indy client component):
 
 ```pascal
-uses TlsLibIndyTls;
+uses TlpIndyTls;
 ...
 IO := TTlsLibIOHandlerSocket.Create(Client);
 IO.SSLOptions.RootCertFile := 'ca-bundle.pem';   // trust

--- a/TlsLib.Adapters/Synapse/Adapter/TlpSynapseTls.pas
+++ b/TlsLib.Adapters/Synapse/Adapter/TlpSynapseTls.pas
@@ -17,7 +17,7 @@
 /// may be linked per project (do not also link ssl_openssl). This unit is the only place our
 /// types and Synapse's types meet.
 /// </summary>
-unit TlsLibSynapseTls;
+unit TlpSynapseTls;
 
 {$IFDEF FPC}
 {$MODE DELPHI}
@@ -284,7 +284,7 @@ end;
 
 function TSSLTlsLib.LibName: string;
 begin
-  Result := 'TlsLibSynapseTls';
+  Result := 'TlpSynapseTls';
 end;
 
 function TSSLTlsLib.LoadFileBytes(const APath: string): TBytes;

--- a/TlsLib.Adapters/Synapse/Examples/src/SynapseAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/Synapse/Examples/src/SynapseAdvancedConfigExample.pas
@@ -50,7 +50,7 @@ uses
   TlpITlsConfig,
   TlpITlsConfigBuilder,
   TlpTlsPresets,
-  TlsLibSynapseTls;
+  TlpSynapseTls;
 
 const
   PORT = '28450';

--- a/TlsLib.Adapters/Synapse/Examples/src/SynapseLoopbackExample.pas
+++ b/TlsLib.Adapters/Synapse/Examples/src/SynapseLoopbackExample.pas
@@ -39,7 +39,7 @@ uses
   SyncObjs,
   blcksock,
   TlpDataEncoding,
-  TlsLibSynapseTls;
+  TlpSynapseTls;
 
 const
   PORT = '28445';

--- a/TlsLib.Adapters/Synapse/Examples/src/SynapseRealWorldExample.pas
+++ b/TlsLib.Adapters/Synapse/Examples/src/SynapseRealWorldExample.pas
@@ -65,7 +65,7 @@ uses
   SysUtils,
   blcksock,
   httpsend,
-  TlsLibSynapseTls;
+  TlpSynapseTls;
 
 { TSynapseRealWorldExample }
 
@@ -121,7 +121,7 @@ begin
   Result := 1;
   LGetBody := '';
   LPostBody := '';
-  // uses TlsLibSynapseTls has already registered our TCustomSSL plugin process-wide, so the
+  // uses TlpSynapseTls has already registered our TCustomSSL plugin process-wide, so the
   // socket THTTPSend creates carries TlsLib4Pascal TLS. A pinned bundle uses Synapse's own
   // CertCAFile; the OS system store is an explicit opt-in via our per-connection UseSystemTrust
   // (system trust is never implicit) - reached by casting Sock.SSL to the plugin type.

--- a/TlsLib.Adapters/Synapse/Packages/Delphi/TlsLib.Adapter.Synapse.dpk
+++ b/TlsLib.Adapters/Synapse/Packages/Delphi/TlsLib.Adapter.Synapse.dpk
@@ -35,6 +35,6 @@ requires
   TlsLib.Trust.System;
 
 contains
-  TlsLibSynapseTls in '..\..\Adapter\TlsLibSynapseTls.pas';
+  TlpSynapseTls in '..\..\Adapter\TlpSynapseTls.pas';
 
 end.

--- a/TlsLib.Adapters/Synapse/Packages/FPC/TlsLib.Adapter.Synapse.lpk
+++ b/TlsLib.Adapters/Synapse/Packages/FPC/TlsLib.Adapter.Synapse.lpk
@@ -23,8 +23,8 @@
     <Version Major="1"/>
     <Files Count="1">
       <Item1>
-        <Filename Value="..\..\Adapter\TlsLibSynapseTls.pas"/>
-        <UnitName Value="TlsLibSynapseTls"/>
+        <Filename Value="..\..\Adapter\TlpSynapseTls.pas"/>
+        <UnitName Value="TlpSynapseTls"/>
       </Item1>
     </Files>
     <RequiredPkgs Count="4">

--- a/TlsLib.Adapters/Synapse/Packages/FPC/TlsLib.Adapter.Synapse.pas
+++ b/TlsLib.Adapters/Synapse/Packages/FPC/TlsLib.Adapter.Synapse.pas
@@ -8,7 +8,7 @@ unit TlsLib.Adapter.Synapse;
 interface
 
 uses
-  TlsLibSynapseTls;
+  TlpSynapseTls;
 
 implementation
 

--- a/TlsLib.Adapters/Synapse/README.md
+++ b/TlsLib.Adapters/Synapse/README.md
@@ -10,7 +10,7 @@ block registers it as the process-wide `SSLImplementation`. **Exactly one SSL pl
 linked per project** — do *not* also link `ssl_openssl`.
 
 ```pascal
-uses blcksock, TlsLibSynapseTls;   // registers SSLImplementation := TSSLTlsLib
+uses blcksock, TlpSynapseTls;   // registers SSLImplementation := TSSLTlsLib
 
 // client
 sock := TTCPBlockSocket.CreateWithSSL(SSLImplementation);

--- a/TlsLib.Adapters/mORMot/Adapter/TlpMormotTls.pas
+++ b/TlsLib.Adapters/mORMot/Adapter/TlpMormotTls.pas
@@ -16,7 +16,7 @@
 /// recompile of mORMot. This unit is the only place our types and mORMot's types meet;
 /// the core library references nothing here.
 /// </summary>
-unit TlsLibMormotTls;
+unit TlpMormotTls;
 
 {$IFDEF FPC}
 {$MODE DELPHI}

--- a/TlsLib.Adapters/mORMot/Examples/src/MormotAdvancedConfigExample.pas
+++ b/TlsLib.Adapters/mORMot/Examples/src/MormotAdvancedConfigExample.pas
@@ -53,7 +53,7 @@ uses
   TlpITlsConfig,
   TlpITlsConfigBuilder,
   TlpTlsPresets,
-  TlsLibMormotTls;
+  TlpMormotTls;
 
 const
   PORT = '28449';

--- a/TlsLib.Adapters/mORMot/Examples/src/MormotLoopbackExample.pas
+++ b/TlsLib.Adapters/mORMot/Examples/src/MormotLoopbackExample.pas
@@ -41,7 +41,7 @@ uses
   mormot.core.unicode,
   mormot.net.sock,
   TlpDataEncoding,
-  TlsLibMormotTls;
+  TlpMormotTls;
 
 const
   PORT = '28443';

--- a/TlsLib.Adapters/mORMot/Examples/src/MormotRealWorldExample.pas
+++ b/TlsLib.Adapters/mORMot/Examples/src/MormotRealWorldExample.pas
@@ -66,7 +66,7 @@ uses
   mormot.core.os.security,
   mormot.net.sock,
   mormot.net.client,
-  TlsLibMormotTls;
+  TlpMormotTls;
 
 { TMormotRealWorldExample }
 

--- a/TlsLib.Adapters/mORMot/Packages/Delphi/TlsLib.Adapter.mORMot.dpk
+++ b/TlsLib.Adapters/mORMot/Packages/Delphi/TlsLib.Adapter.mORMot.dpk
@@ -35,6 +35,6 @@ requires
   TlsLib.Trust.System;
 
 contains
-  TlsLibMormotTls in '..\..\Adapter\TlsLibMormotTls.pas';
+  TlpMormotTls in '..\..\Adapter\TlpMormotTls.pas';
 
 end.

--- a/TlsLib.Adapters/mORMot/Packages/FPC/TlsLib.Adapter.mORMot.lpk
+++ b/TlsLib.Adapters/mORMot/Packages/FPC/TlsLib.Adapter.mORMot.lpk
@@ -23,8 +23,8 @@
     <Version Major="1"/>
     <Files Count="1">
       <Item1>
-        <Filename Value="..\..\Adapter\TlsLibMormotTls.pas"/>
-        <UnitName Value="TlsLibMormotTls"/>
+        <Filename Value="..\..\Adapter\TlpMormotTls.pas"/>
+        <UnitName Value="TlpMormotTls"/>
       </Item1>
     </Files>
     <RequiredPkgs Count="4">

--- a/TlsLib.Adapters/mORMot/Packages/FPC/TlsLib.Adapter.mORMot.pas
+++ b/TlsLib.Adapters/mORMot/Packages/FPC/TlsLib.Adapter.mORMot.pas
@@ -8,7 +8,7 @@ unit TlsLib.Adapter.mORMot;
 interface
 
 uses
-  TlsLibMormotTls;
+  TlpMormotTls;
 
 implementation
 

--- a/TlsLib.Adapters/mORMot/README.md
+++ b/TlsLib.Adapters/mORMot/README.md
@@ -5,11 +5,11 @@ mORMot's own `INetTls` "swap-your-SSL" seam — no fork, no recompile of mORMot.
 
 ## How to swap it in
 
-Add `TlsLibMormotTls` to your uses clause and point mORMot's global factory at ours **once**,
+Add `TlpMormotTls` to your uses clause and point mORMot's global factory at ours **once**,
 at startup (before any `TCrtSocket` is created):
 
 ```pascal
-uses mormot.net.sock, TlsLibMormotTls;
+uses mormot.net.sock, TlpMormotTls;
 begin
   RegisterTlsLib4PascalTls;          // NewNetTls := NewTlsLib4PascalTls
   // ... every TCrtSocket opened with TLS now uses TlsLib4Pascal

--- a/TlsLib.Trust.System/Examples/Delphi/README.md
+++ b/TlsLib.Trust.System/Examples/Delphi/README.md
@@ -36,7 +36,7 @@ headless build scripts.
 2. Target platform **Android64** (or **Android**).
 3. Add the Indy runtime dependency the same way the adapter examples under
    `TlsLib.Adapters/Indy/Examples/Delphi` do (Indy ships with Delphi; the IOHandler unit
-   `TlsLibIndyTls` should be in the search path).
+   `TlpIndyTls` should be in the search path).
 4. In the Android manifest, grant the `INTERNET` permission (Project -> Options -> Uses
    Permissions -> **Internet**). No other permission is required - trust roots are read
    through the framework, never from the filesystem.

--- a/TlsLib.Trust.System/Examples/Delphi/SystemTrustDemoFormUnit.pas
+++ b/TlsLib.Trust.System/Examples/Delphi/SystemTrustDemoFormUnit.pas
@@ -63,7 +63,7 @@ uses
   IdHTTP,
   IdStack,
   TlpTlsStreamPump,
-  TlsLibIndyTls;
+  TlpIndyTls;
 
 const
   TimeoutMs = 15000;

--- a/TlsLib.Trust.System/Examples/Lazarus/src/SystemTrustExample.pas
+++ b/TlsLib.Trust.System/Examples/Lazarus/src/SystemTrustExample.pas
@@ -55,7 +55,7 @@ uses
   SysUtils,
   ssockets,
   fphttpclient,
-  TlsLibFclNetTls;
+  TlpFclNetTls;
 
 type
   /// <summary>Supplies a per-connection FclNet handler configured for OS system trust. This is the

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -157,14 +157,14 @@ package (singular `Adapter`), then:
 **mORMot** — swap the global TLS factory (process-wide), then use mORMot exactly as before:
 
 ```pascal
-uses TlsLibMormotTls;
+uses TlpMormotTls;
 RegisterTlsLib4PascalTls;        // every mORMot TCrtSocket now uses TlsLib4Pascal
 ```
 
 **Indy** — drop in the IO handler:
 
 ```pascal
-uses TlsLibIndyTls;
+uses TlpIndyTls;
 LClient.IOHandler := TTlsLibIOHandlerSocket.Create(LClient);   // client
 LServer.IOHandler := TTlsLibServerIOHandler.Create(LServer);   // server
 ```
@@ -172,19 +172,19 @@ LServer.IOHandler := TTlsLibServerIOHandler.Create(LServer);   // server
 **Synapse** — the plugin registers itself on `uses`; create sockets normally:
 
 ```pascal
-uses TlsLibSynapseTls;           // registers SSLImplementation := TSSLTlsLib
+uses TlpSynapseTls;           // registers SSLImplementation := TSSLTlsLib
 LSock := TTCPBlockSocket.CreateWithSSL(SSLImplementation);
 ```
 
 (Link exactly one SSL plugin — don't also link `ssl_openssl`.)
 
 **fcl-net** — a little different from the others: you configure through fcl-net's own
-`CertificateData` (file names), and `uses TlsLibFclNetTls` registers `TTlsLibSocketHandler` as
+`CertificateData` (file names), and `uses TlpFclNetTls` registers `TTlsLibSocketHandler` as
 fcl-net's default SSL handler class. Client side, construct a handler, point it at your trust root,
 and hand it to the socket:
 
 ```pascal
-uses ssockets, TlsLibFclNetTls;
+uses ssockets, TlpFclNetTls;
 
 LHandler := TTlsLibSocketHandler.Create;
 LHandler.CertificateData.CertCA.FileName := 'root.pem';         // trust anchor (VerifyPeerCert defaults True)

--- a/docs/system-trust.md
+++ b/docs/system-trust.md
@@ -182,7 +182,7 @@ its own plugin — the same way Synapse's own plugins expose extras (`TSSLSChann
 `TSSLCryptLib.PrivateKeyLabel`): cast `Sock.SSL` to the plugin type.
 
 ```pascal
-uses TlsLibSynapseTls;    // registers the plugin
+uses TlpSynapseTls;    // registers the plugin
 
 (LHttp.Sock.SSL as TSSLTlsLib).UseSystemTrust := True;   // OS roots
 LHttp.Sock.SSL.VerifyCert := True;                        // real verification


### PR DESCRIPTION
The four TLS adapter units were the only shipping library units without the project's Tlp unit-namespace prefix. Rename for consistency:

  TlsLibIndyTls    -> TlpIndyTls
  TlsLibSynapseTls -> TlpSynapseTls
  TlsLibMormotTls  -> TlpMormotTls
  TlsLibFclNetTls  -> TlpFclNetTls

Update every reference across both build systems and the docs.