### PR TITLE
Make the named-group registry authoritative and add a classical-only registry

### DIFF
--- a/TlsLib.Tests/src/ConfigBuilderTests.pas
+++ b/TlsLib.Tests/src/ConfigBuilderTests.pas
@@ -35,6 +35,7 @@ uses
   TlpNegotiationTypes,
   TlpCipherSuiteRegistry,
   TlpSignatureSchemeRegistry,
+  TlpINamedGroup,
   TlpNamedGroups,
   TlpISecretBuffer,
   TlpSecretBuffer,
@@ -100,6 +101,16 @@ type
     procedure TestTicketLifetimeAboveCapIsRejected;
     procedure TestTicketLifetimeAtCapIsAccepted;
     procedure TestClientRejectsServerSniCredential;
+    // a restricted (classical-only) registry composes with a preset whose preferred order still
+    // names the pruned hybrid: the engine drops it from the offer instead of failing to build,
+    // and the handshake negotiates a classical group
+    procedure TestClassicalRegistryOverPresetNegotiatesClassical;
+    // the asymmetric case: a classical-registry client against a default, post-quantum-preferring
+    // server - the client advertises no hybrid, so the server cannot retry it onto a pruned group
+    procedure TestClassicalRegistryClientAgainstDefaultServer;
+    // a 1.3 server whose registry holds none of its preferred groups is refused at creation, not
+    // left to fault on the first ClientHello
+    procedure TestServerWithEmptyGroupIntersectionFailsFast;
   end;
 
 implementation
@@ -750,6 +761,76 @@ begin
       LRaised := True;
   end;
   CheckTrue(LRaised, 'a client configuration rejects server-only SNI credential settings');
+end;
+
+procedure TTestConfigBuilder.TestClassicalRegistryOverPresetNegotiatesClassical;
+var
+  LClient, LServer: ITlsEngine;
+begin
+  // Hardened prefers X25519MLKEM768 first; installing the classical-only registry prunes it.
+  // Before the registry became authoritative this raised at engine creation (preferred group not
+  // in the registry); now the hybrid is dropped from the offer and X25519 is negotiated instead.
+  LClient := TTlsEngineFactory.CreateClientEngine(TTlsPresets.Hardened(Provider).Client
+    .WithNamedGroups(TNamedGroups.CreateClassicalRegistry(Provider))
+    .WithTrustStore(ClientTrust).Build, 'localhost');
+  LServer := TTlsEngineFactory.CreateServerEngine(TTlsPresets.Hardened(Provider).Server
+    .WithNamedGroups(TNamedGroups.CreateClassicalRegistry(Provider))
+    .WithCredential(ServerCredential).Build);
+  RunHandshake(LClient, LServer);
+
+  CheckFalse(LClient.IsHandshaking, 'the handshake completed');
+  CheckFalse(LClient.IsTerminal, 'the client did not fail');
+  CheckFalse(LServer.IsTerminal, 'the server did not fail');
+  CheckEquals(Integer(TNamedGroupCatalog.X25519), Integer(LClient.NegotiatedGroup),
+    'negotiated classical X25519, not the pruned post-quantum hybrid');
+  CheckEquals(Integer(LClient.NegotiatedGroup), Integer(LServer.NegotiatedGroup),
+    'client and server agree on the negotiated group');
+end;
+
+procedure TTestConfigBuilder.TestClassicalRegistryClientAgainstDefaultServer;
+var
+  LClient, LServer: ITlsEngine;
+begin
+  // the client's registry is classical-only, so its supported_groups carries no hybrid; the server
+  // keeps the default registry and prefers the hybrid, but cannot select or retry onto a group the
+  // client never offered. Both settle on X25519 with no fatal - the case the OfferedGroups filter,
+  // not the PreferredGroup fix, protects.
+  LClient := TTlsEngineFactory.CreateClientEngine(TTlsPresets.Hardened(Provider).Client
+    .WithNamedGroups(TNamedGroups.CreateClassicalRegistry(Provider))
+    .WithTrustStore(ClientTrust).Build, 'localhost');
+  LServer := TTlsEngineFactory.CreateServerEngine(TTlsPresets.Hardened(Provider).Server
+    .WithCredential(ServerCredential).Build);
+  RunHandshake(LClient, LServer);
+
+  CheckFalse(LClient.IsHandshaking, 'the handshake completed');
+  CheckFalse(LClient.IsTerminal, 'the client did not fail (no retry into a pruned group)');
+  CheckFalse(LServer.IsTerminal, 'the server did not fail');
+  CheckEquals(Integer(TNamedGroupCatalog.X25519), Integer(LClient.NegotiatedGroup),
+    'negotiated classical X25519 though the server prefers the hybrid');
+end;
+
+procedure TTestConfigBuilder.TestServerWithEmptyGroupIntersectionFailsFast;
+var
+  LReg: INamedGroupRegistry;
+  LRaised: Boolean;
+begin
+  // Hardened prefers the hybrid, X25519 and secp256r1; prune the classical registry down to
+  // secp384r1 (which Hardened does not prefer), leaving the registry-vs-preference intersection
+  // empty. The server must refuse at creation rather than build with an empty offer and fault on
+  // the first ClientHello.
+  LReg := TNamedGroups.CreateClassicalRegistry(Provider);
+  LReg.Prune(TNamedGroupCatalog.X25519);
+  LReg.Prune(TNamedGroupCatalog.Secp256r1);
+  LReg.Prune(TNamedGroupCatalog.Secp521r1);
+  LRaised := False;
+  try
+    TTlsEngineFactory.CreateServerEngine(TTlsPresets.Hardened(Provider).Server
+      .WithNamedGroups(LReg).WithCredential(ServerCredential).Build);
+  except
+    on E: EArgumentTlsLibException do
+      LRaised := True;
+  end;
+  CheckTrue(LRaised, 'a server with an empty registry-vs-preference intersection is refused');
 end;
 
 initialization

