### PR TITLE
Complete incomplete peer chains from supplied intermediates; stop faking an alert on transport death

### DIFF
--- a/TlsLib.Adapters/FclNet/Adapter/TlsLibFclNetTls.pas
+++ b/TlsLib.Adapters/FclNet/Adapter/TlsLibFclNetTls.pas
@@ -299,7 +299,7 @@ begin
     Exit(0); // orderly close (peer FIN): the pump reports it as a truncated handshake
   // Result < 0: while the handshake timeout is armed this is our SO_RCVTIMEO firing
   if FReadTimeoutMs > 0 then
-    raise ETlsHandshakeTimeout.Create(TTlsAlertDescription.InternalError,
+    raise ETlsHandshakeTimeout.Create(
       Format('the peer sent no handshake data within %d ms', [FReadTimeoutMs]));
   Result := 0; // app phase: surface any error as EOF, as before
 end;
@@ -315,8 +315,7 @@ begin
   begin
     LN := fpSend(FHandle, @ABuffer[LOff], LRemain, TRANSPORT_FLAGS);
     if LN <= 0 then
-      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
-        'fcl-net socket send returned no progress');
+      raise ETlsStreamError.Create('fcl-net socket send returned no progress');
     Inc(LOff, LN);
     Dec(LRemain, LN);
   end;

--- a/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
+++ b/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
@@ -337,7 +337,7 @@ var
 begin
   // bounded during the handshake; distinct from a peer close (which returns 0 below)
   if (FReadTimeoutMs > 0) and (not FBinding.Readable(FReadTimeoutMs)) then
-    raise ETlsHandshakeTimeout.Create(TTlsAlertDescription.InternalError,
+    raise ETlsHandshakeTimeout.Create(
       Format('the peer sent no handshake data within %d ms', [FReadTimeoutMs]));
   LTmp := nil;
   SetLength(LTmp, AMaxLength);
@@ -363,8 +363,7 @@ begin
   begin
     LN := FBinding.Send(LTmp, LOff, LRemain);
     if LN <= 0 then
-      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
-        'Indy socket send returned no progress');
+      raise ETlsStreamError.Create('Indy socket send returned no progress');
     Inc(LOff, LN);
     Dec(LRemain, LN);
   end;

