### PR TITLE
Resume out of the box when a server enables resumption

### DIFF
--- a/TlsLib.Interop/src/InteropEngine.pas
+++ b/TlsLib.Interop/src/InteropEngine.pas
@@ -351,7 +351,12 @@ begin
         LServer.WithCertificateVerifyCallback(GRejecter.Reject);
     end;
     // resumption: the shared STEK issues and re-opens tickets across the resume-count loop;
-    // 0-RTT authorizes early data on the 1.3 facet
+    // 0-RTT authorizes early data on the 1.3 facet. With neither ticket keys nor a session store
+    // the harness is driving a non-resumption scenario: opt out of resumption explicitly so the
+    // engine issues no NewSessionTicket. The harness is exact about ticket presence and does not
+    // lean on the engine's resume-by-default (which mints a STEK when resumption is left on).
+    if (AOptions.SessionTicketKeys = nil) and (AOptions.SessionStore = nil) then
+      LServer.WithResumption(False);
     if AOptions.SessionTicketKeys <> nil then
       LServer.WithSessionTicketKeys(AOptions.SessionTicketKeys);
     if AOptions.SessionStore <> nil then

--- a/TlsLib.Tests/src/ConfigResumptionTests.pas
+++ b/TlsLib.Tests/src/ConfigResumptionTests.pas
@@ -75,6 +75,8 @@ type
   published
     procedure TestTls13StoreResumptionViaConfig;
     procedure TestTls12ResumptionViaConfig;
+    procedure TestDefaultServerIssuesTicketsOutOfBox;
+    procedure TestResumptionOffServerIssuesNoTicket;
     procedure TestStrictPresetLeavesResumptionOff;
     procedure TestStrictResumptionReEnabledWithNoGuard;
   end;
@@ -332,6 +334,52 @@ begin
     '1.2 resumption via the config is abbreviated (no Certificate)');
   CheckFalse(LServer.IsTerminal, 'the 1.2 resume did not fail');
   CheckAppDataFlows(LClient, LServer);
+end;
+
+procedure TTestConfigResumption.TestDefaultServerIssuesTicketsOutOfBox;
+var
+  LCache: ISessionCache;
+  LServerConfig: ITlsServerConfig;
+  LClient, LServer: ITlsEngine;
+begin
+  // a server built through the public surface with only a credential - no WithSessionStore and
+  // no WithDefaultSessionTicketKeys - resumes out of the box: the resume-by-default posture mints
+  // a STEK, so the server issues a ticket the client caches and can later present. One frozen
+  // config is reused across both handshakes so the same STEK opens the ticket
+  LCache := TInMemorySessionCache.Create;
+  LServerConfig := TTlsPresets.Hardened(Provider).Server
+    .WithCredential(ServerCredential).Build;
+
+  LClient := NewClient13(LCache, True);
+  LServer := TTlsEngineFactory.CreateServerEngine(LServerConfig);
+  PumpToCompletion(LClient, LServer);
+  CheckFalse(LClient.IsHandshaking, 'the initial handshake completed');
+  CheckTrue(LCache.Count >= 1, 'the default server issued a ticket the client cached');
+
+  LClient := NewClient13(LCache, True);
+  LServer := TTlsEngineFactory.CreateServerEngine(LServerConfig);
+  PumpToCompletion(LClient, LServer);
+  CheckFalse(LServer.IsHandshaking, 'the resuming server completed');
+  CheckFalse(LServer.IsTerminal, 'the resuming server did not fail');
+  // prove it actually resumed via the out-of-box ticket, not a silent full-handshake fallback
+  CheckTrue(LClient.IsResumed, 'the second handshake resumed off the auto-issued ticket');
+  CheckAppDataFlows(LClient, LServer);
+end;
+
+procedure TTestConfigResumption.TestResumptionOffServerIssuesNoTicket;
+var
+  LCache: ISessionCache;
+  LClient, LServer: ITlsEngine;
+begin
+  // WithResumption(False) opts a server out even under the resume-by-default posture: no STEK is
+  // engaged, so no ticket is issued and the client caches nothing
+  LCache := TInMemorySessionCache.Create;
+  LClient := NewClient13(LCache, True);
+  LServer := TTlsEngineFactory.CreateServerEngine(TTlsPresets.Hardened(Provider).Server
+    .WithCredential(ServerCredential).WithResumption(False).Build);
+  PumpToCompletion(LClient, LServer);
+  CheckFalse(LClient.IsHandshaking, 'the handshake completed');
+  CheckEquals(0, LCache.Count, 'a resumption-off server issued no ticket');
 end;
 
 procedure TTestConfigResumption.TestStrictPresetLeavesResumptionOff;

--- a/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
+++ b/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
@@ -1347,8 +1347,9 @@ begin
   FCertificateDecompressors := TZlibCertificateCompression.DefaultDecompressors;
   // the cross-connection compression cache is opt-in (like the session store): nil until a
   // caller supplies one via WithCertificateCompressionCache, so a stable body re-deflates