--- a/TlsLib.Tests/src/NamedGroupTests.pas
+++ b/TlsLib.Tests/src/NamedGroupTests.pas
@@ -63,6 +63,7 @@ type
     procedure TestNistDecapsulateRejectsOffCurvePoint;
     procedure TestHybridDecapsulateRejectsShortCiphertext;
     procedure TestRegistry;
+    procedure TestClassicalRegistryOmitsPostQuantum;
     procedure TestGroupKindClassifiesEcdheKemHybrid;
     procedure TestOnlyEcdheGroupsAreTls12Eligible;
   end;
@@ -286,6 +287,21 @@ begin
   LReg.Add(TNamedGroups.CreateNistEcdh(Provider, 'secp521r1'));
   CheckTrue(LReg.Contains(TNamedGroupCatalog.Secp521r1), 're-added');
   CheckFalse(LReg.TryGet($FFFF, LGroup), 'unknown code is not found');
+end;
+
+procedure TTestNamedGroups.TestClassicalRegistryOmitsPostQuantum;
+var
+  LReg: INamedGroupRegistry;
+begin
+  // the classical registry is the default minus the post-quantum hybrids, so a ClientHello
+  // driven off it carries no ~1KB ML-KEM key share (the constrained-path escape hatch)
+  LReg := TNamedGroups.CreateClassicalRegistry(Provider);
+  CheckTrue(LReg.Contains(TNamedGroupCatalog.X25519), 'has X25519');
+  CheckTrue(LReg.Contains(TNamedGroupCatalog.Secp256r1), 'has secp256r1');
+  CheckTrue(LReg.Contains(TNamedGroupCatalog.Secp384r1), 'has secp384r1');
+  CheckTrue(LReg.Contains(TNamedGroupCatalog.Secp521r1), 'has secp521r1');
+  CheckFalse(LReg.Contains(TNamedGroupCatalog.X25519MlKem768), 'no hybrid');
+  CheckFalse(LReg.Contains(TNamedGroupCatalog.MlKem768), 'no ML-KEM');
 end;
 
 procedure TTestNamedGroups.TestGroupKindClassifiesEcdheKemHybrid;

--- a/TlsLib/src/Crypto/TlpNamedGroups.pas
+++ b/TlsLib/src/Crypto/TlpNamedGroups.pas
@@ -49,6 +49,12 @@ type
     class function CreateX25519MlKem768(const AProvider: ICryptoProvider): INamedGroup; static;
     /// <summary>A registry pre-loaded with the default groups.</summary>
     class function CreateDefaultRegistry(const AProvider: ICryptoProvider): INamedGroupRegistry; static;
+    /// <summary>The default registry with the post-quantum groups removed - classical ECDHE only.
+    /// A post-quantum key share enlarges the ClientHello enough to fail on some constrained paths
+    /// (reduced-MTU tunnels/VPNs, or middleboxes intolerant of a fragmented ClientHello); this
+    /// trades post-quantum protection for a smaller ClientHello there. Install it with
+    /// WithNamedGroups.</summary>
+    class function CreateClassicalRegistry(const AProvider: ICryptoProvider): INamedGroupRegistry; static;
   end;
 
 implementation
@@ -405,6 +411,20 @@ begin
   Result.Add(CreateNistEcdh(AProvider, 'secp256r1'));
   Result.Add(CreateNistEcdh(AProvider, 'secp384r1'));
   Result.Add(CreateNistEcdh(AProvider, 'secp521r1'));