--- a/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
+++ b/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
@@ -236,7 +236,7 @@ function TSynapseSocketTransport.Read(var ABuffer: TBytes; AOffset,
 begin
   // bounded during the handshake; distinct from a peer close (which returns 0 below)
   if (FReadTimeoutMs > 0) and (not FSocket.CanRead(FReadTimeoutMs)) then
-    raise ETlsHandshakeTimeout.Create(TTlsAlertDescription.InternalError,
+    raise ETlsHandshakeTimeout.Create(
       Format('the peer sent no handshake data within %d ms', [FReadTimeoutMs]));
   Result := synsock.Recv(FSocket.Socket, @ABuffer[AOffset], AMaxLength, MSG_NOSIGNAL);
   if Result <= 0 then
@@ -254,8 +254,7 @@ begin
   begin
     LN := synsock.Send(FSocket.Socket, @ABuffer[LOff], LRemain, MSG_NOSIGNAL);
     if LN <= 0 then
-      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
-        'Synapse socket send returned no progress');
+      raise ETlsStreamError.Create('Synapse socket send returned no progress');
     Inc(LOff, LN);
     Dec(LRemain, LN);
   end;

--- a/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
+++ b/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
@@ -251,7 +251,7 @@ begin
     // bounded during the handshake; distinct from a peer close (nrClosed / 0 below)
     if (FReadTimeoutMs > 0) and
       (not (neRead in FSocket.WaitFor(FReadTimeoutMs, [neRead]))) then
-      raise ETlsHandshakeTimeout.Create(TTlsAlertDescription.InternalError,
+      raise ETlsHandshakeTimeout.Create(
         Format('the peer sent no handshake data within %d ms', [FReadTimeoutMs]));
     LLen := AMaxLength;
     LRes := FSocket.Recv(@ABuffer[AOffset], LLen);
@@ -266,7 +266,7 @@ begin
       nrRetry:
         ; // a blocking socket rarely reports this; loop and read again
     else
-      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+      raise ETlsStreamError.Create(
         Format('mORMot socket receive failed (nr=%d)', [Ord(LRes)]));
     end;
   until False;
@@ -293,7 +293,7 @@ begin
       nrRetry:
         ; // loop and send the remainder
     else
-      raise ETlsStreamError.Create(TTlsAlertDescription.InternalError,
+      raise ETlsStreamError.Create(
         Format('mORMot socket send failed (nr=%d)', [Ord(LRes)]));
     end;
   end;

--- a/TlsLib.Tests/src/CertificateVerifierTests.pas
+++ b/TlsLib.Tests/src/CertificateVerifierTests.pas
@@ -31,15 +31,24 @@ uses
   TlpTlsAlert,
   TlpICertificateTrust,
   TlpCertificateVerifier,
+  TlpCertificateLimits,
+  TlpTrustPolicy,
   TlsLibTestBase;
 
 type
   TTestCertificateVerifier = class(TTlsLibAlgorithmTestCase)
   private
     FCerts: TStringList;
+    // a three-level hierarchy (leaf <- issuer <- root) so an incomplete chain can be exercised
+    FChain3: TStringList;
     function Cert(const AName: string): TBytes;
+    function Chain3(const AName: string): TBytes;
     function VerifierFor(const ARoot: TBytes; ACheckHostName: Boolean)
       : ICertificateVerifier;
+    // a verifier trusting ARoot and seeded with AIntermediates for path building; host-name
+    // checking is off so these tests isolate PKIX path construction
+    function IntermediateVerifierFor(const ARoot: TBytes;
+      const AIntermediates: TArray<TBytes>): ICertificateVerifier;
   protected
     procedure SetUp; override;
     procedure TearDown; override;
@@ -50,6 +59,9 @@ type
     procedure TestHostNameMismatchRejectedAsBadCertificate;
     procedure TestEmptyChainRejected;
     procedure TestHostNameCheckDisabledIgnoresName;
+    procedure TestIncompleteChainWithoutIntermediatesRejected;
+    procedure TestIncompleteChainCompletedByIntermediates;
+    procedure TestCompleteChainStillTrustedWithIntermediates;
   end;
 
 implementation
@@ -60,11 +72,13 @@ procedure TTestCertificateVerifier.SetUp;
 begin
   inherited SetUp;
   FCerts := LoadVectorFields('Certs/EcP256Chain.txt');
+  FChain3 := LoadVectorFields('Certs/OcspStapling.txt');
 end;
 
 procedure TTestCertificateVerifier.TearDown;
 begin
   FCerts.Free;
+  FChain3.Free;
   inherited TearDown;
 end;
 
@@ -73,12 +87,29 @@ begin
   Result := DecodeHex(FCerts.Values[AName]);
 end;
 
+function TTestCertificateVerifier.Chain3(const AName: string): TBytes;
+begin
+  Result := DecodeHex(FChain3.Values[AName]);
+end;
+
 function TTestCertificateVerifier.VerifierFor(const ARoot: TBytes;
   ACheckHostName: Boolean): ICertificateVerifier;
 begin
   Result := TCertificateVerifier.Create(Provider, TSystemClock.Create as ITlsClock,
     TTrustAnchorStore.Create(TArray<TBytes>.Create(ARoot)) as ITrustAnchorStore,
     ACheckHostName) as ICertificateVerifier;
+end;
+
+function TTestCertificateVerifier.IntermediateVerifierFor(const ARoot: TBytes;
+  const AIntermediates: TArray<TBytes>): ICertificateVerifier;
+var
+  LNoDangerous: TDangerousTrust;
+begin
+  LNoDangerous := Default(TDangerousTrust);
+  Result := TCertificateVerifier.Create(Provider, TSystemClock.Create as ITlsClock,
+    TTrustAnchorStore.Create(TArray<TBytes>.Create(ARoot)) as ITrustAnchorStore,
+    False, TCertificateChainLimits.Defaults, TRevocationPosture.Soft, nil,
+    LNoDangerous, False, AIntermediates) as ICertificateVerifier;
 end;
 
 procedure TTestCertificateVerifier.TestValidChainTrusted;
@@ -139,6 +170,44 @@ begin
   CheckTrue(VerifierFor(Cert('root_cert'), False).Verify(
     TArray<TBytes>.Create(Cert('leaf_cert')), 'other.example', nil, LAlert),
     'with host-name checking off, a name mismatch does not reject a trusted chain');
+end;
+
+procedure TTestCertificateVerifier.TestIncompleteChainWithoutIntermediatesRejected;
+var
+  LAlert: TTlsAlertDescription;
+begin
+  // the server sends only its leaf, omitting the issuing CA; with no configured
+  // intermediates no path to the trusted root can be built - this is the failure a
+  // leaf-only server produces
+  CheckFalse(IntermediateVerifierFor(Chain3('root_cert'), nil).Verify(
+    TArray<TBytes>.Create(Chain3('leaf_cert')), '', nil, LAlert),
+    'a leaf-only chain with no configured intermediates cannot reach the root');
+  CheckEquals(Ord(TTlsAlertDescription.UnknownCa), Ord(LAlert),
+    'the alert is unknown_ca');
+end;
+
+procedure TTestCertificateVerifier.TestIncompleteChainCompletedByIntermediates;
+var
+  LAlert: TTlsAlertDescription;
+begin
+  // the same leaf-only chain, but the missing intermediate is supplied via config: the
+  // path builder now assembles leaf -> issuer -> root and the chain is trusted
+  CheckTrue(IntermediateVerifierFor(Chain3('root_cert'),
+    TArray<TBytes>.Create(Chain3('issuer_cert'))).Verify(
+    TArray<TBytes>.Create(Chain3('leaf_cert')), '', nil, LAlert),
+    'a configured intermediate completes an otherwise incomplete chain');
+end;
+
+procedure TTestCertificateVerifier.TestCompleteChainStillTrustedWithIntermediates;
+var
+  LAlert: TTlsAlertDescription;
+begin
+  // a server that sends its full chain still verifies when intermediates are also
+  // configured - the extra copy is a redundant pool entry, never a second path
+  CheckTrue(IntermediateVerifierFor(Chain3('root_cert'),
+    TArray<TBytes>.Create(Chain3('issuer_cert'))).Verify(
+    TArray<TBytes>.Create(Chain3('leaf_cert'), Chain3('issuer_cert')), '', nil, LAlert),
+    'a complete chain remains trusted when intermediates are configured too');
 end;
 
 initialization

--- a/TlsLib.Tests/src/MockCryptoProvider.pas
+++ b/TlsLib.Tests/src/MockCryptoProvider.pas
@@ -57,8 +57,9 @@ type
     function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
     function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
     function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors: TArray<TBytes>;
-      const AValidationTimeUtc: TDateTime);
+    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
+      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+      var AEffectiveChain: TArray<TBytes>);
     function ValidateOcspStaple(const ALeafCert, AIssuerCert,
       AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
       out AStatus: TOcspStatus;
@@ -117,8 +118,9 @@ type
     function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
     function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
     function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors: TArray<TBytes>;
-      const AValidationTimeUtc: TDateTime);
+    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
+      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+      var AEffectiveChain: TArray<TBytes>);
     function ValidateOcspStaple(const ALeafCert, AIssuerCert,
       AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
       out AStatus: TOcspStatus;
@@ -243,9 +245,11 @@ begin
 end;
 
 procedure TMockCryptoProvider.ValidateCertificatePath(const AChain,
-  ATrustAnchors: TArray<TBytes>; const AValidationTimeUtc: TDateTime);
+  ATrustAnchors, AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+  var AEffectiveChain: TArray<TBytes>);
 begin
-  FInner.ValidateCertificatePath(AChain, ATrustAnchors, AValidationTimeUtc);
+  FInner.ValidateCertificatePath(AChain, ATrustAnchors, AIntermediates,
+    AValidationTimeUtc, AEffectiveChain);
 end;
 
 function TMockCryptoProvider.ValidateOcspStaple(const ALeafCert, AIssuerCert,
@@ -422,9 +426,11 @@ begin
 end;
 
 procedure TFixedAesProvider.ValidateCertificatePath(const AChain,
-  ATrustAnchors: TArray<TBytes>; const AValidationTimeUtc: TDateTime);
+  ATrustAnchors, AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+  var AEffectiveChain: TArray<TBytes>);
 begin