-  // resumption is engaged by default (a preset may turn it off); a client still needs a
-  // cache and a server a store/STEK for anything to actually resume
+  // resumption is engaged by default (a preset may turn it off): a server then resumes out of the
+  // box, minting a default STEK at build time unless explicit ticket keys or a session store were
+  // supplied; a client still needs a session cache to retain the tickets it is offered
   FResumption := True;
   // a client sends GREASE (RFC 8701) and a server acknowledges a received server_name
   // (RFC 6066) by default; both are optional and a caller may turn them off
@@ -2037,11 +2038,14 @@ begin
   LConfig.FClientAuth := FClientAuth;
   LConfig.FSessionStore := FSessionStore;
   LConfig.FCredentialResolver := ComposeCredentialResolver;
-  // explicit keys always win; otherwise mint the requested default STEK from THIS builder's
-  // injected provider + clock (never a concrete default provider), scoped to the config's life
+  // explicit keys always win; otherwise mint the default STEK from THIS builder's injected
+  // provider + clock (never a concrete default provider), scoped to the config's life. With
+  // resumption on and neither ticket keys nor a session store configured, the STEK is minted so
+  // a server resumes out of the box rather than silently issuing nothing; a store-only (stateful)
+  // server and WithResumption(False) both opt out.
   if FSessionTicketKeys <> nil then
     LConfig.FSessionTicketKeys := FSessionTicketKeys
-  else if FWantDefaultSessionTicketKeys then
+  else if FWantDefaultSessionTicketKeys or (FResumption and (FSessionStore = nil)) then
     LConfig.FSessionTicketKeys := TStekTicketKeyManager.CreateDefault(FProvider, FClock);
   LConfig.FAntiReplay := FAntiReplay;
   LConfig.FTicketLifetimeSeconds := FTicketLifetimeSeconds;

--- a/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
@@ -238,6 +238,11 @@ type
     /// <summary>Whether the ClientHello offered status_request, so the server staples its
     /// configured OCSP response in the leaf CertificateEntry (RFC 8446 4.4.2.1).</summary>
     FStatusRequestOffered: Boolean;
+    /// <summary>Whether the ClientHello advertised psk_dhe_ke in psk_key_exchange_modes. A ticket
+    /// this server issues is only resumable via psk_dhe_ke, so a client that offered neither that
+    /// mode nor the extension cannot use one: the server sends no NewSessionTicket (RFC 8446
+    /// 4.2.9).</summary>
+    FClientOfferedPskDheKe: Boolean;
     /// <summary>Whether a HelloRetryRequest has been sent. After an HRR a conformant client
     /// never sends 0-RTT, so the server neither accepts nor skips early data on the second
     /// flight: any early-data records there fail to deprotect (RFC 8446 4.2.10).</summary>
@@ -520,6 +525,8 @@ begin
       TTlsAlertDescription.IllegalParameter, @SPreSharedKeyNotLast);
   FEarlyDataOfferedByClient := AContext.EarlyDataOffered;
   FStatusRequestOffered := AContext.StatusRequestOffered;
+  FClientOfferedPskDheKe := TArrayUtilities.Contains<Byte>(AContext.PskModes,
+    PskDheKeMode);
 
   // version is confirmed via supported_versions
   FParams.Policy.SelectVersion(AContext.SupportedVersions);
@@ -1528,6 +1535,11 @@ var
   LLifetime: UInt32;
 begin
   if (FTicketStrategy = nil) or (FParams.IssueTicketCount <= 0) then
+    Exit;
+  // a ticket is resumable only via psk_dhe_ke; a client that advertised neither that mode nor a
+  // psk_key_exchange_modes extension at all cannot use one, so issuing it would just be wasted
+  // bytes the client discards (RFC 8446 4.2.9)
+  if not FClientOfferedPskDheKe then
     Exit;
   // a server MUST NOT advertise a lifetime above the RFC 8446 4.6.1 ceiling, and MUST NOT honour
   // a resumption beyond it either, so clamp the value the session stores and the ticket carries


### PR DESCRIPTION
A server built with resumption enabled (the default) but without explicit session-ticket keys or a session store issued no tickets at all: WithResumption only signalled willingness to resume, while the actual ticket key was left unset, so the server silently minted nothing and clients never resumed. Toggling WithResumption had no visible effect.

BuildServer now mints the default session-ticket key when resumption is enabled and neither explicit ticket keys nor a session store were configured, so a plain credential-only server resumes without extra ceremony. Explicit WithSessionTicketKeys, a store-only (stateful) server, and WithResumption(False) all opt out unchanged. The facade and presets inherit this through BuildServer; the framework adapters, which already request the default keys, are unaffected.

Because a server now issues tickets by default, also gate ticket emission on the client having advertised psk_dhe_ke in psk_key_exchange_modes: a client that offered neither that mode nor the extension cannot use a ticket, so the server sends none rather than wasting a NewSessionTicket the client discards (RFC 8446 4.2.9). The engine previously gated only resumption acceptance on psk_dhe_ke, not issuance.

Keep the interop harness exact about ticket presence: when a shim server is configured with neither ticket keys nor a session store it drives a non-resumption scenario, so it now opts out of resumption explicitly instead of leaning on the resume-by-default behaviour.

Add regression coverage: a default credential-only server issues a ticket the client caches and resumes off (asserted via IsResumed, so a full-handshake fallback cannot pass), and a WithResumption(False) server issues none.