### PR TITLE
Send close_notify on adapter teardown so a clean shutdown is not seen as truncation

### DIFF
--- a/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
+++ b/TlsLib.Adapters/Indy/Adapter/TlsLibIndyTls.pas
@@ -210,6 +210,9 @@ type
     function Readable(AMSec: Integer): Boolean; override;
   public
     destructor Destroy; override;
+    /// <summary>Sends a TLS close_notify (best-effort, half-close) before the socket is torn down,
+    /// so a strict peer sees a clean shutdown instead of a truncation (RFC 8446 6.1).</summary>
+    procedure Close; override;
     function Clone: TIdSSLIOHandlerSocketBase; override;
     procedure StartSSL; override;
     procedure ConnectClient; override;
@@ -386,10 +389,33 @@ end;
 
 destructor TTlsLibIOHandlerSocket.Destroy;
 begin
+  // belt-and-braces for a handler freed directly without a prior Close: emit close_notify while
+  // the socket may still be open. Idempotent - a no-op when Close already sent it.
+  if FStream <> nil then
+    try
+      FStream.CloseNotify;
+    except
+    end;
   FStream.Free;
+  FStream := nil; // inherited Destroy calls Close; keep it from touching a freed stream
   FOptions.Free;
   FHandshakeLock.Free;
   inherited Destroy;
+end;
+
+procedure TTlsLibIOHandlerSocket.Close;
+begin
+  // send a TLS close_notify before the transport goes away, so a strict peer reads a clean
+  // shutdown rather than a truncation (RFC 8446 6.1). Best-effort and half-close: CloseNotify
+  // only writes and flushes (it never waits for the peer's answering close_notify, so there is
+  // no wedge), is idempotent, and no-ops on a stream that never finished the handshake. A write
+  // to an already-dead peer is expected and ignored.
+  if FStream <> nil then
+    try
+      FStream.CloseNotify;
+    except
+    end;
+  inherited Close;
 end;
 
 function TTlsLibIOHandlerSocket.LoadFileBytes(const APath: string): TBytes;

--- a/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
+++ b/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
@@ -554,8 +554,12 @@ end;
 
 function TSSLTlsLib.Shutdown: boolean;
 begin
+  // best-effort: a close_notify write to a peer that already closed must not raise here
   if FStream <> nil then
-    FStream.CloseNotify;
+    try
+      FStream.CloseNotify;
+    except
+    end;
   FSSLEnabled := False;
   Result := True;
 end;

--- a/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
+++ b/TlsLib.Adapters/mORMot/Adapter/TlsLibMormotTls.pas
@@ -303,6 +303,17 @@ end;
 
 destructor TTlsLibNetTls.Destroy;
 begin
+  // close_notify before the stream goes away, so a strict peer reads a clean shutdown rather
+  // than a truncation (RFC 8446 6.1). Half-close, idempotent, and a no-op when the handshake
+  // never finished. The INetTls seam has no explicit close hook, but mORMot's TCrtSocket.Close
+  // releases this interface (running us here) BEFORE it closes the socket, so FSocket is still
+  // open and the alert goes out. Best-effort: a write to a peer that already RST the connection
+  // is expected and ignored.
+  if FStream <> nil then
+    try
+      FStream.CloseNotify;
+    except
+    end;
   FStream.Free;
   inherited Destroy;
 end;


### PR DESCRIPTION
The Indy and mORMot adapters never emitted a TLS close_notify when the connection closed, so a TlsLib server tore the socket down with a bare FIN. A strict peer (our own client) then reported "the transport closed without close_notify (possible truncation)" - the connection worked against OpenSSL servers, which send close_notify on SSL_shutdown, but not against a TlsLib server.

- Indy: TTlsLibIOHandlerSocket overrides Close to send a best-effort, half-close close_notify before the socket is torn down (idempotent, a no-op when the handshake never finished, and it ignores a write to an already-dead peer). Destroy nils the stream after freeing it so the base teardown's Close cannot touch a freed stream, and also sends a belt-and-braces close_notify for a handler freed without a Close.
- mORMot: TTlsLibNetTls.Destroy sends the same best-effort close_notify; mORMot releases the INetTls before closing the socket, so the alert reaches the wire.
- Synapse: guard TSSLTlsLib.Shutdown's existing close_notify so a dead-peer write cannot raise out of its Boolean API (parity with the other adapters).

FclNet already did this; no engine or core change was needed. Verified with a repro that flips ETlsTransportTruncated to a clean EIdConnClosedGracefully.