-  FInner.ValidateCertificatePath(AChain, ATrustAnchors, AValidationTimeUtc);
+  FInner.ValidateCertificatePath(AChain, ATrustAnchors, AIntermediates,
+    AValidationTimeUtc, AEffectiveChain);
 end;
 
 function TFixedAesProvider.ValidateOcspStaple(const ALeafCert, AIssuerCert,

--- a/TlsLib.Tests/src/OcspStaplingTests.pas
+++ b/TlsLib.Tests/src/OcspStaplingTests.pas
@@ -57,8 +57,13 @@ type
     function VerifyChain(APosture: TRevocationPosture; const AChain: TArray<TBytes>;
       const AStaple: TBytes; out AAlert: TTlsAlertDescription): Boolean;
     function LeafSpkiPin: TBytes;
+    function IssuerSpkiPin: TBytes;
     function VerifyWithPins(const APins: TArray<TBytes>;
       out AAlert: TTlsAlertDescription): Boolean;
+    // a verifier trusting the root and seeded with AIntermediates for path building
+    function IntermediateVerifierFor(APosture: TRevocationPosture;
+      const AIntermediates: TArray<TBytes>; const APins: TArray<TBytes> = nil)
+      : ICertificateVerifier;
   protected
     procedure SetUp; override;
     procedure TearDown; override;
@@ -99,6 +104,10 @@ type
     // SPKI public-key pinning
     procedure TestPinningMatchCompletes;
     procedure TestPinningNoMatchAbortsBadCertificate;
+    // a leaf-only peer whose chain is completed from a configured intermediate: the recovered
+    // issuer must be available to the staple and pinning steps (not just the bare leaf)
+    procedure TestLeafOnlyGoodStapleHardCompletesViaConfiguredIssuer;
+    procedure TestLeafOnlyPinOnConfiguredIssuerMatches;
   end;
 
 implementation
@@ -169,6 +178,29 @@ begin
   LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(LSpki, 0, System.Length(LSpki));
   Result := LHash.DoFinal;
+end;
+
+function TTestOcspStapling.IssuerSpkiPin: TBytes;
+var
+  LSpki: TBytes;
+  LHash: IHash;
+begin
+  LSpki := Provider.CertificatePublicKeyInfo(V('issuer_cert'));
+  LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+  LHash.Update(LSpki, 0, System.Length(LSpki));
+  Result := LHash.DoFinal;
+end;
+
+function TTestOcspStapling.IntermediateVerifierFor(APosture: TRevocationPosture;
+  const AIntermediates: TArray<TBytes>; const APins: TArray<TBytes>): ICertificateVerifier;
+var
+  LNoDangerous: TDangerousTrust;
+begin
+  LNoDangerous := Default(TDangerousTrust);
+  Result := TCertificateVerifier.Create(Provider, TSystemClock.Create as ITlsClock,
+    TTrustAnchorStore.Create(TArray<TBytes>.Create(V('root_cert')))
+    as ITrustAnchorStore, False, TCertificateChainLimits.Defaults, APosture, APins,
+    LNoDangerous, False, AIntermediates) as ICertificateVerifier;
 end;
 
 function TTestOcspStapling.VerifyWithPins(const APins: TArray<TBytes>;
@@ -484,6 +516,33 @@ begin
     'a chain that matches no pin is rejected');
   CheckEquals(Ord(TTlsAlertDescription.BadCertificate), Ord(LAlert),
     'the alert is bad_certificate');
+end;
+
+procedure TTestOcspStapling.TestLeafOnlyGoodStapleHardCompletesViaConfiguredIssuer;
+var
+  LAlert: TTlsAlertDescription;
+begin
+  // the peer sends only its leaf; the issuer that signs the staple is supplied as a configured
+  // intermediate. Under Hard posture a good staple must still be authenticated - which is only
+  // possible because path building hands the recovered issuer to the revocation step.
+  CheckTrue(IntermediateVerifierFor(TRevocationPosture.Hard,
+    TArray<TBytes>.Create(V('issuer_cert'))).Verify(
+    TArray<TBytes>.Create(V('leaf_cert')), '', V('ocsp_good'), LAlert),
+    'a good staple authenticates against the configured issuer for a leaf-only peer');
+end;
+
+procedure TTestOcspStapling.TestLeafOnlyPinOnConfiguredIssuerMatches;
+var
+  LAlert: TTlsAlertDescription;
+begin
+  // pin the issuer's public key while the peer sends only its leaf: the pin must match the
+  // intermediate recovered by path building, not just the presented leaf. Revocation Off
+  // isolates the pinning step.
+  CheckTrue(IntermediateVerifierFor(TRevocationPosture.Off,
+    TArray<TBytes>.Create(V('issuer_cert')),
+    TArray<TBytes>.Create(IssuerSpkiPin)).Verify(
+    TArray<TBytes>.Create(V('leaf_cert')), '', nil, LAlert),
+    'a pin on the configured issuer matches the recovered path for a leaf-only peer');
 end;
 
 initialization

--- a/TlsLib/src/Common/TlpTlsLibExceptions.pas
+++ b/TlsLib/src/Common/TlpTlsLibExceptions.pas
@@ -78,6 +78,11 @@ type
     constructor Create(const AError: TTlsError); overload;
     constructor Create(ADescription: TTlsAlertDescription;
       const AMessage: string); overload;
+    /// <summary>Constructs a stream error that carries no TLS alert: the transport died
+    /// (EOF or a read timeout) with no alert exchanged, so HasAlert is False and Alert is
+    /// meaningless. Used for truncation and timeout, which are transport events, not TLS
+    /// alerts - stamping a placeholder alert here misreports them as an on-the-wire alert.</summary>
+    constructor Create(const AMessage: string); overload;
     /// <summary>The alert that was (or would be) sent; valid only when HasAlert.</summary>
     property Alert: TTlsAlertDescription read FAlert;
     property HasAlert: Boolean read FHasAlert;
@@ -144,6 +149,12 @@ begin
   inherited Create(AMessage);
   FAlert := ADescription;
   FHasAlert := True;
+end;
+
+constructor ETlsStreamError.Create(const AMessage: string);
+begin
+  inherited Create(AMessage);
+  FHasAlert := False;
 end;
 
 end.

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -1958,7 +1958,6 @@ begin
   // normalises ordering). A well-formed chain of any depth is accepted here, unchanged, and
   // never reaches the path builder below - so configuring intermediates never relaxes validation
   // for a peer that already sends a complete chain.
-  LLiteralValidated := False;
   try
     LParams := TPkixParameters.Create(LAnchors);
     LParams.SetIsRevocationEnabled(False);

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -101,6 +101,12 @@ uses
   ClpPkixCertPath,
   ClpPkixParameters,
   ClpPkixCertPathValidator,
+  ClpPkixCertPathBuilder,
+  ClpPkixBuilderParameters,
+  ClpX509StoreSelectors,
+  ClpIX509StoreSelectors,
+  ClpCollectionStore,
+  ClpIStore,
   ClpTrustAnchor,
   ClpIPkixTypes,
   ClpOcspProtocolObjects,
@@ -210,8 +216,9 @@ type
     function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
     function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
     function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors: TArray<TBytes>;
-      const AValidationTimeUtc: TDateTime);
+    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
+      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+      var AEffectiveChain: TArray<TBytes>);
     function ValidateOcspStaple(const ALeafCert, AIssuerCert,
       AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
       out AStatus: TOcspStatus;
@@ -1864,18 +1871,36 @@ begin
 end;
 
 procedure TDefaultCryptoProvider.ValidateCertificatePath(const AChain,
-  ATrustAnchors: TArray<TBytes>; const AValidationTimeUtc: TDateTime);
+  ATrustAnchors, AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+  var AEffectiveChain: TArray<TBytes>);
+const
+  // the builder only reconstructs an INCOMPLETE chain, which is inherently shallow (a real
+  // hierarchy is a leaf plus at most a few intermediates). Capping the built path's length
+  // keeps a hostile peer that pads its chain with many like-named certificates from driving
+  // the depth-first search into an expensive fan-out. A legitimately deeper chain sent in
+  // full is unaffected: the strict literal pass below has no such cap and accepts it there.
+  MaxBuiltPathLength = 4;
 var
   LParser: IX509CertificateParser;