+end;
+
+class function TNamedGroups.CreateClassicalRegistry(const AProvider: ICryptoProvider): INamedGroupRegistry;
+var
+  LDefault: INamedGroupRegistry;
+  LGroup: INamedGroup;
+begin
+  // derived from the default registry with the post-quantum (KEM/hybrid) groups filtered out, so
+  // a classical group added to CreateDefaultRegistry is carried here without a second hand-kept list
+  Result := TNamedGroupRegistry.Create;
+  LDefault := CreateDefaultRegistry(AProvider);
+  for LGroup in LDefault.Items do
+    if LGroup.Kind = TNamedGroupKind.Ecdhe then
+      Result.Add(LGroup);
 end;
 
 end.

--- a/TlsLib/src/Engine/TlpTlsEngineFactory.pas
+++ b/TlsLib/src/Engine/TlpTlsEngineFactory.pas
@@ -67,6 +67,13 @@ type
     /// KEM/hybrid (post-quantum) groups in supported_groups.</summary>
     class function EcdheGroupCodes(const AConfig: ITlsCommonConfig;
       const ACodes: TArray<UInt16>): TArray<UInt16>; static;
+    /// <summary>The subset of ACodes that name a group present in the config's registry, in
+    /// order - the registry is the source of capability truth, so a preferred codepoint that
+    /// was pruned (or never registered) is silently dropped rather than advertised and then
+    /// failing to resolve when selected. This is what a restricted registry (e.g. classical-only)
+    /// composes through, whatever a preset's preferred order still names.</summary>
+    class function RegisteredGroupCodes(const AConfig: ITlsCommonConfig;
+      const ACodes: TArray<UInt16>): TArray<UInt16>; static;
     class function Offers(const AConfig: ITlsCommonConfig;
       AVersion: UInt16): Boolean; static;
   public
@@ -117,14 +124,21 @@ end;
 class function TTlsEngineFactory.PreferredGroup(const AConfig: ITlsCommonConfig;
   out ACode: UInt16): INamedGroup;
 var
-  LGroups: TArray<UInt16>;
+  LCode: UInt16;
 begin
-  LGroups := AConfig.PreferredGroups;
-  if System.Length(LGroups) = 0 then
+  if System.Length(AConfig.PreferredGroups) = 0 then
     raise EArgumentTlsLibException.CreateRes(@SNoPreferredGroup);
-  ACode := LGroups[0];
-  if not AConfig.NamedGroups.TryGet(ACode, Result) then
-    raise EArgumentTlsLibException.CreateResFmt(@SUnconfiguredGroup, [ACode]);
+  // the registry is authoritative: pick the first preferred group it actually holds, so a
+  // preferred order that still names a pruned group (a preset lists the hybrid first) resolves
+  // to the top registered group instead of failing
+  for LCode in AConfig.PreferredGroups do
+    if AConfig.NamedGroups.TryGet(LCode, Result) then
+    begin
+      ACode := LCode;
+      Exit;
+    end;
+  raise EArgumentTlsLibException.CreateResFmt(@SUnconfiguredGroup,
+    [AConfig.PreferredGroups[0]]);
 end;
 
 class function TTlsEngineFactory.PreferredEcdheGroup(
@@ -151,6 +165,23 @@ begin
   for LCode in ACodes do
     if AConfig.NamedGroups.TryGet(LCode, LGroup) and
       (LGroup.Kind = TNamedGroupKind.Ecdhe) then
+    begin
+      LN := System.Length(Result);
+      SetLength(Result, LN + 1);
+      Result[LN] := LCode;
+    end;
+end;
+
+class function TTlsEngineFactory.RegisteredGroupCodes(const AConfig: ITlsCommonConfig;
+  const ACodes: TArray<UInt16>): TArray<UInt16>;
+var
+  LCode: UInt16;
+  LGroup: INamedGroup;
+  LN: Int32;
+begin
+  Result := nil;
+  for LCode in ACodes do
+    if AConfig.NamedGroups.TryGet(LCode, LGroup) then
     begin
       LN := System.Length(Result);
       SetLength(Result, LN + 1);
@@ -200,9 +231,10 @@ begin
   L13 := Default(TClientHandshakeParams);
   L13.Provider := AConfig.Provider;
   L13.Group := PreferredGroup(AConfig, L13.GroupCode);
-  // advertise every preferred group and carry the registry, so the server may retry
-  // the client onto any offered group it prefers (HelloRetryRequest)
-  L13.OfferedGroups := AConfig.PreferredGroups;
+  // advertise every preferred group the registry holds (a pruned/absent group is dropped, not
+  // advertised-then-unresolvable) and carry the registry, so the server may retry the client
+  // onto any offered group it prefers (HelloRetryRequest)
+  L13.OfferedGroups := RegisteredGroupCodes(AConfig, AConfig.PreferredGroups);
   L13.GroupRegistry := AConfig.NamedGroups;
   L13.CipherSuites := AConfig.CipherSuites;
   L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
@@ -301,6 +333,7 @@ var
   LOffers13, LOffers12, LAsyncVerdict: Boolean;
   LVerdictDeadlineMs: Cardinal;
   LMachine: IHandshakeMachine;
+  LGroupCode: UInt16;
 begin
   LOffers13 := Offers(AConfig, TlsWireVersionTls13);
   LOffers12 := Offers(AConfig, TlsWireVersionTls12);
@@ -322,10 +355,17 @@ begin
     AConfig.SupportedVersions, AConfig.CipherSuitePreference);
   L13.CipherSuites := AConfig.CipherSuites;
   L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