-  LCerts: TArray<IX509Certificate>;
+  LCerts, LPool, LInter: TArray<IX509Certificate>;
   LAnchors: TArray<ITrustAnchor>;
+  LBuilt: TArray<IX509Certificate>;
   LAnchorKey: TBytes;
-  LHit: Boolean;
+  LHit, LLiteralValidated: Boolean;
   LParams: IPkixParameters;
   LPath: IPkixCertPath;
   LValidator: IPkixCertPathValidator;
+  LTarget: IX509CertStoreSelector;
+  LBuilderParams: IPkixBuilderParameters;
+  LPoolStore: IStore<IX509Certificate>;
+  LBuilder: IPkixCertPathBuilder;
+  LBuildResult: IPkixCertPathBuilderResult;
   LI: Int32;
 begin
+  // by default the effective chain is the one the peer presented; a successful path build
+  // (below) replaces it with the assembled leaf-to-anchor path
+  AEffectiveChain := AChain;
+
   LParser := TX509CertificateParser.Create;
   try
     SetLength(LCerts, System.Length(AChain));
@@ -1929,7 +1954,11 @@ begin
     end;
   end;
 
-  // build the PKIX path to a trusted anchor; anything else is unknown_ca
+  // strict pass first: validate the chain the peer presented (a leaf-first path; the validator
+  // normalises ordering). A well-formed chain of any depth is accepted here, unchanged, and
+  // never reaches the path builder below - so configuring intermediates never relaxes validation
+  // for a peer that already sends a complete chain.
+  LLiteralValidated := False;
   try
     LParams := TPkixParameters.Create(LAnchors);
     LParams.SetIsRevocationEnabled(False);
@@ -1938,11 +1967,68 @@ begin
     LPath := TPkixCertPath.Create(LCerts);
     LValidator := TPkixCertPathValidator.Create;
     LValidator.Validate(LPath, LParams);
+    LLiteralValidated := True;
+  except
+    on E: ECryptoLibException do
+      LLiteralValidated := False; // fall through to path building if intermediates are configured
+  end;
+  if LLiteralValidated then
+    Exit;
+
+  // the chain did not validate as received. With no configured intermediates that is the
+  // final verdict: the peer did not chain to a trusted anchor.
+  if System.Length(AIntermediates) = 0 then
+    raise EFatalAlertTlsLibException.CreateRes(
+      TTlsAlertDescription.UnknownCa, @SUntrustedChain);
+
+  // fall back to path building: the peer may have sent an incomplete chain, so pool its
+  // certificates with the configured intermediates and let the builder assemble an ordered
+  // path from the leaf up to a trusted anchor - the sans-IO stand-in for AIA fetching.
+  try
+    SetLength(LInter, System.Length(AIntermediates));
+    for LI := 0 to High(AIntermediates) do
+      LInter[LI] := LParser.ReadCertificate(AIntermediates[LI]);
   except
     on E: ECryptoLibException do
       raise EFatalAlertTlsLibException.CreateRes(
         TTlsAlertDescription.UnknownCa, @SUntrustedChain);
   end;
+
+  // note: an out-of-window configured intermediate is left for the builder's own path-time
+  // validity check (SetDate) to reject as part of a path that will not build (unknown_ca). We
+  // do NOT pre-reject every configured intermediate on expiry: a bundle may carry an unused
+  // stale entry, and failing an otherwise-buildable connection on it would be worse than the
+  // slightly less precise alert.
+  SetLength(LPool, System.Length(LCerts) + System.Length(LInter));
+  for LI := 0 to High(LCerts) do
+    LPool[LI] := LCerts[LI];
+  for LI := 0 to High(LInter) do
+    LPool[System.Length(LCerts) + LI] := LInter[LI];
+
+  try
+    // the target of the build is the leaf as the peer presented it
+    LTarget := TX509CertStoreSelector.Create;
+    LTarget.SetCertificate(LCerts[0]);
+    LBuilderParams := TPkixBuilderParameters.Create(LAnchors, LTarget);
+    LBuilderParams.SetIsRevocationEnabled(False);
+    LBuilderParams.SetDate(AValidationTimeUtc);
+    LBuilderParams.SetMaxPathLength(MaxBuiltPathLength);
+    LPoolStore := TCollectionStore<IX509Certificate>.Create(LPool);
+    LBuilderParams.AddStoreCert(LPoolStore);
+    LBuilder := TPkixCertPathBuilder.Create as IPkixCertPathBuilder;
+    LBuildResult := LBuilder.Build(LBuilderParams);
+  except
+    on E: ECryptoLibException do
+      raise EFatalAlertTlsLibException.CreateRes(
+        TTlsAlertDescription.UnknownCa, @SUntrustedChain);
+  end;
+
+  // hand back the assembled path (leaf-first) so the downstream staple and pin checks see the
+  // real issuer the peer omitted, not just the bare leaf
+  LBuilt := LBuildResult.CertPath.Certificates;
+  SetLength(AEffectiveChain, System.Length(LBuilt));
+  for LI := 0 to High(LBuilt) do
+    AEffectiveChain[LI] := LBuilt[LI].GetEncoded;
 end;
 
 class function TDefaultCryptoProvider.OcspDelegatedResponder(const AResponderCert,

--- a/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
+++ b/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
@@ -79,6 +79,7 @@ type
     FClientAuth: TClientAuthMode;
     FRevocationPosture: TRevocationPosture;
     FCertificatePins: TArray<TBytes>;
+    FIntermediateCertificates: TArray<TBytes>;
     FDangerousTrust: TDangerousTrust;
     FAsyncVerdict: TAsyncCertificateVerdict;
     FCertificateCompressors: TArray<ICertificateCompressor>;
@@ -178,6 +179,7 @@ type
     function WithPeerAuth(AMode: TClientAuthMode): TTlsConfigBuilder;
     function WithRevocation(APosture: TRevocationPosture): TTlsConfigBuilder;
     function WithCertificatePinning(const APins: TArray<TBytes>): TTlsConfigBuilder;
+    function WithIntermediateCertificates(const AData: TBytes): TTlsConfigBuilder;
     function WithDangerousInsecureSkipVerify(AEnabled: Boolean): TTlsConfigBuilder;
     function WithCertificateVerifyCallback(
       const ACallback: TTlsCertificateVerifyCallback): TTlsConfigBuilder;
@@ -271,6 +273,7 @@ type
     FChainLimits: TCertificateChainLimits;
     FRevocationPosture: TRevocationPosture;
     FCertificatePins: TArray<TBytes>;
+    FIntermediateCertificates: TArray<TBytes>;
     FDangerousTrust: TDangerousTrust;
     FAsyncVerdict: TAsyncCertificateVerdict;
     FRequireExtendedMasterSecret: Boolean;
@@ -299,6 +302,7 @@ type
     function CertificateChainLimits: TCertificateChainLimits;
     function RevocationPosture: TRevocationPosture;
     function CertificatePins: TArray<TBytes>;
+    function IntermediateCertificates: TArray<TBytes>;
     function DangerousTrust: TDangerousTrust;
     function AsyncCertificateVerdict: TAsyncCertificateVerdict;
     function RequireExtendedMasterSecret: Boolean;
@@ -391,6 +395,8 @@ type
     function WithRevocation(APosture: TRevocationPosture): ITlsClientConfigBuilder;
     function WithCertificatePinning(
       const APins: TArray<TBytes>): ITlsClientConfigBuilder;
+    function WithIntermediateCertificates(
+      const AData: TBytes): ITlsClientConfigBuilder;
     function WithNameCheck(AEnabled: Boolean): ITlsClientConfigBuilder;
     function WithOcspStaplingRequest(AEnabled: Boolean): ITlsClientConfigBuilder;
     function WithDangerousInsecureSkipVerify(
@@ -454,6 +460,8 @@ type
     function WithRevocation(APosture: TRevocationPosture): ITlsServerConfigBuilder;
     function WithCertificatePinning(
       const APins: TArray<TBytes>): ITlsServerConfigBuilder;
+    function WithIntermediateCertificates(
+      const AData: TBytes): ITlsServerConfigBuilder;
     function WithDangerousInsecureSkipVerify(
       AEnabled: Boolean): ITlsServerConfigBuilder;
     function WithCertificateVerifyCallback(
@@ -599,6 +607,15 @@ begin
   SetLength(Result, System.Length(FCertificatePins));
   for LI := 0 to System.High(FCertificatePins) do
     Result[LI] := System.Copy(FCertificatePins[LI]);
+end;
+
+function TFrozenCommonConfig.IntermediateCertificates: TArray<TBytes>;
+var
+  LI: Int32;
+begin
+  SetLength(Result, System.Length(FIntermediateCertificates));
+  for LI := 0 to System.High(FIntermediateCertificates) do
+    Result[LI] := System.Copy(FIntermediateCertificates[LI]);
 end;
 
 function TFrozenCommonConfig.DangerousTrust: TDangerousTrust;
@@ -851,6 +868,13 @@ function TTlsClientConfigBuilder.WithCertificatePinning(
   const APins: TArray<TBytes>): ITlsClientConfigBuilder;
 begin
   FOwner.WithCertificatePinning(APins);
+  Result := Self;
+end;
+
+function TTlsClientConfigBuilder.WithIntermediateCertificates(
+  const AData: TBytes): ITlsClientConfigBuilder;
+begin
+  FOwner.WithIntermediateCertificates(AData);
   Result := Self;
 end;
 
@@ -1114,6 +1138,13 @@ function TTlsServerConfigBuilder.WithCertificatePinning(
   const APins: TArray<TBytes>): ITlsServerConfigBuilder;
 begin
   FOwner.WithCertificatePinning(APins);
+  Result := Self;
+end;
+
+function TTlsServerConfigBuilder.WithIntermediateCertificates(
+  const AData: TBytes): ITlsServerConfigBuilder;
+begin
+  FOwner.WithIntermediateCertificates(AData);
   Result := Self;
 end;
 
@@ -1758,6 +1789,20 @@ begin
   Result := Self;
 end;
 
+function TTlsConfigBuilder.WithIntermediateCertificates(
+  const AData: TBytes): TTlsConfigBuilder;
+var
+  LCerts: TArray<TBytes>;
+  LI: Int32;
+begin
+  GuardMutable;
+  // parse the bundle and accumulate, so successive calls add more intermediates
+  LCerts := FProvider.LoadCertificateChain(AData);
+  for LI := 0 to System.High(LCerts) do
+    TArrayUtilities.Append<TBytes>(FIntermediateCertificates, LCerts[LI]);
+  Result := Self;
+end;
+
 function TTlsConfigBuilder.WithDangerousInsecureSkipVerify(
   AEnabled: Boolean): TTlsConfigBuilder;
 begin
@@ -1961,6 +2006,7 @@ begin
   LConfig.FChainLimits := FChainLimits;
   LConfig.FRevocationPosture := FRevocationPosture;
   LConfig.FCertificatePins := FCertificatePins;
+  LConfig.FIntermediateCertificates := FIntermediateCertificates;
   LConfig.FDangerousTrust := FDangerousTrust;
   LConfig.FAsyncVerdict := FAsyncVerdict;
   LConfig.FRequireExtendedMasterSecret := FRequireExtendedMasterSecret;
@@ -2024,6 +2070,7 @@ begin
   LConfig.FChainLimits := FChainLimits;
   LConfig.FRevocationPosture := FRevocationPosture;
   LConfig.FCertificatePins := FCertificatePins;
+  LConfig.FIntermediateCertificates := FIntermediateCertificates;
   LConfig.FDangerousTrust := FDangerousTrust;
   LConfig.FAsyncVerdict := FAsyncVerdict;
   LConfig.FRequireExtendedMasterSecret := FRequireExtendedMasterSecret;

--- a/TlsLib/src/Engine/TlpTlsEngineFactory.pas
+++ b/TlsLib/src/Engine/TlpTlsEngineFactory.pas
@@ -224,7 +224,7 @@ begin
     LVerifier := TCertificateVerifier.Create(AConfig.Provider, AConfig.Clock,
       AConfig.TrustStore, AConfig.CheckServerName, AConfig.CertificateChainLimits,
       AConfig.RevocationPosture, AConfig.CertificatePins, AConfig.DangerousTrust,
-      LAsyncVerdict);
+      LAsyncVerdict, AConfig.IntermediateCertificates);
 
   L13 := Default(TClientHandshakeParams);
   L13.Provider := AConfig.Provider;
@@ -390,7 +390,7 @@ begin
       L13.ClientCertificateVerifier := TCertificateVerifier.Create(AConfig.Provider,
         AConfig.Clock, AConfig.TrustStore, False, AConfig.CertificateChainLimits,
         AConfig.RevocationPosture, AConfig.CertificatePins, AConfig.DangerousTrust,
-        LAsyncVerdict);
+        LAsyncVerdict, AConfig.IntermediateCertificates);
   end;
   L13.AsyncVerdict := LAsyncVerdict;
 
@@ -423,7 +423,7 @@ begin
       L12.ClientCertificateVerifier := TCertificateVerifier.Create(AConfig.Provider,
         AConfig.Clock, AConfig.TrustStore, False, AConfig.CertificateChainLimits,
         AConfig.RevocationPosture, AConfig.CertificatePins, AConfig.DangerousTrust,
-        LAsyncVerdict);
+        LAsyncVerdict, AConfig.IntermediateCertificates);
   end;
   L12.AsyncVerdict := LAsyncVerdict;
 