-  // the server offers all its preferred groups and selects one the client offered (RFC 8446
-  // 4.2.8); secp256r1 is mandatory to implement (9.1), so it is never a single group
-  L13.OfferedGroups := AConfig.PreferredGroups;
+  // the server offers all its preferred groups the registry holds and selects one the client
+  // offered (RFC 8446 4.2.8); a group pruned from the registry is never selected, so it cannot fail
+  // to resolve mid-handshake. secp256r1 is mandatory to implement (RFC 8446 9.1), never a single group
+  L13.OfferedGroups := RegisteredGroupCodes(AConfig, AConfig.PreferredGroups);
   L13.GroupRegistry := AConfig.NamedGroups;
+  // require at least one preferred group to be registered when 1.3 is offered: this validates the
+  // registry-vs-preference intersection at creation (an empty offer would leave the 1.3 server
+  // unable to select any group) and seeds Group, the single-group fallback the state machine reads
+  // when OfferedGroups is empty, so neither path can fault on the first ClientHello
+  if LOffers13 then
+    L13.Group := PreferredGroup(AConfig, LGroupCode);
   L13.ServerRandom := LServerRandom;
   L13.AlpnProtocols := AConfig.AlpnProtocols;
   // the server compresses its Certificate with what it holds and the client advertised


### PR DESCRIPTION
Restricting a server or client to a subset of key-exchange groups - by installing a smaller registry with WithNamedGroups, or pruning one with INamedGroupRegistry.Prune - did not compose with the presets, whose preferred order lists the post-quantum hybrid first. The engine factory consumed the preferred order verbatim: it took PreferredGroups[0] for the client key_share and advertised the whole preferred list as supported_groups, without reconciling either against the registry. So a config whose registry no longer held a preferred group failed at engine creation (the top preferred group was unresolvable) or, worse, mid-handshake - a client advertised a group it had pruned and then could not answer a HelloRetryRequest onto it, and a server selected such a group and failed to resolve it per connection.

Make the registry the single source of capability truth. PreferredGroup now selects the first preferred group the registry actually holds, and the client and server advertise only the preferred groups present in the registry (new RegisteredGroupCodes helper, mirroring the existing ECDHE-only filter). A group absent from the registry is silently dropped from the offer instead of being advertised and then failing to resolve when chosen. This is a no-op for the default registry (which holds every preferred group) and independently fixes the documented Prune hardening path, which broke the same way.

Guard the server the way the client is already guarded. CreateServerEngine had no counterpart to the client's preferred-group resolution, so a 1.3 server whose registry held none of its preferred groups would build with an empty offer and then fault on the first ClientHello (dereferencing the unset single-group fallback) instead of failing cleanly. It now validates the registry-versus- preference intersection at creation - raising when no preferred group is registered - and seeds that fallback. The check is gated on TLS 1.3 being offered and cannot newly fail a 1.2-only or dual-version server, whose existing ECDHE guard is stricter.

Add TNamedGroups.CreateClassicalRegistry: the default registry with the post-quantum groups filtered out (classical ECDHE only), derived from the default registry so a classical group added there is carried through automatically. A post-quantum key share enlarges the ClientHello enough to fail on some constrained network paths (reduced-MTU tunnels/VPNs, or middleboxes intolerant of a fragmented ClientHello); this trades post-quantum protection for a smaller ClientHello there. Post-quantum stays on by default - this is an opt-in escape hatch.

Add coverage: the classical registry omits the post-quantum codepoints; a Hardened-preset config restricted to the classical registry builds and negotiates X25519 end to end; a classical-registry client against a default, post-quantum- preferring server negotiates X25519 without being retried onto a pruned group; and a server whose registry shares nothing with its preferred order is refused at creation rather than faulting on the first ClientHello.

Usage for anyone stuck behind a PQ-hostile VPN/middlebox:

    .WithNamedGroups(TNamedGroups.CreateClassicalRegistry(Provider))