--- a/TlsLib/src/Engine/TlpTlsStream.pas
+++ b/TlsLib/src/Engine/TlpTlsStream.pas
@@ -18,7 +18,6 @@ interface
 uses
   SysUtils,
   Classes,
-  TlpTlsAlert,
   TlpTlsLibExceptions,
   TlpTlsConnectionInfo,
   TlpITlsEngine,
@@ -192,8 +191,7 @@ begin
         // a stripped close_notify is a truncation, not a graceful EOF
         FReadClosed := True;
         FTruncated := True;
-        raise ETlsTransportTruncated.Create(
-          TTlsAlertDescription.InternalError, SReadTruncated);
+        raise ETlsTransportTruncated.Create(SReadTruncated);
       end;
   end;
   Result := LGot;

--- a/TlsLib/src/Engine/TlpTlsStreamPump.pas
+++ b/TlsLib/src/Engine/TlpTlsStreamPump.pas
@@ -229,7 +229,7 @@ begin
     end;
     LGot := ATransport.Read(LBuf, 0, TransportChunk);
     if LGot = 0 then
-      raise ETlsTransportTruncated.Create(TTlsAlertDescription.InternalError,
+      raise ETlsTransportTruncated.Create(
         Format('%s (after %d handshake bytes from the peer)', [STruncatedHandshake, LTotal]));
     Inc(LTotal, LGot);
     AEngine.ProcessInput(LBuf, 0, LGot);

--- a/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
+++ b/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
@@ -239,10 +239,19 @@ type
     /// reason (certificate_expired / unknown_ca / bad_certificate). Every validity
     /// check (chain notBefore/notAfter and the PKIX path date) is evaluated at
     /// AValidationTimeUtc, so the caller's injected clock drives the whole time-based
-    /// trust decision from one source.
+    /// trust decision from one source. AIntermediates are extra untrusted DER
+    /// certificates seeded into path building for a peer that sends an incomplete
+    /// chain (e.g. a leaf-only server); empty validates the chain exactly as received.
+    /// They never anchor a path and never bypass validation. The chain is first validated
+    /// exactly as presented; the intermediates are consulted only if that strict pass fails.
+    /// AEffectiveChain returns the validated leaf-first chain - the assembled path when one was
+    /// built, otherwise AChain - so the caller's staple and pin checks see the real issuer. It is
+    /// a var parameter so a caller may pre-seed it with AChain as a fallback; an implementation
+    /// that returns normally must set it.
     /// </summary>
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors: TArray<TBytes>;
-      const AValidationTimeUtc: TDateTime);
+    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
+      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+      var AEffectiveChain: TArray<TBytes>);
     /// <summary>
     /// Verifies a stapled OCSP response (RFC 6960) about the leaf certificate,
     /// in-band only - no network. Confirms the response is signed by the leaf's

--- a/TlsLib/src/Interfaces/Engine/TlpITlsConfig.pas
+++ b/TlsLib/src/Interfaces/Engine/TlpITlsConfig.pas
@@ -81,6 +81,12 @@ type
     /// chain must have a SubjectPublicKeyInfo whose SHA-256 matches one pin (public-key
     /// pinning). Augments PKIX validation; it never replaces it. Empty disables pinning.</summary>
     function CertificatePins: TArray<TBytes>;
+    /// <summary>Optional untrusted intermediate certificates that seed PKIX path building:
+    /// when the peer sends an incomplete chain (e.g. a leaf-only server), these fill the gap
+    /// so a path to a trust anchor can still be built. They are never trusted on their own -
+    /// only trust anchors anchor a path - and they never bypass validation. Empty (the
+    /// default) validates the peer chain exactly as received.</summary>
+    function IntermediateCertificates: TArray<TBytes>;
     /// <summary>Whether TLS 1.2 requires extended_master_secret (RFC 7627); when False,
     /// a peer that does not offer it falls back to the plain master secret.</summary>
     function RequireExtendedMasterSecret: Boolean;

--- a/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
+++ b/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
@@ -114,7 +114,14 @@ type
     /// validation - a path must still reach a configured trust anchor, and a complete chain the
     /// server sends is still validated exactly as presented. Calls accumulate. Use this when a
     /// server you must reach ships a partial chain; the well-behaved fix is to have the server
-    /// send its full chain.</summary>
+    /// send its full chain. This is NOT a substitute for a trust anchor: if validation fails with
+    /// unknown_ca even when the server sends a complete chain, the client is missing the ROOT, not
+    /// an intermediate - configure the root with WithTrustAnchors (or opt into OS system trust)
+    /// instead, since an intermediate can never terminate a path. Public-CA intermediates rotate,
+    /// so a pinned intermediate can go stale - bundle the currently valid set (e.g. a CA's current
+    /// and next issuing certificates) and refresh it with your trust configuration. The library
+    /// never fetches (sans-IO); an application that wants AIA behaviour can resolve the issuer URL
+    /// out of band and feed the result here.</summary>
     function WithIntermediateCertificates(const AData: TBytes): ITlsClientConfigBuilder;
     /// <summary>Whether the server certificate must match the connected host (RFC 6125).
     /// Default True.</summary>
@@ -279,10 +286,15 @@ type
     /// PKIX, never a bypass. Empty disables it.</summary>
     function WithCertificatePinning(const APins: TArray<TBytes>): ITlsServerConfigBuilder;
     /// <summary>Untrusted intermediate certificates that seed PKIX path building for a requested
-    /// client certificate whose chain arrives incomplete. AData is a PEM bundle (one or more
-    /// certificates) or a single DER certificate; call more than once to add several DER
-    /// certificates. Never trusted on their own and never a bypass - a path must still reach a
-    /// configured trust anchor. Calls accumulate.</summary>
+    /// client certificate whose chain arrives incomplete (leaf-only client certificates are common
+    /// in enterprise mutual-TLS). AData is a PEM bundle (one or more certificates) or a single DER
+    /// certificate; call more than once to add several DER certificates. Never trusted on their own
+    /// and never a bypass - a path must still reach a configured trust anchor. Calls accumulate.
+    /// This is NOT a substitute for a trust anchor: if validation fails with unknown_ca even when
+    /// the client sends a complete chain, the missing piece is the ROOT, not an intermediate -
+    /// configure it with WithTrustAnchors, since an intermediate can never terminate a path.
+    /// Public-CA intermediates rotate, so a pinned intermediate can go stale - bundle the currently
+    /// valid set and refresh it with your trust configuration.</summary>
     function WithIntermediateCertificates(const AData: TBytes): ITlsServerConfigBuilder;
     /// <summary>DANGEROUS: when enabled, a requested client certificate chain is accepted
     /// without PKIX, revocation, or pinning checks. For tests only - never production.</summary>

--- a/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
+++ b/TlsLib/src/Interfaces/Engine/TlpITlsConfigBuilder.pas
@@ -107,6 +107,15 @@ type
     /// <summary>SPKI-SHA256 public-key pins: when set, some certificate in the server chain
     /// must match one pin. Augments PKIX validation; never a bypass. Empty disables it.</summary>
     function WithCertificatePinning(const APins: TArray<TBytes>): ITlsClientConfigBuilder;
+    /// <summary>Untrusted intermediate certificates that seed PKIX path building when the server
+    /// sends an incomplete chain (e.g. a leaf-only server that omits its issuing CA). AData is a
+    /// PEM bundle (one or more certificates) or a single DER certificate; call more than once to
+    /// add several DER certificates. They are never trusted on their own and never bypass
+    /// validation - a path must still reach a configured trust anchor, and a complete chain the
+    /// server sends is still validated exactly as presented. Calls accumulate. Use this when a
+    /// server you must reach ships a partial chain; the well-behaved fix is to have the server
+    /// send its full chain.</summary>
+    function WithIntermediateCertificates(const AData: TBytes): ITlsClientConfigBuilder;
     /// <summary>Whether the server certificate must match the connected host (RFC 6125).
     /// Default True.</summary>
     function WithNameCheck(AEnabled: Boolean): ITlsClientConfigBuilder;
@@ -269,6 +278,12 @@ type
     /// <summary>SPKI-SHA256 pins the requested client chain must match one of; augments
     /// PKIX, never a bypass. Empty disables it.</summary>
     function WithCertificatePinning(const APins: TArray<TBytes>): ITlsServerConfigBuilder;
+    /// <summary>Untrusted intermediate certificates that seed PKIX path building for a requested
+    /// client certificate whose chain arrives incomplete. AData is a PEM bundle (one or more
+    /// certificates) or a single DER certificate; call more than once to add several DER
+    /// certificates. Never trusted on their own and never a bypass - a path must still reach a
+    /// configured trust anchor. Calls accumulate.</summary>
+    function WithIntermediateCertificates(const AData: TBytes): ITlsServerConfigBuilder;
     /// <summary>DANGEROUS: when enabled, a requested client certificate chain is accepted
     /// without PKIX, revocation, or pinning checks. For tests only - never production.</summary>
     function WithDangerousInsecureSkipVerify(AEnabled: Boolean): ITlsServerConfigBuilder;

--- a/TlsLib/src/Trust/TlpCertificateVerifier.pas
+++ b/TlsLib/src/Trust/TlpCertificateVerifier.pas
@@ -73,6 +73,9 @@ type
     FChainLimits: TCertificateChainLimits;
     FRevocationPosture: TRevocationPosture;
     FCertificatePins: TArray<TBytes>;
+    /// <summary>Untrusted intermediates that seed PKIX path building when the peer sends an
+    /// incomplete chain; empty validates the chain exactly as received.</summary>
+    FIntermediates: TArray<TBytes>;
     FDangerous: TDangerousTrust;
     /// <summary>Whether an out-of-band async certificate-verdict resolver runs after the pipeline
     /// (the live OCSP/CRL fetch at the park). When set, an indeterminate stapled outcome is
@@ -124,7 +127,17 @@ type
       const AChainLimits: TCertificateChainLimits;
       ARevocationPosture: TRevocationPosture; const APins: TArray<TBytes>;
       const ADangerous: TDangerousTrust;
-      AAsyncVerdictEnabled: Boolean = False); overload;
+      AAsyncVerdictEnabled: Boolean); overload;
+    /// <summary>As above, plus AIntermediates: untrusted intermediate certificates seeded into
+    /// PKIX path building for a peer that sends an incomplete chain (e.g. a leaf-only server).
+    /// They never anchor a path and never bypass validation; empty behaves exactly as the
+    /// overload without it.</summary>
+    constructor Create(const AProvider: ICryptoProvider; const AClock: ITlsClock;
+      const ATrustStore: ITrustAnchorStore; ACheckHostName: Boolean;
+      const AChainLimits: TCertificateChainLimits;
+      ARevocationPosture: TRevocationPosture; const APins: TArray<TBytes>;
+      const ADangerous: TDangerousTrust; AAsyncVerdictEnabled: Boolean;
+      const AIntermediates: TArray<TBytes>); overload;
     function Verify(const AChain: TArray<TBytes>; const AHostName: string;
       const AOcspStaple: TBytes; out AAlert: TTlsAlertDescription): Boolean;
   end;
@@ -194,7 +207,7 @@ var
 begin
   LNoDangerous := Default(TDangerousTrust);
   Create(AProvider, AClock, ATrustStore, ACheckHostName, AChainLimits,
-    ARevocationPosture, APins, LNoDangerous);
+    ARevocationPosture, APins, LNoDangerous, False);
 end;
 
 constructor TCertificateVerifier.Create(const AProvider: ICryptoProvider;
@@ -202,6 +215,17 @@ constructor TCertificateVerifier.Create(const AProvider: ICryptoProvider;
   ACheckHostName: Boolean; const AChainLimits: TCertificateChainLimits;
   ARevocationPosture: TRevocationPosture; const APins: TArray<TBytes>;
   const ADangerous: TDangerousTrust; AAsyncVerdictEnabled: Boolean);
+begin
+  Create(AProvider, AClock, ATrustStore, ACheckHostName, AChainLimits,
+    ARevocationPosture, APins, ADangerous, AAsyncVerdictEnabled, nil);
+end;
+
+constructor TCertificateVerifier.Create(const AProvider: ICryptoProvider;
+  const AClock: ITlsClock; const ATrustStore: ITrustAnchorStore;
+  ACheckHostName: Boolean; const AChainLimits: TCertificateChainLimits;
+  ARevocationPosture: TRevocationPosture; const APins: TArray<TBytes>;
+  const ADangerous: TDangerousTrust; AAsyncVerdictEnabled: Boolean;
+  const AIntermediates: TArray<TBytes>);
 begin
   inherited Create;
   FProvider := AProvider;
@@ -211,6 +235,7 @@ begin
   FChainLimits := AChainLimits;
   FRevocationPosture := ARevocationPosture;
   FCertificatePins := APins;
+  FIntermediates := AIntermediates;
   FDangerous := ADangerous;
   FAsyncVerdictEnabled := AAsyncVerdictEnabled;
 end;
@@ -345,6 +370,10 @@ function TCertificateVerifier.VerifyPipeline(const AChain: TArray<TBytes>;
   out AAlert: TTlsAlertDescription): Boolean;
 var
   LI, LTotal: Int32;
+  // the chain PKIX actually validated: when the peer sent an incomplete chain that path
+  // building completed from the configured intermediates, this carries the assembled path
+  // (with the recovered issuer), so revocation and pinning see it rather than the bare leaf
+  LEffectiveChain: TArray<TBytes>;
 begin
   Result := False;
   AAlert := TTlsAlertDescription.BadCertificate;
@@ -365,10 +394,12 @@ begin
       Exit;
   end;
 
-  // path validation (validity + PKIX) is the provider's job; it raises the reason
+  // path validation (validity + PKIX) is the provider's job; it raises the reason, and hands
+  // back the chain it actually validated (the assembled path when it completed an incomplete one)
+  LEffectiveChain := AChain;
   try
     FProvider.ValidateCertificatePath(AChain, FTrustStore.RootCertificates,
-      ValidationTimeUtc);
+      FIntermediates, ValidationTimeUtc, LEffectiveChain);
   except
     on E: EFatalAlertTlsLibException do
     begin
@@ -377,8 +408,9 @@ begin
     end;
   end;
 
-  // revocation via the stapled OCSP response (RFC 6960), in-band only
-  if not CheckRevocation(AChain, AOcspStaple, AAlert) then
+  // revocation via the stapled OCSP response (RFC 6960), in-band only; run over the validated
+  // chain so a staple can be authenticated against a recovered issuer the peer did not send
+  if not CheckRevocation(LEffectiveChain, AOcspStaple, AAlert) then
     Exit;
 
   // endpoint identity (RFC 6125) over the leaf's dNSName / iPAddress SAN entries
@@ -391,8 +423,9 @@ begin
       Exit;
     end;
 
-  // optional SPKI pinning augments the validated chain; it never bypasses it
-  if not CheckPinning(AChain, AAlert) then
+  // optional SPKI pinning augments the validated chain; it never bypasses it. Pin against the
+  // validated chain so a pin on a recovered intermediate matches even for a leaf-only peer
+  if not CheckPinning(LEffectiveChain, AAlert) then
     Exit;
 
   Result := True;


### PR DESCRIPTION
Two improvements that came out of diagnosing a client that could not validate a server which sent a leaf-only (incomplete) certificate chain.

Client-supplied intermediates
- WithIntermediateCertificates on the client and server config builders accepts a PEM bundle or a single DER certificate (calls accumulate). These untrusted intermediates seed PKIX path building so a peer that omits its issuing CA can still be validated. They never anchor a path and never bypass validation; there is no network fetch (no AIA), matching the library's sans-IO stance.
- The provider validates the chain strictly as presented first and only falls back to building a path from {peer chain + configured intermediates} when that fails. A complete, well-formed chain keeps its strict ordered validation and never reaches the builder, so configuring intermediates does not relax validation for well-behaved peers. The fallback builder is depth-capped to bound the search a hostile padded chain could otherwise drive.
- The provider returns the chain it actually validated (the assembled path when one was built), so stapled-OCSP and SPKI-pin checks see the recovered issuer rather than the bare leaf.

Transport death is not a TLS alert
- ETlsStreamError gains a no-alert constructor. Truncation, handshake-read timeout, and transport socket send/receive failures no longer stamp a placeholder internal_error(80): HasAlert is False, so a connection that died without a close_notify is reported as a transport error, not a fabricated on-the-wire alert.

Tests
- Path-building accept/reject, complete-chain-stays-strict, leaf-only staple authenticated via the configured issuer under Hard revocation, and a pin on the configured issuer.