### PR TITLE
Decompose the crypto provider into composable facets

### DIFF
--- a/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
+++ b/TlsLib.Adapters/Synapse/Adapter/TlsLibSynapseTls.pas
@@ -664,7 +664,7 @@ begin
   Result := '';
   LLeaf := PeerLeaf;
   if (FProvider <> nil) and (System.Length(LLeaf) > 0) and
-    FProvider.CertificatePeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) then
+    FProvider.Certificates.PeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) then
     Result := LSubject;
 end;
 
@@ -676,7 +676,7 @@ begin
   Result := '';
   LLeaf := PeerLeaf;
   if (FProvider <> nil) and (System.Length(LLeaf) > 0) and
-    FProvider.CertificatePeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) then
+    FProvider.Certificates.PeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) then
     Result := LIssuer;
 end;
 
@@ -688,7 +688,7 @@ begin
   Result := '';
   LLeaf := PeerLeaf;
   if (FProvider <> nil) and (System.Length(LLeaf) > 0) and
-    FProvider.CertificatePeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) then
+    FProvider.Certificates.PeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) then
     Result := LCommonName;
 end;
 
@@ -703,7 +703,7 @@ begin
   LLeaf := PeerLeaf;
   if (FProvider = nil) or (System.Length(LLeaf) = 0) then
     Exit;
-  LHash := FProvider.CreateHash(THashAlgorithm.SHA_256);
+  LHash := FProvider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(LLeaf, 0, System.Length(LLeaf));
   LDigest := LHash.DoFinal;
   Result := AnsiString(TDataEncoding.HexEncode(LDigest));
@@ -717,7 +717,7 @@ begin
   Result := 0;
   LLeaf := PeerLeaf;
   if (FProvider <> nil) and (System.Length(LLeaf) > 0) and
-    FProvider.CertificatePeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) and
+    FProvider.Certificates.PeerInfo(LLeaf, LSubject, LIssuer, LCommonName, LSerialHex) and
     (LSerialHex <> '') then
     // a serial can exceed 32 bits; take the low 8 hex digits Synapse's integer can hold
     Result := Integer(StrToInt64Def('$' +

--- a/TlsLib.Benchmark/src/Core/TlsHandshakeBenchmark.pas
+++ b/TlsLib.Benchmark/src/Core/TlsHandshakeBenchmark.pas
@@ -127,7 +127,7 @@ var
     LCurve: UInt16;
   begin
     Result := 0;
-    if LProvider.CertificateKeyKind(LCredential.LeafCertDer, LKind, LCurve)
+    if LProvider.Certificates.KeyKind(LCredential.LeafCertDer, LKind, LCurve)
       and (LKind = TCertKeyKind.Ecdsa) then
       Result := LCurve;
   end;

--- a/TlsLib.Benchmark/src/Core/TlsLibHandshakePeer.pas
+++ b/TlsLib.Benchmark/src/Core/TlsLibHandshakePeer.pas
@@ -93,7 +93,7 @@ begin
   // the leaf's own curve (RFC 8422 5.4 fallback), read from the certificate so the peer is
   // not tied to one curve; 0 (offer nothing extra) for a non-ECDSA leaf
   LCertGroup := 0;
-  if AProvider.CertificateKeyKind(ACredential.LeafCertDer, LKind, LCertCurve)
+  if AProvider.Certificates.KeyKind(ACredential.LeafCertDer, LKind, LCertCurve)
     and (LKind = TCertKeyKind.Ecdsa) then
     LCertGroup := LCertCurve;
 

--- a/TlsLib.Benchmark/src/Core/TlsLibThroughputPeer.pas
+++ b/TlsLib.Benchmark/src/Core/TlsLibThroughputPeer.pas
@@ -85,7 +85,7 @@ var
   LCurve: UInt16;
 begin
   // X25519 for the ECDHE key exchange, plus the ECDSA leaf's curve (RFC 8422 5.4)
-  if AProvider.CertificateKeyKind(ACredential.LeafCertDer, LKind, LCurve)
+  if AProvider.Certificates.KeyKind(ACredential.LeafCertDer, LKind, LCurve)
     and (LKind = TCertKeyKind.Ecdsa) and (LCurve <> TNamedGroupCatalog.X25519) then
     Result := TArray<UInt16>.Create(TNamedGroupCatalog.X25519, LCurve)
   else

--- a/TlsLib.Interop/src/BoGoShimRunner.pas
+++ b/TlsLib.Interop/src/BoGoShimRunner.pas
@@ -1123,9 +1123,9 @@ begin
       // resumes via the session id, which the server can only honor from a persistent store.
       // -no-ticket suppresses the STEK so no ticket is minted, leaving only the session-id path
       if not LConfig.NoTicket then
-        LConfig.SessionTicketKeys := TStekTicketKeyManager.Create(LProvider.GetRandom)
+        LConfig.SessionTicketKeys := TStekTicketKeyManager.Create(LProvider.Primitives.GetRandom)
           as ISessionTicketKeyManager;
-      LConfig.SessionStore := TInMemorySessionStore.Create(LProvider.GetRandom)
+      LConfig.SessionStore := TInMemorySessionStore.Create(LProvider.Primitives.GetRandom)
         as ISessionStore;
     end;
   end

--- a/TlsLib.Interop/src/InteropCredentials.pas
+++ b/TlsLib.Interop/src/InteropCredentials.pas
@@ -74,8 +74,8 @@ implementation
 class function TInteropCredentials.ServerCredential(const AProvider: ICryptoProvider;
   const ALeafCertDer, AKeyDer: TBytes): TTlsCredential;
 begin
-  Result.CertificateChain := AProvider.LoadCertificateChain(ALeafCertDer);
-  Result.PrivateKey := AProvider.ImportSigningKey(AKeyDer);
+  Result.CertificateChain := AProvider.Certificates.LoadChain(ALeafCertDer);
+  Result.PrivateKey := AProvider.Signing.ImportSigningKey(AKeyDer);
 end;
 
 class function TInteropCredentials.ServerCredentialFromFieldFile(
@@ -105,7 +105,7 @@ begin
     Result.CertificateChain := TArray<TBytes>.Create(
       TInteropUtils.DecodeHex(LFields.Values['leaf_cert']),
       TInteropUtils.DecodeHex(LFields.Values['issuer_cert']));
-    Result.PrivateKey := AProvider.ImportSigningKey(
+    Result.PrivateKey := AProvider.Signing.ImportSigningKey(
       TInteropUtils.DecodeHex(LFields.Values['leaf_key']));
   finally
     LFields.Free;
@@ -117,16 +117,16 @@ class function TInteropCredentials.ServerCredentialFromPem(
   const ACertFile, AKeyFile: string): TTlsCredential;
 begin
   // the loaders accept PEM directly; a PEM cert file may carry the whole chain
-  Result.CertificateChain := AProvider.LoadCertificateChain(
+  Result.CertificateChain := AProvider.Certificates.LoadChain(
     TEncoding.ASCII.GetBytes(TInteropUtils.ReadAllText(ACertFile)));
-  Result.PrivateKey := AProvider.ImportSigningKey(
+  Result.PrivateKey := AProvider.Signing.ImportSigningKey(
     TEncoding.ASCII.GetBytes(TInteropUtils.ReadAllText(AKeyFile)));
 end;
 
 class function TInteropCredentials.Trust(const AProvider: ICryptoProvider;
   const ARootDer: TBytes): ITrustAnchorStore;
 begin
-  Result := TTrustAnchorStore.Create(AProvider.LoadCertificateChain(ARootDer))
+  Result := TTrustAnchorStore.Create(AProvider.Certificates.LoadChain(ARootDer))
     as ITrustAnchorStore;
 end;
 

--- a/TlsLib.Interop/src/OpenSslInteropRunner.pas
+++ b/TlsLib.Interop/src/OpenSslInteropRunner.pas
@@ -307,7 +307,7 @@ begin
     begin
       LStek := nil;
       if LResumeCount > 0 then
-        LStek := TStekTicketKeyManager.Create(TInteropEngine.DefaultProvider.GetRandom)
+        LStek := TStekTicketKeyManager.Create(TInteropEngine.DefaultProvider.Primitives.GetRandom)
           as ISessionTicketKeyManager;
       LProvider := TInteropEngine.DefaultProvider;
       LStaple := nil;

--- a/TlsLib.Tests/src/BundleTrustTests.pas
+++ b/TlsLib.Tests/src/BundleTrustTests.pas
@@ -76,7 +76,7 @@ begin
   CheckTrue(LStore <> nil, 'FromPem returns an anchor store');
   CheckEquals(1, Length(LStore.RootCertificates),
     'the one-cert bundle yields exactly one anchor');
-  CheckTrue(FProvider.IsWellFormedCertificate(LStore.RootCertificates[0]),
+  CheckTrue(FProvider.Certificates.IsWellFormed(LStore.RootCertificates[0]),
     'the harvested anchor is a well-formed certificate');
 end;
 

--- a/TlsLib.Tests/src/CertificateCheckTests.pas
+++ b/TlsLib.Tests/src/CertificateCheckTests.pas
@@ -85,7 +85,7 @@ function TTestCertificateChecks.Permits(const ACertName: string;
   AUsage: TCertKeyUsage): Boolean;
 begin
   // asserts the certificate parsed (method result True) and reports the permission
-  CheckTrue(Provider.CertificateKeyUsagePermits(V(ACertName), AUsage, Result),
+  CheckTrue(Provider.Certificates.KeyUsagePermits(V(ACertName), AUsage, Result),
     'the certificate should parse');
 end;
 
@@ -124,7 +124,7 @@ var
   LPermitted: Boolean;
 begin
   // a certificate that does not parse cannot restrict usage: result False, permitted True
-  CheckFalse(Provider.CertificateKeyUsagePermits(
+  CheckFalse(Provider.Certificates.KeyUsagePermits(
     TBytes.Create(1, 2, 3, 4), TCertKeyUsage.DigitalSignature, LPermitted),
     'a malformed certificate cannot be determined');
   CheckTrue(LPermitted, 'an undeterminable certificate imposes no restriction');
@@ -134,7 +134,7 @@ procedure TTestCertificateChecks.TestRsaPssKeyIsDetected;
 var
   LIsRsaPss: Boolean;
 begin
-  CheckTrue(Provider.CertificateHasRsaPssKey(V('rsapss_cert'), LIsRsaPss),
+  CheckTrue(Provider.Certificates.HasRsaPssKey(V('rsapss_cert'), LIsRsaPss),
     'the certificate should parse');
   CheckTrue(LIsRsaPss, 'an id-RSASSA-PSS SubjectPublicKeyInfo is detected');
 end;
@@ -143,7 +143,7 @@ procedure TTestCertificateChecks.TestNormalRsaKeyIsNotPss;
 var
   LIsRsaPss: Boolean;
 begin
-  CheckTrue(Provider.CertificateHasRsaPssKey(V('rsa_normal_cert'), LIsRsaPss),
+  CheckTrue(Provider.Certificates.HasRsaPssKey(V('rsa_normal_cert'), LIsRsaPss),
     'the certificate should parse');
   CheckFalse(LIsRsaPss, 'an rsaEncryption key is not id-RSASSA-PSS');
 end;
@@ -152,7 +152,7 @@ procedure TTestCertificateChecks.TestEcKeyIsNotPss;
 var
   LIsRsaPss: Boolean;
 begin
-  CheckTrue(Provider.CertificateHasRsaPssKey(V('ku_digsig_cert'), LIsRsaPss),
+  CheckTrue(Provider.Certificates.HasRsaPssKey(V('ku_digsig_cert'), LIsRsaPss),
     'the certificate should parse');
   CheckFalse(LIsRsaPss, 'an ecPublicKey key is not id-RSASSA-PSS');
 end;
@@ -161,7 +161,7 @@ procedure TTestCertificateChecks.TestMalformedCertIsNotPss;
 var
   LIsRsaPss: Boolean;
 begin
-  CheckFalse(Provider.CertificateHasRsaPssKey(TBytes.Create(9, 9, 9), LIsRsaPss),
+  CheckFalse(Provider.Certificates.HasRsaPssKey(TBytes.Create(9, 9, 9), LIsRsaPss),
     'a malformed certificate cannot be determined');
   CheckFalse(LIsRsaPss, 'an undeterminable certificate is not reported as PSS');
 end;

--- a/TlsLib.Tests/src/CertificateCompressionCacheTests.pas
+++ b/TlsLib.Tests/src/CertificateCompressionCacheTests.pas
@@ -358,7 +358,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;

--- a/TlsLib.Tests/src/ClientAuthTests.pas
+++ b/TlsLib.Tests/src/ClientAuthTests.pas
@@ -108,7 +108,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;

--- a/TlsLib.Tests/src/ConfigBuilderTests.pas
+++ b/TlsLib.Tests/src/ConfigBuilderTests.pas
@@ -129,7 +129,7 @@ end;
 function TTestConfigBuilder.ServerCredential: TTlsCredential;
 begin
   Result.CertificateChain := TArray<TBytes>.Create(DecodeHex(FCerts.Values['leaf_cert']));
-  Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(FCerts.Values['leaf_key']));
+  Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(FCerts.Values['leaf_key']));
 end;
 
 function TTestConfigBuilder.ClientTrust: ITrustAnchorStore;

--- a/TlsLib.Tests/src/ConfigResumptionTests.pas
+++ b/TlsLib.Tests/src/ConfigResumptionTests.pas
@@ -100,7 +100,7 @@ end;
 function TTestConfigResumption.ServerCredential: TTlsCredential;
 begin
   Result.CertificateChain := TArray<TBytes>.Create(DecodeHex(FCerts.Values['leaf_cert']));
-  Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(FCerts.Values['leaf_key']));
+  Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(FCerts.Values['leaf_key']));
 end;
 
 function TTestConfigResumption.ClientTrust: ITrustAnchorStore;
@@ -292,7 +292,7 @@ begin
   // the public surface: a store-backed 1.3 server issues one stateful ticket; a later
   // handshake resumes it. The store single-use consumption proves the config wired through
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
 
   LClient := NewClient13(LCache, True);
   LServer := NewServer13(LStore, 1, True);
@@ -320,7 +320,7 @@ begin
   // a TLS 1.2 client and server through the public surface: the second handshake resumes,
   // proven by the abbreviated server flight (no plaintext Certificate)
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
 
   LClient := NewClient12(LCache);
   LServer := NewServer12(LStore);
@@ -391,7 +391,7 @@ begin
   // the Strict preset defaults resumption OFF: even with a cache and store supplied, the
   // factory does not engage them, so nothing is cached or stored
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
 
   LClient := TTlsEngineFactory.CreateClientEngine(TTlsPresets.Strict(Provider).Client
     .WithTrustStore(ClientTrust).WithSessionCache(LCache).Build, ServerHost);
@@ -412,7 +412,7 @@ var
 begin
   // Strict is a mutable starting point: re-enabling resumption on it needs no ceremony
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
 
   LClient := TTlsEngineFactory.CreateClientEngine(TTlsPresets.Strict(Provider).Client
     .WithResumption(True).WithTrustStore(ClientTrust).WithSessionCache(LCache).Build,

--- a/TlsLib.Tests/src/CredentialImportTests.pas
+++ b/TlsLib.Tests/src/CredentialImportTests.pas
@@ -91,7 +91,7 @@ end;
 
 function TTestCredentialImport.Import(const AField: string): ISigningKey;
 begin
-  Result := Provider.ImportSigningKey(DecodeHex(FV.Values[AField]));
+  Result := Provider.Signing.ImportSigningKey(DecodeHex(FV.Values[AField]));
 end;
 
 function TTestCredentialImport.RoundTrips(AScheme: TSignatureScheme;
@@ -102,11 +102,11 @@ var
   LMessage, LSignature: TBytes;
 begin
   LMessage := DecodeHex(SMessageHex);
-  LSigner := Provider.CreateSignatureSigner(AScheme, AKey);
+  LSigner := Provider.Signing.CreateSignatureSigner(AScheme, AKey);
   LSigner.Update(LMessage, 0, System.Length(LMessage));
   LSignature := LSigner.Sign;
 
-  LVerifier := Provider.CreateSignatureVerifier(AScheme,
+  LVerifier := Provider.Signing.CreateSignatureVerifier(AScheme,
     DecodeHex(FV.Values[APubField]));
   LVerifier.Update(LMessage, 0, System.Length(LMessage));
   Result := LVerifier.Verify(LSignature);
@@ -184,16 +184,16 @@ var
   LKey: ISigningKey;
 begin
   // encrypted PKCS#8 in DER and PEM, decrypted with the password
-  LKey := Provider.ImportSigningKey(DecodeHex(FV.Values['rsa_enc_der']), SPassword);
+  LKey := Provider.Signing.ImportSigningKey(DecodeHex(FV.Values['rsa_enc_der']), SPassword);
   CheckTrue(RoundTrips(TSignatureScheme.RSA_PSS_RSAE_SHA256, LKey, 'rsa_pub'),
     'encrypted RSA PKCS#8 (DER) imports and signs');
-  LKey := Provider.ImportSigningKey(DecodeHex(FV.Values['rsa_enc_pem']), SPassword);
+  LKey := Provider.Signing.ImportSigningKey(DecodeHex(FV.Values['rsa_enc_pem']), SPassword);
   CheckTrue(RoundTrips(TSignatureScheme.RSA_PSS_RSAE_SHA256, LKey, 'rsa_pub'),
     'encrypted RSA PKCS#8 (PEM) imports and signs');
-  LKey := Provider.ImportSigningKey(DecodeHex(FV.Values['ec256_enc_der']), SPassword);
+  LKey := Provider.Signing.ImportSigningKey(DecodeHex(FV.Values['ec256_enc_der']), SPassword);
   CheckTrue(RoundTrips(TSignatureScheme.ECDSA_SECP256R1_SHA256, LKey, 'ec256_pub'),
     'encrypted EC P-256 PKCS#8 (DER) imports and signs');
-  LKey := Provider.ImportSigningKey(DecodeHex(FV.Values['ed25519_enc_der']), SPassword);
+  LKey := Provider.Signing.ImportSigningKey(DecodeHex(FV.Values['ed25519_enc_der']), SPassword);
   CheckTrue(RoundTrips(TSignatureScheme.ED25519, LKey, 'ed25519_pub'),
     'encrypted Ed25519 PKCS#8 (DER) imports and signs');
 end;
@@ -203,7 +203,7 @@ var
   LChain: TArray<TBytes>;
 begin
   // a fullchain PEM (leaf then root) splits into the two ordered DER certificates
-  LChain := Provider.LoadCertificateChain(DecodeHex(FV.Values['chain_pem']));
+  LChain := Provider.Certificates.LoadChain(DecodeHex(FV.Values['chain_pem']));
   CheckEquals(2, System.Length(LChain), 'the PEM bundle yields two certificates');
   CheckEqualBytes('leaf DER', DecodeHex(FV.Values['chain_leaf_der']), LChain[0]);
   CheckEqualBytes('root DER', DecodeHex(FV.Values['chain_root_der']), LChain[1]);
@@ -214,7 +214,7 @@ var
   LChain: TArray<TBytes>;
 begin
   // a lone DER certificate still loads (as a single-element chain)
-  LChain := Provider.LoadCertificateChain(DecodeHex(FV.Values['single_leaf_der']));
+  LChain := Provider.Certificates.LoadChain(DecodeHex(FV.Values['single_leaf_der']));
   CheckEquals(1, System.Length(LChain), 'a lone DER certificate is a one-element chain');
   CheckEqualBytes('single DER', DecodeHex(FV.Values['single_leaf_der']), LChain[0]);
 end;
@@ -225,7 +225,7 @@ var
 begin
   LRaised := False;
   try
-    Provider.ImportSigningKey(DecodeHex('deadbeefdeadbeef'));
+    Provider.Signing.ImportSigningKey(DecodeHex('deadbeefdeadbeef'));
   except
     // a typed library exception, never a raw backend/ASN.1 exception
     on E: EArgumentTlsLibException do
@@ -241,7 +241,7 @@ begin
   LRaised := False;
   try
     // a valid PKCS#8 X25519 key: parseable, but not a signing algorithm
-    Provider.ImportSigningKey(DecodeHex(FV.Values['x25519_pkcs8_der']));
+    Provider.Signing.ImportSigningKey(DecodeHex(FV.Values['x25519_pkcs8_der']));
   except
     on E: ENotSupportedTlsLibException do
       LRaised := True;
@@ -255,7 +255,7 @@ var
 begin
   LRaised := False;
   try
-    Provider.ImportSigningKey(DecodeHex(FV.Values['rsa_enc_der']), 'not-the-password');
+    Provider.Signing.ImportSigningKey(DecodeHex(FV.Values['rsa_enc_der']), 'not-the-password');
   except
     on E: EArgumentTlsLibException do
       LRaised := True;

--- a/TlsLib.Tests/src/EngineSkeletonTests.pas
+++ b/TlsLib.Tests/src/EngineSkeletonTests.pas
@@ -107,7 +107,7 @@ end;
 function TTestEngineSkeleton.MakeTls13(const AKey, AIv: TBytes): IRecordProtection;
 begin
   Result := TTls13RecordProtection.Create(TSecretBuffer.From(AKey),
-    TSecretBuffer.From(AIv), Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    TSecretBuffer.From(AIv), Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
 end;
 
 function TTestEngineSkeleton.TakeAll(const AEngine: ITlsEngine): TBytes;

--- a/TlsLib.Tests/src/ExtensionNegotiationTests.pas
+++ b/TlsLib.Tests/src/ExtensionNegotiationTests.pas
@@ -197,7 +197,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;

--- a/TlsLib.Tests/src/HelloRetryRequestTests.pas
+++ b/TlsLib.Tests/src/HelloRetryRequestTests.pas
@@ -267,7 +267,7 @@ begin
   LCerts := LoadVectorFields('Certs/EcP256Chain.txt');
   try
     LCred := Default(TTlsCredential);
-    LCred.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    LCred.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
     LParams.CredentialResolver := TSniCredentialResolver.ForCredential(LCred);
   finally
     LCerts.Free;

--- a/TlsLib.Tests/src/HkdfLabelTests.pas
+++ b/TlsLib.Tests/src/HkdfLabelTests.pas
@@ -51,7 +51,7 @@ implementation
 
 function TTestHkdfLabel.Hkdf: IHkdf;
 begin
-  Result := Provider.CreateHkdf(THashAlgorithm.SHA_256);
+  Result := Provider.Primitives.CreateHkdf(THashAlgorithm.SHA_256);
 end;
 
 procedure TTestHkdfLabel.TestHkdfLabelEncoding;

--- a/TlsLib.Tests/src/LiveRevocationTests.pas
+++ b/TlsLib.Tests/src/LiveRevocationTests.pas
@@ -217,7 +217,7 @@ procedure TTestLiveRevocation.TestOcspResponderUrlExtracted;
 var
   LUrl: string;
 begin
-  CheckTrue(Provider.TryGetOcspResponderUrl(LeafCert, LUrl),
+  CheckTrue(Provider.Revocation.TryGetOcspResponderUrl(LeafCert, LUrl),
     'the leaf AIA carries an OCSP responder URL');
   CheckEquals('http://ocsp.tlslib.test/', LUrl, 'the OCSP URL is extracted verbatim');
 end;
@@ -226,7 +226,7 @@ procedure TTestLiveRevocation.TestCrlDistributionPointsExtracted;
 var
   LUrls: TArray<string>;
 begin
-  CheckTrue(Provider.TryGetCrlDistributionPoints(LeafCert, LUrls),
+  CheckTrue(Provider.Revocation.TryGetCrlDistributionPoints(LeafCert, LUrls),
     'the leaf carries a CRL distribution point');
   CheckTrue(System.Length(LUrls) >= 1, 'at least one CRL URL is returned');
   CheckEquals('http://crl.tlslib.test/ca.crl', LUrls[0], 'the CRL URL is extracted');
@@ -236,7 +236,7 @@ procedure TTestLiveRevocation.TestBuildOcspRequestNonEmpty;
 var
   LReq: TBytes;
 begin
-  CheckTrue(Provider.BuildOcspRequest(LeafCert, CaCert, LReq),
+  CheckTrue(Provider.Revocation.BuildOcspRequest(LeafCert, CaCert, LReq),
     'an OCSP request is built for the leaf/issuer');
   CheckTrue(System.Length(LReq) > 0, 'the OCSP request is non-empty DER');
 end;
@@ -247,7 +247,7 @@ var
 begin
   // the neutral peer-identity accessor an adapter's native verify hook (Synapse GetPeer*)
   // reads, so no adapter touches a CryptoLib type
-  CheckTrue(Provider.CertificatePeerInfo(LeafCert, LSubject, LIssuer, LCommonName,
+  CheckTrue(Provider.Certificates.PeerInfo(LeafCert, LSubject, LIssuer, LCommonName,
     LSerialHex), 'peer info is extracted from the leaf');
   CheckEquals('localhost', LCommonName, 'the leaf common name is localhost');
   CheckTrue(Pos('localhost', LSubject) > 0, 'the subject DN carries the common name');
@@ -259,7 +259,7 @@ procedure TTestLiveRevocation.TestCrlRevocationDetectsRevoked;
 var
   LRevoked: Boolean;
 begin
-  CheckTrue(Provider.CheckCrlRevocation(LeafCert, CaCert, CrlRevoked, LRevoked),
+  CheckTrue(Provider.Revocation.CheckCrlRevocation(LeafCert, CaCert, CrlRevoked, LRevoked),
     'the issuer-signed CRL parses and verifies');
   CheckTrue(LRevoked, 'the leaf serial is listed as revoked in the CRL');
 end;
@@ -268,7 +268,7 @@ procedure TTestLiveRevocation.TestCrlRevocationDetectsNotRevoked;
 var
   LRevoked: Boolean;
 begin
-  CheckTrue(Provider.CheckCrlRevocation(LeafCert, CaCert, CrlGood, LRevoked),
+  CheckTrue(Provider.Revocation.CheckCrlRevocation(LeafCert, CaCert, CrlGood, LRevoked),
     'the issuer-signed CRL parses and verifies');
   CheckFalse(LRevoked, 'the leaf is not listed in the good CRL');
 end;
@@ -404,7 +404,7 @@ begin
   // check it reads as a definitive Good; the window check makes it indeterminate, defeating a
   // stale-CRL replay. The provider primitive reports it directly, and the checker follows the
   // posture (Hard rejects).
-  CheckFalse(Provider.CheckCrlRevocation(LeafCert, CaCert, CrlStale, LRevoked),
+  CheckFalse(Provider.Revocation.CheckCrlRevocation(LeafCert, CaCert, CrlStale, LRevoked),
     'a stale CRL (out of its validity window) is not authoritative');
   CheckFalse(LRevoked, 'a stale CRL yields no definitive revocation');
 

--- a/TlsLib.Tests/src/MockCryptoProvider.pas
+++ b/TlsLib.Tests/src/MockCryptoProvider.pas
@@ -20,320 +20,113 @@ interface
 uses
   SysUtils,
   TlpCryptoAlgorithms,
-  TlpISigningKey,
-  TlpTlsCredential,
-  TlpICryptoProvider;
+  TlpICryptoProvider,
+  TlpDefaultCryptoProvider;
 
 type
   /// <summary>
-  /// A test <see cref="ICryptoProvider" /> that returns a caller-supplied
-  /// (deterministic) <see cref="IRandom" /> and delegates every other primitive
-  /// to an inner provider. This is the seam an engine leans on to run with a
-  /// fixed randomness stream. Skeleton for now; grown as tests need it.
+  /// A test provider that runs the default crypto with a caller-supplied
+  /// (deterministic) <see cref="IRandom" />. It is a thin wrapper over the
+  /// composition seam - a provider built with the random override - so
+  /// <c>Primitives.GetRandom</c> hands back the injected stream while every crypto
+  /// operation is the real default. This is the seam an engine leans on to run with
+  /// a fixed randomness stream.
   /// </summary>
   TMockCryptoProvider = class(TInterfacedObject, ICryptoProvider)
   strict private
   var
-    FInner: ICryptoProvider;
-    FRandom: IRandom;
+    FComposed: ICryptoProvider;
   public
-    constructor Create(const AInner: ICryptoProvider; const ARandom: IRandom);
+    constructor Create(const ARandom: IRandom);
+    function Primitives: ICryptoPrimitives;
+    function Signing: ISigningCrypto;
+    function Certificates: ICertificateInspector;
+    function PathValidation: ICertificatePathValidator;
+    function Revocation: IRevocationChecker;
+  end;
+
+  /// <summary>
+  /// An <see cref="ICryptoPrimitives" /> decorator that forces a fixed
+  /// <c>HasHardwareAes</c> answer and forwards every other primitive to an inner
+  /// primitives facet.
+  /// </summary>
+  TFixedAesPrimitives = class(TInterfacedObject, ICryptoPrimitives)
+  strict private
+  var
+    FInner: ICryptoPrimitives;
+    FHasHardwareAes: Boolean;
+  public
+    constructor Create(const AInner: ICryptoPrimitives; AHasHardwareAes: Boolean);
     function GetRandom: IRandom;
     function CreateHash(AAlgorithm: THashAlgorithm): IHash;
     function CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
     function CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
     function CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
-    function ImportSigningKey(const AData: TBytes): ISigningKey; overload;
-    function ImportSigningKey(const AData: TBytes;
-      const APassword: string): ISigningKey; overload;
-    function CreateSignatureSigner(AScheme: TSignatureScheme;
-      const AKey: ISigningKey): ISignatureSigner;
-    function CreateSignatureVerifier(AScheme: TSignatureScheme;
-      const APublicKeyDer: TBytes): ISignatureVerifier;
-    function LoadCertificateChain(const AData: TBytes): TArray<TBytes>;
-    function IsWellFormedCertificate(const ADer: TBytes): Boolean;
-    function ImportPkcs12(const AData: TBytes;
-      const APassword: string): TTlsCredential;
-    function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
-    function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
-    function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
-      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
-      var AEffectiveChain: TArray<TBytes>);
-    function ValidateOcspStaple(const ALeafCert, AIssuerCert,
-      AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
-      out AStatus: TOcspStatus;
-      out AThisUpdate, ANextUpdate: TDateTime): Boolean;
-    function BuildOcspRequest(const ALeafCert, AIssuerCert: TBytes;
-      out ARequestDer: TBytes): Boolean;
-    function TryGetOcspResponderUrl(const ACert: TBytes;
-      out AUrl: string): Boolean;
-    function TryGetCrlDistributionPoints(const ACert: TBytes;
-      out AUrls: TArray<string>): Boolean;
-    function CheckCrlRevocation(const ALeafCert, AIssuerCert, ACrlDer: TBytes;
-      out ARevoked: Boolean): Boolean;
-    function CertificatePeerInfo(const ACertificateDer: TBytes;
-      out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-    function CertificateTlsFeatures(const ACert: TBytes;
-      out AFeatures: TArray<UInt16>): Boolean;
-    function CertificateKeyUsagePermits(const ACertificateDer: TBytes;
-      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    function CertificateHasRsaPssKey(const ACertificateDer: TBytes;
-      out AIsRsaPss: Boolean): Boolean;
-    function CertificateKeyKind(const ACertificateDer: TBytes;
-      out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
-    function CreateKeyAgreement(AName: TKeyAgreementAlgorithm): IKeyAgreement;
-    function CreateKem(AName: TKemAlgorithm): IKem;
+    function CreateKeyAgreement(AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
+    function CreateKem(AAlgorithm: TKemAlgorithm): IKem;
     function HasHardwareAes: Boolean;
   end;
 
   /// <summary>
-  /// A test <see cref="ICryptoProvider" /> that forces a fixed
-  /// <c>HasHardwareAes</c> answer and delegates every primitive to an inner
-  /// provider. It makes the CPU-adaptive AEAD ordering deterministic in tests.
+  /// A test provider that forces a fixed <c>HasHardwareAes</c> answer while running
+  /// the real crypto. It is a thin wrapper over the composition seam - a provider
+  /// built with a primitives override that decorates the inner's primitives - and
+  /// makes the CPU-adaptive AEAD ordering deterministic in tests.
   /// </summary>
   TFixedAesProvider = class(TInterfacedObject, ICryptoProvider)
   strict private
   var
-    FInner: ICryptoProvider;
-    FHasHardwareAes: Boolean;
+    FComposed: ICryptoProvider;
   public
     constructor Create(const AInner: ICryptoProvider; AHasHardwareAes: Boolean);
-    function GetRandom: IRandom;
-    function CreateHash(AAlgorithm: THashAlgorithm): IHash;
-    function CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
-    function CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
-    function CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
-    function ImportSigningKey(const AData: TBytes): ISigningKey; overload;
-    function ImportSigningKey(const AData: TBytes;
-      const APassword: string): ISigningKey; overload;
-    function CreateSignatureSigner(AScheme: TSignatureScheme;
-      const AKey: ISigningKey): ISignatureSigner;
-    function CreateSignatureVerifier(AScheme: TSignatureScheme;
-      const APublicKeyDer: TBytes): ISignatureVerifier;
-    function LoadCertificateChain(const AData: TBytes): TArray<TBytes>;
-    function IsWellFormedCertificate(const ADer: TBytes): Boolean;
-    function ImportPkcs12(const AData: TBytes;
-      const APassword: string): TTlsCredential;
-    function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
-    function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
-    function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
-      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
-      var AEffectiveChain: TArray<TBytes>);
-    function ValidateOcspStaple(const ALeafCert, AIssuerCert,
-      AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
-      out AStatus: TOcspStatus;
-      out AThisUpdate, ANextUpdate: TDateTime): Boolean;
-    function BuildOcspRequest(const ALeafCert, AIssuerCert: TBytes;
-      out ARequestDer: TBytes): Boolean;
-    function TryGetOcspResponderUrl(const ACert: TBytes;
-      out AUrl: string): Boolean;
-    function TryGetCrlDistributionPoints(const ACert: TBytes;
-      out AUrls: TArray<string>): Boolean;
-    function CheckCrlRevocation(const ALeafCert, AIssuerCert, ACrlDer: TBytes;
-      out ARevoked: Boolean): Boolean;
-    function CertificatePeerInfo(const ACertificateDer: TBytes;
-      out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-    function CertificateTlsFeatures(const ACert: TBytes;
-      out AFeatures: TArray<UInt16>): Boolean;
-    function CertificateKeyUsagePermits(const ACertificateDer: TBytes;
-      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    function CertificateHasRsaPssKey(const ACertificateDer: TBytes;
-      out AIsRsaPss: Boolean): Boolean;
-    function CertificateKeyKind(const ACertificateDer: TBytes;
-      out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
-    function CreateKeyAgreement(AName: TKeyAgreementAlgorithm): IKeyAgreement;
-    function CreateKem(AName: TKemAlgorithm): IKem;
-    function HasHardwareAes: Boolean;
+    function Primitives: ICryptoPrimitives;
+    function Signing: ISigningCrypto;
+    function Certificates: ICertificateInspector;
+    function PathValidation: ICertificatePathValidator;
+    function Revocation: IRevocationChecker;
   end;
 
 implementation
 
 { TMockCryptoProvider }
 
-constructor TMockCryptoProvider.Create(const AInner: ICryptoProvider;
-  const ARandom: IRandom);
+constructor TMockCryptoProvider.Create(const ARandom: IRandom);
+var
+  LBuilder: ICryptoProviderBuilder;
 begin
   inherited Create;
-  FInner := AInner;
-  FRandom := ARandom;
+  LBuilder := TCryptoProviderBuilder.Create;
+  FComposed := LBuilder.WithRandom(ARandom).Build;
 end;
 
-function TMockCryptoProvider.GetRandom: IRandom;
+function TMockCryptoProvider.Primitives: ICryptoPrimitives;
 begin
-  Result := FRandom;
+  Result := FComposed.Primitives;
 end;
 
-function TMockCryptoProvider.CreateHash(AAlgorithm: THashAlgorithm): IHash;
+function TMockCryptoProvider.Signing: ISigningCrypto;
 begin
-  Result := FInner.CreateHash(AAlgorithm);
+  Result := FComposed.Signing;
 end;
 
-function TMockCryptoProvider.CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
+function TMockCryptoProvider.Certificates: ICertificateInspector;
 begin
-  Result := FInner.CreateHmac(AAlgorithm);
+  Result := FComposed.Certificates;
 end;
 
-function TMockCryptoProvider.CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
+function TMockCryptoProvider.PathValidation: ICertificatePathValidator;
 begin
-  Result := FInner.CreateHkdf(AAlgorithm);
+  Result := FComposed.PathValidation;
 end;
 
-function TMockCryptoProvider.CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
+function TMockCryptoProvider.Revocation: IRevocationChecker;
 begin
-  Result := FInner.CreateAead(AAlgorithm);
+  Result := FComposed.Revocation;
 end;
 
-function TMockCryptoProvider.ImportSigningKey(const AData: TBytes): ISigningKey;
-begin
-  Result := FInner.ImportSigningKey(AData);
-end;
+{ TFixedAesPrimitives }
 
-function TMockCryptoProvider.ImportSigningKey(const AData: TBytes;
-  const APassword: string): ISigningKey;
-begin
-  Result := FInner.ImportSigningKey(AData, APassword);
-end;
-
-function TMockCryptoProvider.CreateSignatureSigner(AScheme: TSignatureScheme;
-  const AKey: ISigningKey): ISignatureSigner;
-begin
-  Result := FInner.CreateSignatureSigner(AScheme, AKey);
-end;
-
-function TMockCryptoProvider.CreateSignatureVerifier(AScheme: TSignatureScheme;
-  const APublicKeyDer: TBytes): ISignatureVerifier;
-begin
-  Result := FInner.CreateSignatureVerifier(AScheme, APublicKeyDer);
-end;
-
-function TMockCryptoProvider.LoadCertificateChain(
-  const AData: TBytes): TArray<TBytes>;
-begin
-  Result := FInner.LoadCertificateChain(AData);
-end;
-
-function TMockCryptoProvider.IsWellFormedCertificate(
-  const ADer: TBytes): Boolean;
-begin
-  Result := FInner.IsWellFormedCertificate(ADer);
-end;
-
-function TMockCryptoProvider.ImportPkcs12(const AData: TBytes;
-  const APassword: string): TTlsCredential;
-begin
-  Result := FInner.ImportPkcs12(AData, APassword);
-end;
-
-function TMockCryptoProvider.CertificatePublicKeyInfo(
-  const ACertificateDer: TBytes): TBytes;
-begin
-  Result := FInner.CertificatePublicKeyInfo(ACertificateDer);
-end;
-
-function TMockCryptoProvider.CertificateDnsNames(
-  const ACertificateDer: TBytes): TArray<string>;
-begin
-  Result := FInner.CertificateDnsNames(ACertificateDer);
-end;
-
-function TMockCryptoProvider.CertificateIpAddresses(
-  const ACertificateDer: TBytes): TArray<TBytes>;
-begin
-  Result := FInner.CertificateIpAddresses(ACertificateDer);
-end;
-
-procedure TMockCryptoProvider.ValidateCertificatePath(const AChain,
-  ATrustAnchors, AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
-  var AEffectiveChain: TArray<TBytes>);
-begin
-  FInner.ValidateCertificatePath(AChain, ATrustAnchors, AIntermediates,
-    AValidationTimeUtc, AEffectiveChain);
-end;
-
-function TMockCryptoProvider.ValidateOcspStaple(const ALeafCert, AIssuerCert,
-  AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
-  out AStatus: TOcspStatus; out AThisUpdate, ANextUpdate: TDateTime): Boolean;
-begin
-  Result := FInner.ValidateOcspStaple(ALeafCert, AIssuerCert, AOcspResponseDer,
-    AValidationTimeUtc, AStatus, AThisUpdate, ANextUpdate);
-end;
-
-function TMockCryptoProvider.BuildOcspRequest(const ALeafCert, AIssuerCert: TBytes;
-  out ARequestDer: TBytes): Boolean;
-begin
-  Result := FInner.BuildOcspRequest(ALeafCert, AIssuerCert, ARequestDer);
-end;
-
-function TMockCryptoProvider.TryGetOcspResponderUrl(const ACert: TBytes;
-  out AUrl: string): Boolean;
-begin
-  Result := FInner.TryGetOcspResponderUrl(ACert, AUrl);
-end;
-
-function TMockCryptoProvider.TryGetCrlDistributionPoints(const ACert: TBytes;
-  out AUrls: TArray<string>): Boolean;
-begin
-  Result := FInner.TryGetCrlDistributionPoints(ACert, AUrls);
-end;
-
-function TMockCryptoProvider.CheckCrlRevocation(const ALeafCert, AIssuerCert,
-  ACrlDer: TBytes; out ARevoked: Boolean): Boolean;
-begin
-  Result := FInner.CheckCrlRevocation(ALeafCert, AIssuerCert, ACrlDer, ARevoked);
-end;
-
-function TMockCryptoProvider.CertificatePeerInfo(const ACertificateDer: TBytes;
-  out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-begin
-  Result := FInner.CertificatePeerInfo(ACertificateDer, ASubject, AIssuer,
-    ACommonName, ASerialHex);
-end;
-
-function TMockCryptoProvider.CertificateTlsFeatures(const ACert: TBytes;
-  out AFeatures: TArray<UInt16>): Boolean;
-begin
-  Result := FInner.CertificateTlsFeatures(ACert, AFeatures);
-end;
-
-function TMockCryptoProvider.CertificateKeyUsagePermits(
-  const ACertificateDer: TBytes; AUsage: TCertKeyUsage;
-  out APermitted: Boolean): Boolean;
-begin
-  Result := FInner.CertificateKeyUsagePermits(ACertificateDer, AUsage, APermitted);
-end;
-
-function TMockCryptoProvider.CertificateHasRsaPssKey(
-  const ACertificateDer: TBytes; out AIsRsaPss: Boolean): Boolean;
-begin
-  Result := FInner.CertificateHasRsaPssKey(ACertificateDer, AIsRsaPss);
-end;
-
-function TMockCryptoProvider.CertificateKeyKind(const ACertificateDer: TBytes;
-  out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
-begin
-  Result := FInner.CertificateKeyKind(ACertificateDer, AKind, AEcNamedGroup);
-end;
-
-function TMockCryptoProvider.CreateKeyAgreement(AName: TKeyAgreementAlgorithm): IKeyAgreement;
-begin
-  Result := FInner.CreateKeyAgreement(AName);
-end;
-
-function TMockCryptoProvider.CreateKem(AName: TKemAlgorithm): IKem;
-begin
-  Result := FInner.CreateKem(AName);
-end;
-
-function TMockCryptoProvider.HasHardwareAes: Boolean;
-begin
-  Result := FInner.HasHardwareAes;
-end;
-
-{ TFixedAesProvider }
-
-constructor TFixedAesProvider.Create(const AInner: ICryptoProvider;
+constructor TFixedAesPrimitives.Create(const AInner: ICryptoPrimitives;
   AHasHardwareAes: Boolean);
 begin
   inherited Create;
@@ -341,175 +134,85 @@ begin
   FHasHardwareAes := AHasHardwareAes;
 end;
 
-function TFixedAesProvider.GetRandom: IRandom;
+function TFixedAesPrimitives.GetRandom: IRandom;
 begin
   Result := FInner.GetRandom;
 end;
 
-function TFixedAesProvider.CreateHash(AAlgorithm: THashAlgorithm): IHash;
+function TFixedAesPrimitives.CreateHash(AAlgorithm: THashAlgorithm): IHash;
 begin
   Result := FInner.CreateHash(AAlgorithm);
 end;
 
-function TFixedAesProvider.CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
+function TFixedAesPrimitives.CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
 begin
   Result := FInner.CreateHmac(AAlgorithm);
 end;
 
-function TFixedAesProvider.CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
+function TFixedAesPrimitives.CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
 begin
   Result := FInner.CreateHkdf(AAlgorithm);
 end;
 
-function TFixedAesProvider.CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
+function TFixedAesPrimitives.CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
 begin
   Result := FInner.CreateAead(AAlgorithm);
 end;
 
-function TFixedAesProvider.ImportSigningKey(const AData: TBytes): ISigningKey;
+function TFixedAesPrimitives.CreateKeyAgreement(
+  AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
 begin
-  Result := FInner.ImportSigningKey(AData);
+  Result := FInner.CreateKeyAgreement(AAlgorithm);
 end;
 
-function TFixedAesProvider.ImportSigningKey(const AData: TBytes;
-  const APassword: string): ISigningKey;
+function TFixedAesPrimitives.CreateKem(AAlgorithm: TKemAlgorithm): IKem;
 begin
-  Result := FInner.ImportSigningKey(AData, APassword);
+  Result := FInner.CreateKem(AAlgorithm);
 end;
 
-function TFixedAesProvider.CreateSignatureSigner(AScheme: TSignatureScheme;
-  const AKey: ISigningKey): ISignatureSigner;
-begin
-  Result := FInner.CreateSignatureSigner(AScheme, AKey);
-end;
-
-function TFixedAesProvider.CreateSignatureVerifier(AScheme: TSignatureScheme;
-  const APublicKeyDer: TBytes): ISignatureVerifier;
-begin
-  Result := FInner.CreateSignatureVerifier(AScheme, APublicKeyDer);
-end;
-
-function TFixedAesProvider.LoadCertificateChain(
-  const AData: TBytes): TArray<TBytes>;
-begin
-  Result := FInner.LoadCertificateChain(AData);
-end;
-
-function TFixedAesProvider.IsWellFormedCertificate(
-  const ADer: TBytes): Boolean;
-begin
-  Result := FInner.IsWellFormedCertificate(ADer);
-end;
-
-function TFixedAesProvider.ImportPkcs12(const AData: TBytes;
-  const APassword: string): TTlsCredential;
-begin
-  Result := FInner.ImportPkcs12(AData, APassword);
-end;
-
-function TFixedAesProvider.CertificatePublicKeyInfo(
-  const ACertificateDer: TBytes): TBytes;
-begin
-  Result := FInner.CertificatePublicKeyInfo(ACertificateDer);
-end;
-
-function TFixedAesProvider.CertificateDnsNames(
-  const ACertificateDer: TBytes): TArray<string>;
-begin
-  Result := FInner.CertificateDnsNames(ACertificateDer);
-end;
-
-function TFixedAesProvider.CertificateIpAddresses(
-  const ACertificateDer: TBytes): TArray<TBytes>;
-begin
-  Result := FInner.CertificateIpAddresses(ACertificateDer);
-end;
-
-procedure TFixedAesProvider.ValidateCertificatePath(const AChain,
-  ATrustAnchors, AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
-  var AEffectiveChain: TArray<TBytes>);
-begin
-  FInner.ValidateCertificatePath(AChain, ATrustAnchors, AIntermediates,
-    AValidationTimeUtc, AEffectiveChain);
-end;
-
-function TFixedAesProvider.ValidateOcspStaple(const ALeafCert, AIssuerCert,
-  AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
-  out AStatus: TOcspStatus; out AThisUpdate, ANextUpdate: TDateTime): Boolean;
-begin
-  Result := FInner.ValidateOcspStaple(ALeafCert, AIssuerCert, AOcspResponseDer,
-    AValidationTimeUtc, AStatus, AThisUpdate, ANextUpdate);
-end;
-
-function TFixedAesProvider.BuildOcspRequest(const ALeafCert, AIssuerCert: TBytes;
-  out ARequestDer: TBytes): Boolean;
-begin
-  Result := FInner.BuildOcspRequest(ALeafCert, AIssuerCert, ARequestDer);
-end;
-
-function TFixedAesProvider.TryGetOcspResponderUrl(const ACert: TBytes;
-  out AUrl: string): Boolean;
-begin
-  Result := FInner.TryGetOcspResponderUrl(ACert, AUrl);
-end;
-
-function TFixedAesProvider.TryGetCrlDistributionPoints(const ACert: TBytes;
-  out AUrls: TArray<string>): Boolean;
-begin
-  Result := FInner.TryGetCrlDistributionPoints(ACert, AUrls);
-end;
-
-function TFixedAesProvider.CheckCrlRevocation(const ALeafCert, AIssuerCert,
-  ACrlDer: TBytes; out ARevoked: Boolean): Boolean;
-begin
-  Result := FInner.CheckCrlRevocation(ALeafCert, AIssuerCert, ACrlDer, ARevoked);
-end;
-
-function TFixedAesProvider.CertificatePeerInfo(const ACertificateDer: TBytes;
-  out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-begin
-  Result := FInner.CertificatePeerInfo(ACertificateDer, ASubject, AIssuer,
-    ACommonName, ASerialHex);
-end;
-
-function TFixedAesProvider.CertificateTlsFeatures(const ACert: TBytes;
-  out AFeatures: TArray<UInt16>): Boolean;
-begin
-  Result := FInner.CertificateTlsFeatures(ACert, AFeatures);
-end;
-
-function TFixedAesProvider.CertificateKeyUsagePermits(
-  const ACertificateDer: TBytes; AUsage: TCertKeyUsage;
-  out APermitted: Boolean): Boolean;
-begin
-  Result := FInner.CertificateKeyUsagePermits(ACertificateDer, AUsage, APermitted);
-end;
-
-function TFixedAesProvider.CertificateHasRsaPssKey(
-  const ACertificateDer: TBytes; out AIsRsaPss: Boolean): Boolean;
-begin
-  Result := FInner.CertificateHasRsaPssKey(ACertificateDer, AIsRsaPss);
-end;
-
-function TFixedAesProvider.CertificateKeyKind(const ACertificateDer: TBytes;
-  out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
-begin
-  Result := FInner.CertificateKeyKind(ACertificateDer, AKind, AEcNamedGroup);
-end;
-
-function TFixedAesProvider.CreateKeyAgreement(AName: TKeyAgreementAlgorithm): IKeyAgreement;
-begin
-  Result := FInner.CreateKeyAgreement(AName);
-end;
-
-function TFixedAesProvider.CreateKem(AName: TKemAlgorithm): IKem;
-begin
-  Result := FInner.CreateKem(AName);
-end;
-
-function TFixedAesProvider.HasHardwareAes: Boolean;
+function TFixedAesPrimitives.HasHardwareAes: Boolean;
 begin
   Result := FHasHardwareAes;
+end;
+
+{ TFixedAesProvider }
+
+constructor TFixedAesProvider.Create(const AInner: ICryptoProvider;
+  AHasHardwareAes: Boolean);
+var
+  LBuilder: ICryptoProviderBuilder;
+begin
+  inherited Create;
+  LBuilder := TCryptoProviderBuilder.Create;
+  FComposed := LBuilder
+    .WithPrimitives(TFixedAesPrimitives.Create(AInner.Primitives, AHasHardwareAes)
+      as ICryptoPrimitives)
+    .Build;
+end;
+
+function TFixedAesProvider.Primitives: ICryptoPrimitives;
+begin
+  Result := FComposed.Primitives;
+end;
+
+function TFixedAesProvider.Signing: ISigningCrypto;
+begin
+  Result := FComposed.Signing;
+end;
+
+function TFixedAesProvider.Certificates: ICertificateInspector;
+begin
+  Result := FComposed.Certificates;
+end;
+
+function TFixedAesProvider.PathValidation: ICertificatePathValidator;
+begin
+  Result := FComposed.PathValidation;
+end;
+
+function TFixedAesProvider.Revocation: IRevocationChecker;
+begin
+  Result := FComposed.Revocation;
 end;
 
 end.

--- a/TlsLib.Tests/src/MockTests.pas
+++ b/TlsLib.Tests/src/MockTests.pas
@@ -27,7 +27,6 @@ uses
 {$ENDIF FPC}
   TlpICryptoProvider,
   TlpCryptoAlgorithms,
-  TlpDefaultCryptoProvider,
   MockRandom,
   MockCryptoProvider,
   TlsLibTestBase;
@@ -69,12 +68,11 @@ var
   LProvider: ICryptoProvider;
   LReference: IRandom;
 begin
-  LProvider := TMockCryptoProvider.Create(TDefaultCryptoProvider.Create as ICryptoProvider,
-    TMockRandom.Create(7) as IRandom);
+  LProvider := TMockCryptoProvider.Create(TMockRandom.Create(7) as IRandom);
   LReference := TMockRandom.Create(7);
   // the provider hands back the injected deterministic stream
   CheckEqualBytes('injected random', LReference.GenerateBytes(16),
-    LProvider.GetRandom.GenerateBytes(16));
+    LProvider.Primitives.GetRandom.GenerateBytes(16));
 end;
 
 procedure TTestMocks.TestMockProviderDelegatesCrypto;
@@ -84,9 +82,8 @@ var
   LMsg: TBytes;
 begin
   // crypto is delegated to the inner real provider
-  LProvider := TMockCryptoProvider.Create(TDefaultCryptoProvider.Create as ICryptoProvider,
-    TMockRandom.Create(0) as IRandom);
-  LHash := LProvider.CreateHash(THashAlgorithm.SHA_256);
+  LProvider := TMockCryptoProvider.Create(TMockRandom.Create(0) as IRandom);
+  LHash := LProvider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LMsg := DecodeHex('616263'); // "abc"
   LHash.Update(LMsg, 0, System.Length(LMsg));
   CheckEqualBytes('delegated SHA-256(abc)',

--- a/TlsLib.Tests/src/NegotiationTests.pas
+++ b/TlsLib.Tests/src/NegotiationTests.pas
@@ -73,7 +73,7 @@ implementation
 function TTestNegotiation.PolicyWithAes(AHasHardwareAes: Boolean): INegotiationPolicy;
 begin
   Result := TNegotiationPolicy.CreateDefault(
-    TFixedAesProvider.Create(Provider, AHasHardwareAes));
+    TFixedAesProvider.Create(Provider, AHasHardwareAes) as ICryptoProvider);
 end;
 
 function TTestNegotiation.SelectSuiteRaises(const APolicy: INegotiationPolicy;

--- a/TlsLib.Tests/src/OcspStaplingTests.pas
+++ b/TlsLib.Tests/src/OcspStaplingTests.pas
@@ -174,8 +174,8 @@ var
   LSpki: TBytes;
   LHash: IHash;
 begin
-  LSpki := Provider.CertificatePublicKeyInfo(V('leaf_cert'));
-  LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+  LSpki := Provider.Certificates.PublicKeyInfo(V('leaf_cert'));
+  LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(LSpki, 0, System.Length(LSpki));
   Result := LHash.DoFinal;
 end;
@@ -185,8 +185,8 @@ var
   LSpki: TBytes;
   LHash: IHash;
 begin
-  LSpki := Provider.CertificatePublicKeyInfo(V('issuer_cert'));
-  LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+  LSpki := Provider.Certificates.PublicKeyInfo(V('issuer_cert'));
+  LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(LSpki, 0, System.Length(LSpki));
   Result := LHash.DoFinal;
 end;
@@ -221,7 +221,7 @@ var
   LStatus: TOcspStatus;
   LThis, LNext: TDateTime;
 begin
-  CheckTrue(Provider.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
+  CheckTrue(Provider.Revocation.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
     V('ocsp_good'), TDateTimeUtilities.ToUniversalTime(Now), LStatus, LThis, LNext),
     'an issuer-signed response about the leaf is authoritative');
   CheckEquals(Ord(TOcspStatus.Good), Ord(LStatus), 'the status is Good');
@@ -233,7 +233,7 @@ var
   LStatus: TOcspStatus;
   LThis, LNext: TDateTime;
 begin
-  CheckTrue(Provider.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
+  CheckTrue(Provider.Revocation.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
     V('ocsp_revoked'), TDateTimeUtilities.ToUniversalTime(Now), LStatus, LThis,
     LNext), 'a revoked response is authoritative');
   CheckEquals(Ord(TOcspStatus.Revoked), Ord(LStatus), 'the status is Revoked');
@@ -245,7 +245,7 @@ var
   LThis, LNext: TDateTime;
 begin
   // signed by an id-kp-OCSPSigning responder the issuer delegated to (RFC 6960 4.2.2.2)
-  CheckTrue(Provider.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
+  CheckTrue(Provider.Revocation.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
     V('ocsp_good_delegated'), TDateTimeUtilities.ToUniversalTime(Now), LStatus,
     LThis, LNext), 'a delegated responder is authoritative');
   CheckEquals(Ord(TOcspStatus.Good), Ord(LStatus), 'the status is Good');
@@ -257,7 +257,7 @@ var
   LThis, LNext: TDateTime;
 begin
   // signed by an unrelated CA the issuer never delegated to
-  CheckFalse(Provider.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
+  CheckFalse(Provider.Revocation.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
     V('ocsp_unauthorized'), TDateTimeUtilities.ToUniversalTime(Now), LStatus,
     LThis, LNext), 'an unauthorized signer leaves the status indeterminate');
 end;
@@ -268,7 +268,7 @@ var
   LThis, LNext: TDateTime;
 begin
   // the CertID names the real issuer, so it does not match an unrelated one
-  CheckFalse(Provider.ValidateOcspStaple(V('leaf_cert'), V('other_ca_cert'),
+  CheckFalse(Provider.Revocation.ValidateOcspStaple(V('leaf_cert'), V('other_ca_cert'),
     V('ocsp_good'), TDateTimeUtilities.ToUniversalTime(Now), LStatus, LThis, LNext),
     'a response whose CertID does not match the issuer is indeterminate');
 end;
@@ -278,7 +278,7 @@ var
   LStatus: TOcspStatus;
   LThis, LNext: TDateTime;
 begin
-  CheckFalse(Provider.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
+  CheckFalse(Provider.Revocation.ValidateOcspStaple(V('leaf_cert'), V('issuer_cert'),
     TBytes.Create(1, 2, 3, 4), TDateTimeUtilities.ToUniversalTime(Now), LStatus,
     LThis, LNext), 'an unparseable response returns False, never raises');
 end;
@@ -287,7 +287,7 @@ procedure TTestOcspStapling.TestTlsFeaturesAbsentIsEmpty;
 var
   LFeatures: TArray<UInt16>;
 begin
-  CheckTrue(Provider.CertificateTlsFeatures(V('leaf_cert'), LFeatures),
+  CheckTrue(Provider.Certificates.TlsFeatures(V('leaf_cert'), LFeatures),
     'a certificate without the TLS Feature extension is well formed');
   CheckEquals(0, System.Length(LFeatures), 'it carries no features');
 end;
@@ -296,7 +296,7 @@ procedure TTestOcspStapling.TestTlsFeaturesMustStaple;
 var
   LFeatures: TArray<UInt16>;
 begin
-  CheckTrue(Provider.CertificateTlsFeatures(V('muststaple_leaf_cert'), LFeatures),
+  CheckTrue(Provider.Certificates.TlsFeatures(V('muststaple_leaf_cert'), LFeatures),
     'a well-formed TLS Feature extension parses');
   CheckEquals(1, System.Length(LFeatures), 'it lists one feature');
   CheckEquals(5, LFeatures[0], 'the feature is status_request (5)');
@@ -307,7 +307,7 @@ var
   LFeatures: TArray<UInt16>;
 begin
   // the extension value is a bare INTEGER, not a SEQUENCE OF INTEGER
-  CheckFalse(Provider.CertificateTlsFeatures(V('badfeature_leaf_cert'), LFeatures),
+  CheckFalse(Provider.Certificates.TlsFeatures(V('badfeature_leaf_cert'), LFeatures),
     'a non-SEQUENCE TLS Feature value is rejected as malformed');
 end;
 

--- a/TlsLib.Tests/src/Pkcs12ImportTests.pas
+++ b/TlsLib.Tests/src/Pkcs12ImportTests.pas
@@ -100,12 +100,12 @@ var
 begin
   LScheme := ACredential.PrivateKey.CapableSchemes[0];
   LMessage := DecodeHex(SMessageHex);
-  LSigner := Provider.CreateSignatureSigner(LScheme, ACredential.PrivateKey);
+  LSigner := Provider.Signing.CreateSignatureSigner(LScheme, ACredential.PrivateKey);
   LSigner.Update(LMessage, 0, System.Length(LMessage));
   LSignature := LSigner.Sign;
 
-  LSpki := Provider.CertificatePublicKeyInfo(ACredential.CertificateChain[0]);
-  LVerifier := Provider.CreateSignatureVerifier(LScheme, LSpki);
+  LSpki := Provider.Certificates.PublicKeyInfo(ACredential.CertificateChain[0]);
+  LVerifier := Provider.Signing.CreateSignatureVerifier(LScheme, LSpki);
   LVerifier.Update(LMessage, 0, System.Length(LMessage));
   Result := LVerifier.Verify(LSignature);
 end;
@@ -114,7 +114,7 @@ procedure TTestPkcs12Import.TestRsaPfxImportsToCredential;
 var
   LCredential: TTlsCredential;
 begin
-  LCredential := Provider.ImportPkcs12(Blob('rsa_pfx'), SPassword);
+  LCredential := Provider.Signing.ImportPkcs12(Blob('rsa_pfx'), SPassword);
   CheckEquals(1, System.Length(LCredential.CertificateChain),
     'a single-leaf .pfx yields a one-certificate chain');
   CheckTrue(TSignatureScheme.RSA_PSS_RSAE_SHA256 =
@@ -127,7 +127,7 @@ procedure TTestPkcs12Import.TestEcPfxImportsToCredential;
 var
   LCredential: TTlsCredential;
 begin
-  LCredential := Provider.ImportPkcs12(Blob('ec_pfx'), SPassword);
+  LCredential := Provider.Signing.ImportPkcs12(Blob('ec_pfx'), SPassword);
   CheckEquals(1, System.Length(LCredential.CertificateChain),
     'a single-leaf EC .pfx yields a one-certificate chain');
   CheckTrue(TSignatureScheme.ECDSA_SECP256R1_SHA256 =
@@ -143,7 +143,7 @@ var
   LAlert: TTlsAlertDescription;
 begin
   // the store holds a leaf signed by a test CA plus that CA certificate
-  LCredential := Provider.ImportPkcs12(Blob('chain_pfx'), SPassword);
+  LCredential := Provider.Signing.ImportPkcs12(Blob('chain_pfx'), SPassword);
   CheckEquals(2, System.Length(LCredential.CertificateChain),
     'the chain .pfx yields leaf + CA');
   CheckTrue(KeyPairsLeaf(LCredential),
@@ -165,7 +165,7 @@ begin
   // the same RSA leaf stored under a different PBE profile (PBES2 AES-128-CBC bags + a
   // SHA-1 integrity MAC, versus rsa_pfx's AES-256-CBC + SHA-256) imports the same way:
   // import is driven by the store's declared algorithms, not pinned to one profile
-  LCredential := Provider.ImportPkcs12(Blob('rsa_altalg_pfx'), SPassword);
+  LCredential := Provider.Signing.ImportPkcs12(Blob('rsa_altalg_pfx'), SPassword);
   CheckEquals(1, System.Length(LCredential.CertificateChain),
     'the alternate-profile .pfx yields the leaf');
   CheckTrue(KeyPairsLeaf(LCredential),
@@ -181,7 +181,7 @@ begin
   // alias order is not stable, so it must be rejected rather than binding an arbitrary one
   LRaised := False;
   try
-    LCredential := Provider.ImportPkcs12(Blob('multikey_pfx'), SPassword);
+    LCredential := Provider.Signing.ImportPkcs12(Blob('multikey_pfx'), SPassword);
     CheckEquals(0, System.Length(LCredential.CertificateChain),
       'unreachable: a multi-key store must not return a credential');
   except
@@ -199,7 +199,7 @@ begin
   LRaised := False;
   try
     // a bad-MAC/wrong-password store must raise a typed TlsLib exception, not a Clp* one
-    LCredential := Provider.ImportPkcs12(Blob('rsa_pfx'), 'not-the-password');
+    LCredential := Provider.Signing.ImportPkcs12(Blob('rsa_pfx'), 'not-the-password');
     CheckEquals(0, System.Length(LCredential.CertificateChain),
       'unreachable: a wrong password must not return a credential');
   except
@@ -217,7 +217,7 @@ begin
   LRaised := False;
   try
     // a truncated/garbage blob must fail closed with a typed exception, never an AV
-    LCredential := Provider.ImportPkcs12(
+    LCredential := Provider.Signing.ImportPkcs12(
       DecodeHex('3082deadbeefdeadbeefdeadbeef'), SPassword);
     CheckEquals(0, System.Length(LCredential.CertificateChain),
       'unreachable: a malformed blob must not return a credential');

--- a/TlsLib.Tests/src/ProviderTests.pas
+++ b/TlsLib.Tests/src/ProviderTests.pas
@@ -96,7 +96,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/Digest/Sha2.txt');
   try
-    LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+    LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
     CheckEquals(32, LHash.HashSize, 'SHA-256 size');
     LMsg := DecodeHex(LVec.Values['sha256_msg']);
     LHash.Update(LMsg, 0, System.Length(LMsg));
@@ -115,7 +115,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/Digest/Sha2.txt');
   try
-    LHash := Provider.CreateHash(THashAlgorithm.SHA_384);
+    LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_384);
     CheckEquals(48, LHash.HashSize, 'SHA-384 size');
     LMsg := DecodeHex(LVec.Values['sha384_msg']);
     LHash.Update(LMsg, 0, System.Length(LMsg));
@@ -131,7 +131,7 @@ var
   LHash, LClone: IHash;
 begin
   // both should finish as SHA-256("abc")
-  LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+  LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(DecodeHex('61'), 0, 1); // 'a'
   LClone := LHash.Clone;
   LHash.Update(DecodeHex('6263'), 0, 2); // 'bc'
@@ -147,7 +147,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/Hmac/HmacSha256.txt');
   try
-    LHmac := Provider.CreateHmac(THashAlgorithm.SHA_256);
+    LHmac := Provider.Primitives.CreateHmac(THashAlgorithm.SHA_256);
     LHmac.Init(TSecretBuffer.From(DecodeHex(LVec.Values['key'])));
     LData := DecodeHex(LVec.Values['data']);
     LHmac.Update(LData, 0, System.Length(LData));
@@ -165,7 +165,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/Hkdf/HkdfSha256.txt');
   try
-    LHkdf := Provider.CreateHkdf(THashAlgorithm.SHA_256);
+    LHkdf := Provider.Primitives.CreateHkdf(THashAlgorithm.SHA_256);
     LPrk := LHkdf.Extract(DecodeHex(LVec.Values['salt']),
       TSecretBuffer.From(DecodeHex(LVec.Values['ikm'])));
     CheckEqualBytes('HKDF-Extract PRK', DecodeHex(LVec.Values['prk']),
@@ -187,7 +187,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/Gcm/Aes128Gcm.txt');
   try
-    LAead := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+    LAead := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
     LAead.Init(TSecretBuffer.From(DecodeHex(LVec.Values['key'])));
     LNonce := DecodeHex(LVec.Values['nonce']);
     LAad := DecodeHex(LVec.Values['aad']);
@@ -210,7 +210,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/Gcm/Aes256Gcm.txt');
   try
-    LAead := Provider.CreateAead(TAeadAlgorithm.AES_256_GCM);
+    LAead := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_256_GCM);
     CheckEquals(32, LAead.KeySize, 'AES-256-GCM key size');
     LAead.Init(TSecretBuffer.From(DecodeHex(LVec.Values['key'])));
     LNonce := DecodeHex(LVec.Values['nonce']);
@@ -231,7 +231,7 @@ var
   LAead: IAead;
   LNonce, LAad, LPlain, LSealed: TBytes;
 begin
-  LAead := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+  LAead := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
   LAead.Init(TSecretBuffer.From(DecodeHex('000102030405060708090a0b0c0d0e0f')));
   LNonce := DecodeHex('101112131415161718191a1b');
   LAad := DecodeHex('cafe');
@@ -250,7 +250,7 @@ var
 begin
   LVec := LoadVectorFields('Crypto/ChaCha/ChaCha20Poly1305.txt');
   try
-    LAead := Provider.CreateAead(TAeadAlgorithm.CHACHA20_POLY1305);
+    LAead := Provider.Primitives.CreateAead(TAeadAlgorithm.CHACHA20_POLY1305);
     LAead.Init(TSecretBuffer.From(DecodeHex(LVec.Values['key'])));
     LNonce := DecodeHex(LVec.Values['nonce']);
     LAad := DecodeHex(LVec.Values['aad']);
@@ -271,7 +271,7 @@ var
   LNonce, LAad, LSealed: TBytes;
   LRaised: Boolean;
 begin
-  LAead := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+  LAead := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
   LAead.Init(TSecretBuffer.From(DecodeHex('000102030405060708090a0b0c0d0e0f')));
   LNonce := DecodeHex('101112131415161718191a1b');
   LAad := DecodeHex('');
@@ -321,7 +321,7 @@ var
 begin
   LKeyBytes := PatternBytes(AKeySize, 99);
   LKey := TSecretBuffer.From(LKeyBytes);
-  LReused := Provider.CreateAead(AAlgorithm);
+  LReused := Provider.Primitives.CreateAead(AAlgorithm);
   LReused.Init(LKey);
   LNonceSize := LReused.NonceSize;
   // a long stream: cycle the length matrix many times so the reused cipher is
@@ -342,13 +342,13 @@ begin
       LAad := PatternBytes(5 + (LRecord mod 11), LRecord + 3);
     LNonce := CounterNonce(LNonceSize, LRecord);
     // reference: a fresh adapter per record reproduces the old create-per-record path
-    LFresh := Provider.CreateAead(AAlgorithm);
+    LFresh := Provider.Primitives.CreateAead(AAlgorithm);
     LFresh.Init(LKey);
     LViaFresh := LFresh.Seal(LNonce, LAad, LPlain);
     LViaReused := LReused.Seal(LNonce, LAad, LPlain);
     CheckEqualBytes('reused seal == fresh seal', LViaFresh, LViaReused);
     // a fresh opener must round-trip the reused adapter's output
-    LOpener := Provider.CreateAead(AAlgorithm);
+    LOpener := Provider.Primitives.CreateAead(AAlgorithm);
     LOpener.Init(LKey);
     CheckEqualBytes('open round-trips reused seal', LPlain,
       LOpener.Open(LNonce, LAad, LViaReused));
@@ -382,9 +382,9 @@ begin
   for LEpoch := 0 to 1 do
   begin
     LKey := TSecretBuffer.From(PatternBytes(16, 40 + LEpoch));
-    LSender := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+    LSender := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
     LSender.Init(LKey);
-    LReceiver := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+    LReceiver := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
     LReceiver.Init(LKey);
     for LRecord := 0 to 255 do
     begin
@@ -406,7 +406,7 @@ var
 begin
   // the reused live cipher lets CL4P's encrypt-side guard catch a forced
   // (key, nonce) repeat - a net the old create-per-record adapter never had
-  LAead := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+  LAead := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
   LAead.Init(TSecretBuffer.From(DecodeHex('000102030405060708090a0b0c0d0e0f')));
   LNonce := DecodeHex('101112131415161718191a1b');
   LAad := nil;
@@ -426,7 +426,7 @@ var
   LRandom: IRandom;
   LA, LB: TBytes;
 begin
-  LRandom := Provider.GetRandom;
+  LRandom := Provider.Primitives.GetRandom;
   LA := LRandom.GenerateBytes(32);
   LB := LRandom.GenerateBytes(32);
   CheckEquals(32, System.Length(LA), 'length');
@@ -439,7 +439,7 @@ var
   LValue: Boolean;
 begin
   // the contract is only that it returns a Boolean without throwing
-  LValue := Provider.HasHardwareAes;
+  LValue := Provider.Primitives.HasHardwareAes;
   CheckTrue((LValue = True) or (LValue = False), 'HasHardwareAes is a Boolean');
 end;
 

--- a/TlsLib.Tests/src/RecordLayerTests.pas
+++ b/TlsLib.Tests/src/RecordLayerTests.pas
@@ -72,7 +72,7 @@ implementation
 function TTestRecordLayer.MakeTls13(const AKey, AIv: TBytes): IRecordProtection;
 begin
   Result := TTls13RecordProtection.Create(TSecretBuffer.From(AKey),
-    TSecretBuffer.From(AIv), Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    TSecretBuffer.From(AIv), Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
 end;
 
 function TTestRecordLayer.DrainOne(const ALayer: TRecordLayer;

--- a/TlsLib.Tests/src/RecordProtectionTests.pas
+++ b/TlsLib.Tests/src/RecordProtectionTests.pas
@@ -69,14 +69,14 @@ function TTestRecordProtection.MakeTls13(const AKey, AIv: TBytes;
   AAlgorithm: TAeadAlgorithm): IRecordProtection;
 begin
   Result := TTls13RecordProtection.Create(TSecretBuffer.From(AKey),
-    TSecretBuffer.From(AIv), Provider.CreateAead(AAlgorithm));
+    TSecretBuffer.From(AIv), Provider.Primitives.CreateAead(AAlgorithm));
 end;
 
 function TTestRecordProtection.MakeTls12(const AKey, ASalt: TBytes;
   AAlgorithm: TAeadAlgorithm): IRecordProtection;
 begin
   Result := TTls12RecordProtection.Create(TSecretBuffer.From(AKey),
-    TSecretBuffer.From(ASalt), Provider.CreateAead(AAlgorithm));
+    TSecretBuffer.From(ASalt), Provider.Primitives.CreateAead(AAlgorithm));
 end;
 
 function TTestRecordProtection.BigEndian8(AValue: UInt64): TBytes;
@@ -342,7 +342,7 @@ begin
     finally
       LAadWriter.Free;
     end;
-    LAeadRef := Provider.CreateAead(TAeadAlgorithm.AES_128_GCM);
+    LAeadRef := Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM);
     LAeadRef.Init(TSecretBuffer.From(LKey));
     LCipher := LAeadRef.Seal(LGcmNonce, LAad, LPlain);
     LBody := ConcatBytes(LExplicitNonce, LCipher);
@@ -404,7 +404,7 @@ begin
   finally
     LAadWriter.Free;
   end;
-  LAeadRef := Provider.CreateAead(TAeadAlgorithm.CHACHA20_POLY1305);
+  LAeadRef := Provider.Primitives.CreateAead(TAeadAlgorithm.CHACHA20_POLY1305);
   LAeadRef.Init(TSecretBuffer.From(LKey));
   LCipher := LAeadRef.Seal(LNonce, LAad, LPlain);
   // no explicit nonce: the record body is exactly the ciphertext

--- a/TlsLib.Tests/src/ScheduleInstallTests.pas
+++ b/TlsLib.Tests/src/ScheduleInstallTests.pas
@@ -105,7 +105,7 @@ begin
     LSched.DeriveEpochSecrets(TTlsEpoch.Handshake, DecodeHex(LVec.Values['hash_ch_sh']));
     LKeys := LSched.TrafficKeys(TTlsEpoch.Handshake, TTlsDirection.ClientWrite);
     LProt := TRecordProtectionFactory.Build(TTlsVersion.Tls13, LKeys,
-      Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+      Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
 
     LEngineObj := TTlsEngine.Create;
     LEngine := LEngineObj;
@@ -153,9 +153,9 @@ begin
   LKeys := LSched.TrafficKeys(TTlsEpoch.Application, TTlsDirection.ClientWrite);
 
   LSender := TRecordProtectionFactory.Build(TTlsVersion.Tls12, LKeys,
-    Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
   LReceiver := TRecordProtectionFactory.Build(TTlsVersion.Tls12, LKeys,
-    Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
 
   LEngineObj := TTlsEngine.Create;
   LEngine := LEngineObj;
@@ -185,7 +185,7 @@ begin
   try
     // 0x0301 is a legacy record version, never a negotiable protocol
     TRecordProtectionFactory.Build(TTlsVersion.LegacyRecordInitial, LKeys,
-      Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+      Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
   except
     on E: EArgumentTlsLibException do
       LRaised := True;

--- a/TlsLib.Tests/src/SessionStoreTests.pas
+++ b/TlsLib.Tests/src/SessionStoreTests.pas
@@ -191,7 +191,7 @@ var
   LHandle: TBytes;
   LTaken: IResumableSession;
 begin
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LHandle := LStore.Put(MakeSession(Tag($22, 8)));
   CheckTrue(System.Length(LHandle) > 0, 'Put returns an opaque handle');
   CheckTrue(LStore.Take(LHandle, LTaken), 'the handle resolves');
@@ -205,7 +205,7 @@ var
   LId: TBytes;
   LTaken: IResumableSession;
 begin
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LId := Tag($33, 32);
   LStore.PutWithId(LId, MakeSession(Tag($44, 4)));
   CheckTrue(LStore.Take(LId, LTaken), 'a caller-chosen id resolves');
@@ -217,7 +217,7 @@ var
   LStore: ISessionStore;
   LI: Int32;
 begin
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom, 3);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom, 3);
   for LI := 0 to 9 do
     LStore.Put(MakeSession(Tag(Byte(LI), 4)));
   CheckEquals(3, LStore.Count, 'the store never grows past its cap');
@@ -236,7 +236,7 @@ begin
   // the live count tiny, so ordinary eviction rarely fires and the order structure must be
   // compacted instead of accumulating one dead entry per ticket, RFC 8446 18.6).
   // Compaction must preserve still-live entries and single-use semantics.
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom, 8);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom, 8);
   for LI := 0 to 4 do
     LLive[LI] := LStore.Put(MakeSession(Tag(Byte($A0 + LI), 8)));
   for LI := 0 to 999 do
@@ -260,7 +260,7 @@ var
   LName: TBytes;
   LKey, LFound: ISecretBuffer;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   CheckTrue(LStek.CurrentKey(LName, LKey), 'a fresh manager has a current key');
   CheckEquals(LStek.KeyNameLength, System.Length(LName), 'the key name is fixed length');
   CheckTrue(LStek.KeyByName(LName, LFound), 'the current key is found by name');
@@ -274,7 +274,7 @@ var
   LKey: ISecretBuffer;
   LOld: ISecretBuffer;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LStek.CurrentKey(LName1, LKey);
   LStek.Rotate;
   LStek.CurrentKey(LName2, LKey);
@@ -290,7 +290,7 @@ var
   LKey, LFound: ISecretBuffer;
   LI: Int32;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom, 2);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom, 2);
   LStek.CurrentKey(LFirst, LKey);
   for LI := 0 to 2 do
     LStek.Rotate; // push the first key out of a 2-wide window
@@ -306,7 +306,7 @@ var
   LName: TBytes;
   LKey, LCurrent: ISecretBuffer;
 begin
-  LConcrete := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LConcrete := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LStek := LConcrete; // the interface reference governs lifetime
   LName := Tag($55, 16);
   LKey := TSecretBuffer.From(Tag($66, 32));
@@ -327,7 +327,7 @@ begin
   LClockObj := TAdjustableClock.Create(1000000);
   LClock := LClockObj; // the interface reference governs lifetime
   // a 10-second auto-rotation interval driven by the injected clock
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom, 0, LClock, 10);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom, 0, LClock, 10);
   LStek.CurrentKey(LName1, LKey);
   LClockObj.Advance(5000); // within the interval: the current key is unchanged
   LStek.CurrentKey(LName2, LKey);

--- a/TlsLib.Tests/src/SignatureTests.pas
+++ b/TlsLib.Tests/src/SignatureTests.pas
@@ -81,11 +81,11 @@ var
   LMessage, LSignature: TBytes;
 begin
   LMessage := DecodeHex('54686520717569636b2062726f776e20666f78'); // "The quick brown fox"
-  LSigner := Provider.CreateSignatureSigner(AScheme, Provider.ImportSigningKey(APrivDer));
+  LSigner := Provider.Signing.CreateSignatureSigner(AScheme, Provider.Signing.ImportSigningKey(APrivDer));
   LSigner.Update(LMessage, 0, System.Length(LMessage));
   LSignature := LSigner.Sign;
 
-  LVerifier := Provider.CreateSignatureVerifier(AScheme, APubDer);
+  LVerifier := Provider.Signing.CreateSignatureVerifier(AScheme, APubDer);
   LVerifier.Update(LMessage, 0, System.Length(LMessage));
   Result := LVerifier.Verify(LSignature);
 end;
@@ -98,14 +98,14 @@ var
   LMessage, LSignature: TBytes;
 begin
   LMessage := DecodeHex('54686520717569636b2062726f776e20666f78');
-  LSigner := Provider.CreateSignatureSigner(AScheme, Provider.ImportSigningKey(APrivDer));
+  LSigner := Provider.Signing.CreateSignatureSigner(AScheme, Provider.Signing.ImportSigningKey(APrivDer));
   LSigner.Update(LMessage, 0, System.Length(LMessage));
   LSignature := LSigner.Sign;
   // flip a signature byte
   LSignature[System.Length(LSignature) - 1] :=
     Byte(LSignature[System.Length(LSignature) - 1] xor $01);
 
-  LVerifier := Provider.CreateSignatureVerifier(AScheme, APubDer);
+  LVerifier := Provider.Signing.CreateSignatureVerifier(AScheme, APubDer);
   LVerifier.Update(LMessage, 0, System.Length(LMessage));
   Result := not LVerifier.Verify(LSignature);
 end;
@@ -116,7 +116,7 @@ var
   LMsg: TBytes;
   LI: Int32;
 begin
-  LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+  LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   for LI := 0 to High(ANames) do
   begin
     LMsg := DecodeHex(FHs.Values[ANames[LI]]);
@@ -135,7 +135,7 @@ begin
   LFramed := DecodeHex(FHs.Values['certificate']);
   LBody := System.Copy(LFramed, 4, System.Length(LFramed) - 4);
   LCert := THandshakeMessages.DecodeCertificate(LBody);
-  Result := Provider.CertificatePublicKeyInfo(LCert.Entries[0].CertData);
+  Result := Provider.Certificates.PublicKeyInfo(LCert.Entries[0].CertData);
 end;
 
 function TTestSignature.CertVerifySignature: TBytes;
@@ -197,7 +197,7 @@ begin
   // the genuine RFC 8448 server CertificateVerify over the real transcript
   LContent := ServerCertVerifyContent(HashOf(['client_hello', 'server_hello',
     'encrypted_ext', 'certificate']));
-  LVerifier := Provider.CreateSignatureVerifier(TSignatureScheme.RSA_PSS_RSAE_SHA256, Rfc8448LeafSpki);
+  LVerifier := Provider.Signing.CreateSignatureVerifier(TSignatureScheme.RSA_PSS_RSAE_SHA256, Rfc8448LeafSpki);
   LVerifier.Update(LContent, 0, System.Length(LContent));
   CheckTrue(LVerifier.Verify(CertVerifySignature),
     'the genuine RFC 8448 server CertificateVerify verifies against the leaf key');
@@ -212,7 +212,7 @@ begin
   LHash := HashOf(['client_hello', 'server_hello', 'encrypted_ext', 'certificate']);
   LHash[0] := Byte(LHash[0] xor $01);
   LContent := ServerCertVerifyContent(LHash);
-  LVerifier := Provider.CreateSignatureVerifier(TSignatureScheme.RSA_PSS_RSAE_SHA256, Rfc8448LeafSpki);
+  LVerifier := Provider.Signing.CreateSignatureVerifier(TSignatureScheme.RSA_PSS_RSAE_SHA256, Rfc8448LeafSpki);
   LVerifier.Update(LContent, 0, System.Length(LContent));
   CheckFalse(LVerifier.Verify(CertVerifySignature),
     'the signature does not verify over a different transcript');

--- a/TlsLib.Tests/src/SystemTrustTests.pas
+++ b/TlsLib.Tests/src/SystemTrustTests.pas
@@ -345,7 +345,7 @@ begin
   if not HarvestOrSkip(LRoots) then
     Exit;
   for LI := 0 to System.Length(LRoots) - 1 do
-    CheckTrue(FProvider.IsWellFormedCertificate(LRoots[LI]),
+    CheckTrue(FProvider.Certificates.IsWellFormed(LRoots[LI]),
       Format('%s harvested root #%d is a well-formed certificate', [PlatformName, LI]));
 end;
 

--- a/TlsLib.Tests/src/Tls12DualVersionTests.pas
+++ b/TlsLib.Tests/src/Tls12DualVersionTests.pas
@@ -134,7 +134,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;
@@ -216,7 +216,7 @@ begin
   Result.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   Result.Group := TNamedGroups.CreateX25519(Provider);
   Result.ServerRandom := Filled($22, 32);
-  Result.CookieSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  Result.CookieSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
   Result.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
 end;
 

--- a/TlsLib.Tests/src/Tls12KeyScheduleTests.pas
+++ b/TlsLib.Tests/src/Tls12KeyScheduleTests.pas
@@ -101,9 +101,9 @@ begin
   // the client write (key, salt) must drive TLS 1.2 AEAD record protection
   LKeys := LSched.TrafficKeys(TTlsEpoch.Application, TTlsDirection.ClientWrite);
   LSender := TTls12RecordProtection.Create(LKeys.Key, LKeys.Iv,
-    Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
   LReceiver := TTls12RecordProtection.Create(LKeys.Key, LKeys.Iv,
-    Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
   LPlain := DecodeHex('141516171819');
   LRecord := LSender.Protect(TTlsContentType.ApplicationData, LPlain, 0,
     System.Length(LPlain));

--- a/TlsLib.Tests/src/Tls12LoopbackTests.pas
+++ b/TlsLib.Tests/src/Tls12LoopbackTests.pas
@@ -127,7 +127,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;
@@ -212,7 +212,7 @@ begin
   LCred := Default(TTlsCredential);
   LCred.CertificateChain := TArray<TBytes>.Create(
     OcspField('leaf_cert'), OcspField('issuer_cert'));
-  LCred.PrivateKey := Provider.ImportSigningKey(OcspField('leaf_key'));
+  LCred.PrivateKey := Provider.Signing.ImportSigningKey(OcspField('leaf_key'));
   LCred.OcspStaple := AStaple;
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(LCred);
   Result := TTlsEngine.CreateConfigured(

--- a/TlsLib.Tests/src/Tls12ResumptionTests.pas
+++ b/TlsLib.Tests/src/Tls12ResumptionTests.pas
@@ -127,7 +127,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;
@@ -152,7 +152,7 @@ begin
   LParams.OfferedSchemes := TArray<UInt16>.Create(
     TSignatureSchemes.EcdsaSecp256r1Sha256);
   LParams.OfferedVersions := TArray<UInt16>.Create(TlsWireVersionTls12);
-  LParams.ClientRandom := Provider.GetRandom.GenerateBytes(32);
+  LParams.ClientRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
   LParams.OfferExtendedMasterSecret := AOfferEms;
   LParams.CertificateVerifier := TCertificateVerifier.Create(Provider, TSystemClock.Create as ITlsClock,
     TTrustAnchorStore.Create(TArray<TBytes>.Create(TestRootCertificate))
@@ -178,8 +178,8 @@ begin
     as ITrustAnchorStore, True) as ICertificateVerifier;
   // the dispatcher sends one unified ClientHello, so both sub-machines must share the same
   // client_random and legacy_session_id (the abbreviated Finished MAC binds them)
-  LRandom := Provider.GetRandom.GenerateBytes(32);
-  LSessionId := Provider.GetRandom.GenerateBytes(32);
+  LRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
+  LSessionId := Provider.Primitives.GetRandom.GenerateBytes(32);
 
   L13 := Default(TClientHandshakeParams);
   L13.Clock := TSystemClock.Create;
@@ -241,7 +241,7 @@ begin
   LParams.CipherSuites := TCipherSuiteRegistry.CreateDualVersion(Provider);
   LParams.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   LParams.Group := TNamedGroups.CreateX25519(Provider);
-  LParams.ServerRandom := Provider.GetRandom.GenerateBytes(32);
+  LParams.ServerRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
   if AWithCredential then
     LParams.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
   LParams.SessionStore := AStore;
@@ -383,7 +383,7 @@ function TTestTls12Resumption.MakeTicketSession(const ATicket: TBytes;
   AExtendedMasterSecret: Boolean): IResumableSession;
 begin
   Result := TResumableSession.CreateTls12(TlsSuite, THashAlgorithm.SHA_256,
-    TSecretBuffer.From(Provider.GetRandom.GenerateBytes(48)), nil, ATicket,
+    TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(48)), nil, ATicket,
     AExtendedMasterSecret, '', '', 7200, 0, UInt64(TDateTimeUtilities.CurrentUnixMs));
 end;
 
@@ -404,7 +404,7 @@ var
 begin
   // a store (no STEK) drives session-id resumption (RFC 5246 7.3)
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
 
   LClient := NewClient(LCache, True);
   LServer := NewServer(LStore, nil, 7200, True);
@@ -434,7 +434,7 @@ var
   LClient, LServer: ITlsEngine;
 begin
   // a STEK (no store) drives stateless RFC 5077 ticket resumption
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   LClient := NewClient(LCache, True);
@@ -462,7 +462,7 @@ var
 begin
   // a session established with Extended Master Secret resumes only when the client
   // re-offers EMS; the abbreviated completion proves the EMS state round-tripped
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   LClient := NewClient(LCache, True);
@@ -488,7 +488,7 @@ begin
   // a session established WITHOUT EMS must resume without the client offering EMS on the
   // resumption ClientHello, or the server would decline (RFC 7627 5.3); an abbreviated
   // completion proves the client aligned its EMS offer to the cached session
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   LClient := NewClient(LCache, False);
@@ -513,7 +513,7 @@ var
 begin
   // a zero-lifetime ticket is expired the instant it is sealed; the resuming server must
   // reject it on freshness and complete a full handshake instead
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   LClient := NewClient(LCache, True);
@@ -539,10 +539,10 @@ var
 begin
   // the client presents a ticket that is not a valid STEK seal; the server cannot open it
   // and completes a full handshake
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
   LCache.Store(ServerHost, ServerHost,
-    MakeTicketSession(Provider.GetRandom.GenerateBytes(64), False));
+    MakeTicketSession(Provider.Primitives.GetRandom.GenerateBytes(64), False));
 
   LClient := NewClient(LCache, True);
   LServer := NewServer(nil, LStek, 7200, True);
@@ -560,7 +560,7 @@ var
 begin
   // with no client cache the client never offers a session id or ticket, so even a
   // store-backed server runs a full handshake
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LClient := NewClient(nil, True);
   LServer := NewServer(LStore, nil, 7200, True);
   CheckTrue(DriveObservingServerCert(LClient, LServer),
@@ -577,7 +577,7 @@ var
   LClient, LServer: ITlsEngine;
 begin
   LCache := TInMemorySessionCache.Create;
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
 
   // connection 1: a dual-version client (offers 1.3 + 1.2) meets a 1.2-only server, so it
   // negotiates 1.2 in full and caches the issued 1.2 session
@@ -611,12 +611,12 @@ begin
   // the 1.2 cross-host resumption guard: a session issued while serving one host must not resume
   // a client that requests another (RFC 6066 3). The client always requests ServerHost, so the
   // server-stored session carries the issuing host the guard checks
-  LIdentity := Provider.GetRandom.GenerateBytes(32);
-  LSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(48));
+  LIdentity := Provider.Primitives.GetRandom.GenerateBytes(32);
+  LSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(48));
 
   // control: issued under the requested host -> resumes (abbreviated, no Certificate)
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost + ':443', ServerHost, MakeStoredSession(LIdentity, LSecret, ServerHost));
   LStore.PutWithId(LIdentity, MakeStoredSession(LIdentity, LSecret, ServerHost));
   LClient := NewClient(LCache, True);
@@ -628,7 +628,7 @@ begin
   // guarded: issued under a different host -> the credentialed server ignores the session id and
   // runs a full handshake (Certificate sent) instead of resuming under the wrong identity
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost + ':443', ServerHost, MakeStoredSession(LIdentity, LSecret, ServerHost));
   LStore.PutWithId(LIdentity, MakeStoredSession(LIdentity, LSecret, 'other.example'));
   LClient := NewClient(LCache, True);

--- a/TlsLib.Tests/src/Tls13KeyScheduleTests.pas
+++ b/TlsLib.Tests/src/Tls13KeyScheduleTests.pas
@@ -123,9 +123,9 @@ var
 begin
   // recompute the RFC 8448 secret tree through the public HKDF seam and pin every
   // node against the published bytes - no reaching into the schedule's internals
-  LHkdf := Provider.CreateHkdf(THashAlgorithm.SHA_256);
+  LHkdf := Provider.Primitives.CreateHkdf(THashAlgorithm.SHA_256);
   LZeros := TSecretBuffer.Allocate(32);
-  LEmptyHash := Provider.CreateHash(THashAlgorithm.SHA_256).DoFinal;
+  LEmptyHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256).DoFinal;
 
   LEarly := LHkdf.Extract(nil, LZeros); // 0-PSK: salt and IKM are HashLen zeros
   CheckEqualBytes('early secret', Bytes('early_secret'), ToBytes(LEarly));
@@ -227,7 +227,7 @@ begin
   // the schedule-derived client handshake keys must decrypt the RFC 8448 record
   LKeys := LSched.TrafficKeys(TTlsEpoch.Handshake, TTlsDirection.ClientWrite);
   LProt := TTls13RecordProtection.Create(LKeys.Key, LKeys.Iv,
-    Provider.CreateAead(TAeadAlgorithm.AES_128_GCM));
+    Provider.Primitives.CreateAead(TAeadAlgorithm.AES_128_GCM));
   LRec := LoadVectorFields('Rfc8448/Tls13RecordFinished.txt');
   try
     LRecord := DecodeHex(LRec.Values['record']);
@@ -293,7 +293,7 @@ var
 begin
   LPsk := TSecretBuffer.From(DecodeHex('AABBCCDDEEFF00112233445566778899'));
   LSched := NewResumptionSchedule(LPsk, nil);
-  LTruncatedHash := Provider.CreateHash(THashAlgorithm.SHA_256).DoFinal;
+  LTruncatedHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256).DoFinal;
   LBinder := LSched.ComputeBinder(TPskBinderKind.Resumption, LTruncatedHash);
   CheckTrue(LSched.VerifyBinder(TPskBinderKind.Resumption, LTruncatedHash, LBinder),
     'a genuine binder verifies');
@@ -314,7 +314,7 @@ begin
   LPsk := TSecretBuffer.From(DecodeHex('1122334455667788990011223344556677889900AABBCCDD'));
   LShared := DecodeHex('9FA1E9C3B6D2074F5E8A0C1D2B3A4958677685948382718065544332211009FF');
   LHash := Bytes('hash_ch_sh');
-  LTrunc := Provider.CreateHash(THashAlgorithm.SHA_256).DoFinal;
+  LTrunc := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256).DoFinal;
 
   LClient := NewResumptionSchedule(LPsk, LShared);
   LServer := NewResumptionSchedule(LPsk, LShared);
@@ -363,12 +363,12 @@ var
   LPrefix, LViaTranscript, LManual: TBytes;
 begin
   // HashPrefixExcludingBinders(prefix) == Hash(running transcript || prefix)
-  LTranscript := TTranscriptHash.Create(Provider.CreateHash(THashAlgorithm.SHA_256));
+  LTranscript := TTranscriptHash.Create(Provider.Primitives.CreateHash(THashAlgorithm.SHA_256));
   LTranscript.Update(DecodeHex('AABBCCDD')); // some prior transcript bytes
   LPrefix := DecodeHex('0100000504030201'); // a partial ClientHello prefix
   LViaTranscript := LTranscript.HashPrefixExcludingBinders(LPrefix);
   // recompute manually: the same prior bytes then the prefix
-  LManual := Provider.CreateHash(THashAlgorithm.SHA_256).DoFinal; // placeholder
+  LManual := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256).DoFinal; // placeholder
   LTranscript.Update(LPrefix);
   LManual := LTranscript.CurrentHash;
   CheckEqualBytes('the partial-transcript hash matches feeding the prefix',
@@ -408,7 +408,7 @@ begin
   LClient.SetPsk(LImp256.Key);
   LServer := TTls13KeySchedule.Create(Provider, LImp256.Hash, 16);
   LServer.SetPsk(LImp256.Key);
-  LTrunc := Provider.CreateHash(THashAlgorithm.SHA_256).DoFinal;
+  LTrunc := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256).DoFinal;
   LImpBinder := LClient.ComputeBinder(TPskBinderKind.Imported, LTrunc);
   CheckTrue(LServer.VerifyBinder(TPskBinderKind.Imported, LTrunc, LImpBinder),
     'the imported-PSK binder round-trips between client and server');

--- a/TlsLib.Tests/src/Tls13KeyUpdateTests.pas
+++ b/TlsLib.Tests/src/Tls13KeyUpdateTests.pas
@@ -73,7 +73,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(FCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(FCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(FCerts.Values['leaf_key']));
   finally
     FreeAndNil(FCerts);
   end;

--- a/TlsLib.Tests/src/Tls13LoopbackTests.pas
+++ b/TlsLib.Tests/src/Tls13LoopbackTests.pas
@@ -166,7 +166,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;
@@ -183,7 +183,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['wrongname_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;
@@ -244,7 +244,7 @@ begin
   LCred := Default(TTlsCredential);
   LCred.CertificateChain := TArray<TBytes>.Create(
     OcspField('leaf_cert'), OcspField('issuer_cert'));
-  LCred.PrivateKey := Provider.ImportSigningKey(OcspField('leaf_key'));
+  LCred.PrivateKey := Provider.Signing.ImportSigningKey(OcspField('leaf_key'));
   LCred.OcspStaple := AStaple;
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(LCred);
 
@@ -322,7 +322,7 @@ begin
   // the server offers only secp256r1; a client that key-shared another group is retried
   LParams.Group := TNamedGroups.CreateNistEcdh(Provider, 'secp256r1');
   LParams.ServerRandom := Filled($22, 32);
-  LParams.CookieSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  LParams.CookieSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
 
   Result := TTlsEngine.CreateConfigured(
@@ -374,7 +374,7 @@ begin
   LParams.GroupRegistry := TNamedGroups.CreateDefaultRegistry(Provider);
   LParams.ServerRandom := Filled($22, 32);
   // a cookie secret lets it answer with a HelloRetryRequest if it ever needed to (it must not)
-  LParams.CookieSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  LParams.CookieSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
 
   Result := TTlsEngine.CreateConfigured(
@@ -467,7 +467,7 @@ begin
   // the server offers only the hybrid; a client that key-shared a classical group is retried
   LParams.Group := TNamedGroups.CreateX25519MlKem768(Provider);
   LParams.ServerRandom := Filled($22, 32);
-  LParams.CookieSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  LParams.CookieSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
 
   Result := TTlsEngine.CreateConfigured(

--- a/TlsLib.Tests/src/Tls13ResumptionTests.pas
+++ b/TlsLib.Tests/src/Tls13ResumptionTests.pas
@@ -138,7 +138,7 @@ begin
   try
     Result.CertificateChain := TArray<TBytes>.Create(
       DecodeHex(LCerts.Values['leaf_cert']));
-    Result.PrivateKey := Provider.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
+    Result.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(LCerts.Values['leaf_key']));
   finally
     LCerts.Free;
   end;
@@ -158,7 +158,7 @@ begin
   LParams.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   LParams.OfferedSuites := TArray<UInt16>.Create(TCipherSuites13.Aes128GcmSha256);
   LParams.OfferedSchemes := TArray<UInt16>.Create(TSignatureSchemes.EcdsaSecp256r1Sha256);
-  LParams.ClientRandom := Provider.GetRandom.GenerateBytes(32);
+  LParams.ClientRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
   LParams.LegacySessionId := Filled($33, 32);
   LParams.CertificateVerifier := TCertificateVerifier.Create(Provider, TSystemClock.Create as ITlsClock,
     TTrustAnchorStore.Create(TArray<TBytes>.Create(TestRootCertificate))
@@ -186,7 +186,7 @@ begin
   LParams.CipherSuites := TCipherSuiteRegistry.CreateDefault(Provider);
   LParams.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   LParams.Group := TNamedGroups.CreateX25519(Provider);
-  LParams.ServerRandom := Provider.GetRandom.GenerateBytes(32);
+  LParams.ServerRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
   if AWithCredential then
     LParams.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
   LParams.SessionTicketKeys := AStek;
@@ -318,7 +318,7 @@ var
   LClient, LServer: ITlsEngine;
 begin
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
 
   // first connection: a full handshake that issues one ticket
   LClient := NewClient(LCache);
@@ -355,10 +355,10 @@ var
   LSecret: ISecretBuffer;
 begin
   // seed a matching client cache entry and server store entry (same identity+secret)
-  LIdentity := Provider.GetRandom.GenerateBytes(32);
-  LSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  LIdentity := Provider.Primitives.GetRandom.GenerateBytes(32);
+  LSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost, ServerHost, MakeSession(LIdentity, LSecret, 7200));
   LStore.PutWithId(LIdentity, MakeSession(LIdentity, LSecret, 7200));
 
@@ -390,9 +390,9 @@ var
 begin
   // the client's cached secret differs from the server's stored secret for the same
   // identity, so the server opens the ticket but its binder does not validate
-  LIdentity := Provider.GetRandom.GenerateBytes(32);
+  LIdentity := Provider.Primitives.GetRandom.GenerateBytes(32);
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost, ServerHost, MakeSession(LIdentity,
     TSecretBuffer.From(Filled($AA, 32)), 7200));
   LStore.PutWithId(LIdentity, MakeSession(LIdentity,
@@ -420,10 +420,10 @@ begin
   // an expired ticket (lifetime 0) against a credential-less server: the server must
   // reject the PSK on freshness and then cannot run a full handshake, so it does not
   // complete - proving the expired ticket was not accepted
-  LIdentity := Provider.GetRandom.GenerateBytes(32);
-  LSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  LIdentity := Provider.Primitives.GetRandom.GenerateBytes(32);
+  LSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost, ServerHost, MakeSession(LIdentity, LSecret, 0));
   LStore.PutWithId(LIdentity, MakeSession(LIdentity, LSecret, 0));
 
@@ -476,7 +476,7 @@ var
 begin
   // the default (no store) strategy: AEAD-sealed tickets under a shared STEK, no
   // server-side storage
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   LClient := NewClient(LCache);
@@ -500,7 +500,7 @@ var
   LClient, LServer: ITlsEngine;
   LI: Int32;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   // issue a real STEK ticket
@@ -529,11 +529,11 @@ var
   LClient, LServer: ITlsEngine;
 begin
   // a client offering a garbage "ticket" that is not a valid STEK seal
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
   LCache.Store(ServerHost, ServerHost, MakeSession(
-    Provider.GetRandom.GenerateBytes(48),
-    TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32)), 7200));
+    Provider.Primitives.GetRandom.GenerateBytes(48),
+    TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32)), 7200));
 
   // the server cannot open the bogus ticket and completes a full handshake instead
   LClient := NewClient(LCache);
@@ -553,8 +553,8 @@ var
   LClient, LServer: ITlsEngine;
 begin
   // configuring both a STEK and a store upgrades to the stateful single-use store
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   LClient := NewClient(LCache);
@@ -577,7 +577,7 @@ var
   LClient, LServer: ITlsEngine;
   LEarly: TBytes;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LAnti := TStrikeRegisterAntiReplay.Create;
   LCache := TInMemorySessionCache.Create;
 
@@ -610,7 +610,7 @@ var
   LClient, LServer: ITlsEngine;
   LEarly: TBytes;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LAnti := TStrikeRegisterAntiReplay.Create;
   LCache := TInMemorySessionCache.Create;
 
@@ -643,7 +643,7 @@ var
   LClient, LServerA, LServerB: ITlsEngine;
   LEarly, LFlight: TBytes;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LAnti := TStrikeRegisterAntiReplay.Create;
   LCache := TInMemorySessionCache.Create;
 
@@ -680,7 +680,7 @@ var
   LClient, LServer: ITlsEngine;
   LEarly: TBytes;
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LAnti := TStrikeRegisterAntiReplay.Create;
   LCache := TInMemorySessionCache.Create;
 
@@ -720,7 +720,7 @@ var
     LP.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
     LP.OfferedSuites := TArray<UInt16>.Create(TCipherSuites13.Aes128GcmSha256);
     LP.OfferedSchemes := TArray<UInt16>.Create(TSignatureSchemes.EcdsaSecp256r1Sha256);
-    LP.ClientRandom := Provider.GetRandom.GenerateBytes(32);
+    LP.ClientRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
     LP.LegacySessionId := Filled($33, 32);
     LP.CertificateVerifier := TCertificateVerifier.Create(Provider, TSystemClock.Create as ITlsClock,
       TTrustAnchorStore.Create(TArray<TBytes>.Create(TestRootCertificate))
@@ -744,7 +744,7 @@ var
     LP.CipherSuites := TCipherSuiteRegistry.CreateDefault(Provider);
     LP.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
     LP.Group := TNamedGroups.CreateX25519(Provider);
-    LP.ServerRandom := Provider.GetRandom.GenerateBytes(32);
+    LP.ServerRandom := Provider.Primitives.GetRandom.GenerateBytes(32);
     if AWithCredential then
       LP.CredentialResolver := TSniCredentialResolver.ForCredential(ServerCredential);
     LP.SessionTicketKeys := LStek;
@@ -762,7 +762,7 @@ var
   end;
 
 begin
-  LStek := TStekTicketKeyManager.Create(Provider.GetRandom);
+  LStek := TStekTicketKeyManager.Create(Provider.Primitives.GetRandom);
   LCache := TInMemorySessionCache.Create;
 
   // a full mutual-TLS handshake: the server verifies the client certificate and issues a ticket
@@ -795,12 +795,12 @@ begin
   // the cross-host resumption guard: a ticket the server issued while serving one host must not
   // resume a connection that requests a different host (RFC 6066 3), even with a matching binder.
   // The client always requests ServerHost, so the server-stored session carries the issuing host
-  LIdentity := Provider.GetRandom.GenerateBytes(32);
-  LSecret := TSecretBuffer.From(Provider.GetRandom.GenerateBytes(32));
+  LIdentity := Provider.Primitives.GetRandom.GenerateBytes(32);
+  LSecret := TSecretBuffer.From(Provider.Primitives.GetRandom.GenerateBytes(32));
 
   // control: issued under the requested host -> resumes
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost, ServerHost, MakeSession(LIdentity, LSecret, 7200));
   LStore.PutWithId(LIdentity, MakeSessionForHost(LIdentity, LSecret, 7200, ServerHost));
   LClient := NewClient(LCache);
@@ -811,7 +811,7 @@ begin
   // guarded: issued under a different host -> the credentialed server ignores the PSK and runs a
   // full handshake instead of resuming under the wrong identity
   LCache := TInMemorySessionCache.Create;
-  LStore := TInMemorySessionStore.Create(Provider.GetRandom);
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
   LCache.Store(ServerHost, ServerHost, MakeSession(LIdentity, LSecret, 7200));
   LStore.PutWithId(LIdentity, MakeSessionForHost(LIdentity, LSecret, 7200, 'other.example'));
   LClient := NewClient(LCache);

--- a/TlsLib.Tests/src/Tls13ServerReplayTests.pas
+++ b/TlsLib.Tests/src/Tls13ServerReplayTests.pas
@@ -275,7 +275,7 @@ begin
   // the RFC 8448 server signs with rsa_pss_rsae_sha256, which the RFC client offers;
   // the CertificateVerify is replayed verbatim, so the key only drives scheme selection
   LCred := Default(TTlsCredential);
-  LCred.PrivateKey := Provider.ImportSigningKey(DecodeHex(FKeys.Values['rsa_key']));
+  LCred.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(FKeys.Values['rsa_key']));
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(LCred);
   FSm := TTls13ServerStateMachine.Create(LParams);
   BuildDriver(LParams.Provider);
@@ -431,7 +431,7 @@ begin
   // machine signs for real (no CertificateVerifyOverride)
   LCred := Default(TTlsCredential);
   LCred.CertificateChain := TArray<TBytes>.Create(DecodeHex(FKeys.Values['rsa_cert']));
-  LCred.PrivateKey := Provider.ImportSigningKey(DecodeHex(FKeys.Values['rsa_key']));
+  LCred.PrivateKey := Provider.Signing.ImportSigningKey(DecodeHex(FKeys.Values['rsa_key']));
   LParams.CredentialResolver := TSniCredentialResolver.ForCredential(LCred);
   FSm := TTls13ServerStateMachine.Create(LParams);
   BuildDriver(Provider);

--- a/TlsLib.Tests/src/TlsStreamLoopbackTests.pas
+++ b/TlsLib.Tests/src/TlsStreamLoopbackTests.pas
@@ -440,8 +440,8 @@ var
   LHash: IHash;
   LSpki: TBytes;
 begin
-  LSpki := Provider.CertificatePublicKeyInfo(ACertDer);
-  LHash := Provider.CreateHash(THashAlgorithm.SHA_256);
+  LSpki := Provider.Certificates.PublicKeyInfo(ACertDer);
+  LHash := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(LSpki, 0, System.Length(LSpki));
   Result := LHash.DoFinal;
 end;

--- a/TlsLib.Tests/src/TranscriptHashTests.pas
+++ b/TlsLib.Tests/src/TranscriptHashTests.pas
@@ -78,7 +78,7 @@ end;
 
 function TTestTranscriptHash.Sha256: IHash;
 begin
-  Result := Provider.CreateHash(THashAlgorithm.SHA_256);
+  Result := Provider.Primitives.CreateHash(THashAlgorithm.SHA_256);
 end;
 
 function TTestTranscriptHash.RawSha256(const AData: TBytes): TBytes;

--- a/TlsLib.Tools/RootGen/src/TlpRootGen.pas
+++ b/TlsLib.Tools/RootGen/src/TlpRootGen.pas
@@ -401,7 +401,7 @@ begin
     AppendLine('    for LI := 0 to System.High(CPemLines) do');
     AppendLine('      LBuilder.Append(CPemLines[LI]).Append(#10);');
     AppendLine('    Result := TTrustAnchorStore.Create(');
-    AppendLine('      AProvider.LoadCertificateChain(');
+    AppendLine('      AProvider.Certificates.LoadChain(');
     AppendLine('        TEncoding.ASCII.GetBytes(LBuilder.ToString)))');
     AppendLine('      as ITrustAnchorStore;');
     AppendLine('  finally');

--- a/TlsLib.Trust.Bundle/src/TlpBundleTrust.pas
+++ b/TlsLib.Trust.Bundle/src/TlpBundleTrust.pas
@@ -67,7 +67,7 @@ end;
 class function TBundleTrust.FromPem(const AProvider: ICryptoProvider;
   const AData: TBytes): ITrustAnchorStore;
 begin
-  Result := TTrustAnchorStore.Create(AProvider.LoadCertificateChain(AData))
+  Result := TTrustAnchorStore.Create(AProvider.Certificates.LoadChain(AData))
     as ITrustAnchorStore;
 end;
 

--- a/TlsLib.Trust.System/src/TlpAndroidSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpAndroidSystemTrust.pas
@@ -620,8 +620,8 @@ begin
   if AHostName <> '' then
     if (FProvider = nil) or
       (not TEndpointIdentity.Matches(AHostName,
-      FProvider.CertificateDnsNames(AChain[0]),
-      FProvider.CertificateIpAddresses(AChain[0]))) then
+      FProvider.Certificates.DnsNames(AChain[0]),
+      FProvider.Certificates.IpAddresses(AChain[0]))) then
     begin
       Result := False;
       AAlert := TTlsAlertDescription.BadCertificate;

--- a/TlsLib.Trust.System/src/TlpFileSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpFileSystemTrust.pas
@@ -104,7 +104,7 @@ begin
   if Length(AData) = 0 then
     Result := nil
   else
-    Result := Provider.LoadCertificateChain(AData);
+    Result := Provider.Certificates.LoadChain(AData);
 end;
 
 procedure TFileSystemAnchorStore.HarvestFile(const APath: string;

--- a/TlsLib.Trust.System/src/TlpSystemTrustBase.pas
+++ b/TlsLib.Trust.System/src/TlpSystemTrustBase.pas
@@ -89,7 +89,7 @@ procedure TSystemTrustBase.AddUnique(var ARoots: TArray<TBytes>;
 var
   LI, LN: Integer;
 begin
-  if not FProvider.IsWellFormedCertificate(ADer) then
+  if not FProvider.Certificates.IsWellFormed(ADer) then
     Exit;
 
   for LI := 0 to Length(ARoots) - 1 do

--- a/TlsLib/src/CertCompression/TlpCertificateCompression.pas
+++ b/TlsLib/src/CertCompression/TlpCertificateCompression.pas
@@ -129,7 +129,7 @@ var
 begin
   SetLength(LPrefix, SizeOf(UInt16));
   TBinaryPrimitives.WriteUInt16BigEndian(LPrefix, 0, AAlgorithm);
-  LHash := AProvider.CreateHash(THashAlgorithm.SHA_256);
+  LHash := AProvider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(LPrefix, 0, System.Length(LPrefix));
   LHash.Update(ABody, 0, System.Length(ABody));
   Result := LHash.DoFinal;

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -22,6 +22,7 @@ uses
   SyncObjs,
   ClpISecureRandom,
   ClpSecureRandom,
+  ClpIRandomGenerator,
   ClpIDigest,
   ClpDigestUtilities,
   ClpIMac,
@@ -135,114 +136,81 @@ uses
 
 type
   /// <summary>
-  /// The default <see cref="ICryptoProvider" />, backed by CryptoLib4Pascal.
+  /// A recipe for composing a provider: each nil field takes the default, each
+  /// non-nil field replaces that one facet (and <c>Random</c> replaces the entropy
+  /// source threaded into the default Primitives and Signing). Composing coherent
+  /// facets is the composer's responsibility: any supplied facet or <c>IRandom</c>
+  /// must be thread-safe (stateless or internally synchronized), since it slots into
+  /// a provider whose accessors promise thread-safety and whose RNG is reached
+  /// concurrently from Primitives and Signing.
+  /// </summary>
+  TCryptoProviderOverrides = record
+    Random: IRandom;
+    Primitives: ICryptoPrimitives;
+    Signing: ISigningCrypto;
+    Inspector: ICertificateInspector;
+    PathValidation: ICertificatePathValidator;
+    Revocation: IRevocationChecker;
+  end;
+
+  /// <summary>
+  /// The default <see cref="ICryptoProvider" />, backed by CryptoLib4Pascal. A thin
+  /// composition root: it holds one instance of each facet and its accessors return
+  /// them. <see cref="Create" /> is the single composition point; the five facet
+  /// implementations are private to this unit.
   /// </summary>
   TDefaultCryptoProvider = class(TInterfacedObject, ICryptoProvider)
   strict private
-  const
-    // RFC 7633 id-pe-tlsfeature
-    TlsFeatureExtensionOid = '1.3.6.1.5.5.7.1.24';
-    // PKCS#1 id-RSASSA-PSS: the restricted RSA-PSS key type (RFC 4055)
-    RsaSsaPssKeyOid = '1.2.840.113549.1.1.10';
-  type
-    // parsed trust anchors keyed by a digest of the anchor set, so a reused
-    // config does not re-parse its (possibly large) anchor store on every verify
-    TTrustAnchorRing = record
-    strict private
-    const
-      TrustAnchorCacheSize = Int32(8);
-    strict private
-      FKeys: TArray<TBytes>;
-      FSets: TArray<TArray<ITrustAnchor>>;
-      FCount: Int32;
-      FNext: Int32;
-    public
-      class function Init: TTrustAnchorRing; static;
-      function TryGet(const AKey: TBytes;
-        out AAnchors: TArray<ITrustAnchor>): Boolean;
-      procedure Remember(const AKey: TBytes;
-        const AAnchors: TArray<ITrustAnchor>);
-    end;
   class var
-    FTrustAnchors: TTrustAnchorRing;
-    FTrustAnchorLock: TCriticalSection;
     FShared: ICryptoProvider;
     FSharedLock: TCriticalSection;
   var
-    FHasHardwareAes: Boolean;
-    FRandom: ISecureRandom;
-    function ResolveDigest(AAlgorithm: THashAlgorithm): IDigest;
-    function TrustAnchorKey(const ATrustAnchors: TArray<TBytes>): TBytes;
-    class function SignerMechanismForScheme(AScheme: TSignatureScheme): string; static;
-    /// <summary>
-    /// Whether AResponse is signed by the certificate issuer itself or by a
-    /// responder the issuer delegated to (RFC 6960 sec. 4.2.2.2).
-    /// </summary>
-    class function OcspResponseAuthorised(const AResponse: IBasicOcspResp;
-      const AIssuerCert: IX509Certificate;
-      const AIssuerPublicKey: IAsymmetricKeyParameter;
-      AValidityDate: TDateTime): Boolean; static;
-    class function OcspDelegatedResponder(const AResponderCert,
-      AIssuerCert: IX509Certificate;
-      const AIssuerPublicKey: IAsymmetricKeyParameter;
-      AValidityDate: TDateTime): Boolean; static;
+    FPrimitives: ICryptoPrimitives;
+    FSigning: ISigningCrypto;
+    FInspector: ICertificateInspector;
+    FPathValidation: ICertificatePathValidator;
+    FRevocation: IRevocationChecker;
   public
-    constructor Create;
+    /// <summary>The single composition point. Resolves the effective RNG first (a supplied
+    /// AOverrides.Random bridged to the CryptoLib CSPRNG, else a fresh one) and threads that
+    /// one instance into the default Primitives and Signing it builds; each nil facet override
+    /// is defaulted, each supplied facet is held as-is. A Random override governs only the
+    /// default facets, not a supplied Primitives.</summary>
+    constructor Create(const AOverrides: TCryptoProviderOverrides); overload;
+    /// <summary>An all-defaults provider (no overrides).</summary>
+    constructor Create; overload;
     class constructor Create;
     class destructor Destroy;
-    /// <summary>A process-wide, lazily-created default provider: the fallback when no provider
-    /// is injected, and the hasher for memo signatures. One CSPRNG seed for the process, shared
-    /// (the provider is a stateless service factory), so no per-connection provider is stood up.</summary>
+    /// <summary>A process-wide, lazily-created all-defaults provider: the fallback when no
+    /// provider is injected, and the hasher for memo signatures. One CSPRNG seed for the
+    /// process, shared (the provider is a stateless service factory). It reflects no overrides -
+    /// it is the all-defaults singleton.</summary>
     class function Shared: ICryptoProvider; static;
 
-    function GetRandom: IRandom;
-    function CreateHash(AAlgorithm: THashAlgorithm): IHash;
-    function CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
-    function CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
-    function CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
-    function ImportSigningKey(const AData: TBytes): ISigningKey; overload;
-    function ImportSigningKey(const AData: TBytes;
-      const APassword: string): ISigningKey; overload;
-    function CreateSignatureSigner(AScheme: TSignatureScheme;
-      const AKey: ISigningKey): ISignatureSigner;
-    function CreateSignatureVerifier(AScheme: TSignatureScheme;
-      const APublicKeyDer: TBytes): ISignatureVerifier;
-    function LoadCertificateChain(const AData: TBytes): TArray<TBytes>;
-    function IsWellFormedCertificate(const ADer: TBytes): Boolean;
-    function ImportPkcs12(const AData: TBytes;
-      const APassword: string): TTlsCredential;
-    function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
-    function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
-    function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
-    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
-      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
-      var AEffectiveChain: TArray<TBytes>);
-    function ValidateOcspStaple(const ALeafCert, AIssuerCert,
-      AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
-      out AStatus: TOcspStatus;
-      out AThisUpdate, ANextUpdate: TDateTime): Boolean;
-    function BuildOcspRequest(const ALeafCert, AIssuerCert: TBytes;
-      out ARequestDer: TBytes): Boolean;
-    function TryGetOcspResponderUrl(const ACert: TBytes;
-      out AUrl: string): Boolean;
-    function TryGetCrlDistributionPoints(const ACert: TBytes;
-      out AUrls: TArray<string>): Boolean;
-    function CheckCrlRevocation(const ALeafCert, AIssuerCert, ACrlDer: TBytes;
-      out ARevoked: Boolean): Boolean;
-    function CertificatePeerInfo(const ACertificateDer: TBytes;
-      out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-    function CertificateTlsFeatures(const ACert: TBytes;
-      out AFeatures: TArray<UInt16>): Boolean;
-    function CertificateKeyUsagePermits(const ACertificateDer: TBytes;
-      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    function CertificateHasRsaPssKey(const ACertificateDer: TBytes;
-      out AIsRsaPss: Boolean): Boolean;
-    function CertificateKeyKind(const ACertificateDer: TBytes;
-      out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
-    function CreateKeyAgreement(AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
-    function CreateKem(AAlgorithm: TKemAlgorithm): IKem;
+    function Primitives: ICryptoPrimitives;
+    function Signing: ISigningCrypto;
+    function Certificates: ICertificateInspector;
+    function PathValidation: ICertificatePathValidator;
+    function Revocation: IRevocationChecker;
+  end;
 
-    function HasHardwareAes: Boolean;
+  /// <summary>
+  /// The fluent <see cref="ICryptoProviderBuilder" />: accumulates facet overrides
+  /// and composes through <see cref="TDefaultCryptoProvider.Create" /> (zero
+  /// duplication - all composition logic stays in that one constructor).
+  /// </summary>
+  TCryptoProviderBuilder = class(TInterfacedObject, ICryptoProviderBuilder)
+  strict private
+  var
+    FOverrides: TCryptoProviderOverrides;
+  public
+    function WithRandom(const ARandom: IRandom): ICryptoProviderBuilder;
+    function WithPrimitives(const APrimitives: ICryptoPrimitives): ICryptoProviderBuilder;
+    function WithSigning(const ASigning: ISigningCrypto): ICryptoProviderBuilder;
+    function WithInspector(const AInspector: ICertificateInspector): ICryptoProviderBuilder;
+    function WithPathValidation(const APathValidation: ICertificatePathValidator): ICryptoProviderBuilder;
+    function WithRevocation(const ARevocation: IRevocationChecker): ICryptoProviderBuilder;
+    function Build: ICryptoProvider;
   end;
 
 implementation
@@ -278,7 +246,7 @@ type
   var
     FRandom: ISecureRandom;
   public
-    constructor Create;
+    constructor Create(const ARandom: ISecureRandom);
     procedure NextBytes(var ABuffer: TBytes);
     function GenerateBytes(ALength: Int32): TBytes;
   end;
@@ -497,12 +465,165 @@ type
       const AKeyParam: IAsymmetricKeyParameter): ISigningKey; static;
   end;
 
+  // Resolves a hash algorithm to its CryptoLib digest. A stateless leaf shared by
+  // the primitives and the path validator's anchor-key hash.
+  TDigestResolver = class sealed(TObject)
+  public
+    class function Resolve(AAlgorithm: THashAlgorithm): IDigest; static;
+  end;
+
+  // Bridges a facet IRandom into the CryptoLib IRandomGenerator a TSecureRandom
+  // draws from, so a supplied entropy source governs the default facets' key
+  // generation. Seed material is ignored - the source is already a CSPRNG.
+  TRandomGeneratorBridge = class(TInterfacedObject, IRandomGenerator)
+  strict private
+  var
+    FRandom: IRandom;
+  public
+    constructor Create(const ARandom: IRandom);
+    procedure AddSeedMaterial(const ASeed: TCryptoLibByteArray); overload;
+    procedure AddSeedMaterial(ASeed: Int64); overload;
+    procedure NextBytes(const ABytes: TCryptoLibByteArray); overload;
+    procedure NextBytes(const ABytes: TCryptoLibByteArray;
+      AStart, ALen: Int32); overload;
+  end;
+
+  // ICryptoPrimitives - CSPRNG, hashes / HMAC / HKDF, AEAD, key agreement and KEM.
+  TCryptoPrimitives = class(TInterfacedObject, ICryptoPrimitives)
+  strict private
+  var
+    FRandom: ISecureRandom;
+    FRandomFacet: IRandom;
+    FHasHardwareAes: Boolean;
+  public
+    constructor Create(const ARandom: ISecureRandom; AHasHardwareAes: Boolean);
+    function GetRandom: IRandom;
+    function CreateHash(AAlgorithm: THashAlgorithm): IHash;
+    function CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
+    function CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
+    function CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
+    function CreateKeyAgreement(AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
+    function CreateKem(AAlgorithm: TKemAlgorithm): IKem;
+    function HasHardwareAes: Boolean;
+  end;
+
+  // ISigningCrypto - imports signing keys / PKCS#12 identities and mints signers / verifiers.
+  TSigningCrypto = class(TInterfacedObject, ISigningCrypto)
+  strict private
+  var
+    FRandom: ISecureRandom;
+    class function SignerMechanismForScheme(AScheme: TSignatureScheme): string; static;
+  public
+    constructor Create(const ARandom: ISecureRandom);
+    function ImportSigningKey(const AData: TBytes): ISigningKey; overload;
+    function ImportSigningKey(const AData: TBytes;
+      const APassword: string): ISigningKey; overload;
+    function ImportPkcs12(const AData: TBytes;
+      const APassword: string): TTlsCredential;
+    function CreateSignatureSigner(AScheme: TSignatureScheme;
+      const AKey: ISigningKey): ISignatureSigner;
+    function CreateSignatureVerifier(AScheme: TSignatureScheme;
+      const APublicKeyDer: TBytes): ISignatureVerifier;
+  end;
+
+  // ICertificateInspector - pure, per-certificate, side-effect-free X.509 inspection.
+  TCertificateInspector = class(TInterfacedObject, ICertificateInspector)
+  strict private
+  const
+    // RFC 7633 id-pe-tlsfeature
+    TlsFeatureExtensionOid = '1.3.6.1.5.5.7.1.24';
+    // PKCS#1 id-RSASSA-PSS: the restricted RSA-PSS key type (RFC 4055)
+    RsaSsaPssKeyOid = '1.2.840.113549.1.1.10';
+  public
+    function LoadChain(const AData: TBytes): TArray<TBytes>;
+    function IsWellFormed(const ADer: TBytes): Boolean;
+    function PublicKeyInfo(const ACertificateDer: TBytes): TBytes;
+    function DnsNames(const ACertificateDer: TBytes): TArray<string>;
+    function IpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
+    function PeerInfo(const ACertificateDer: TBytes;
+      out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
+    function TlsFeatures(const ACert: TBytes;
+      out AFeatures: TArray<UInt16>): Boolean;
+    function KeyUsagePermits(const ACertificateDer: TBytes;
+      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
+    function HasRsaPssKey(const ACertificateDer: TBytes;
+      out AIsRsaPss: Boolean): Boolean;
+    function KeyKind(const ACertificateDer: TBytes;
+      out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+  end;
+
+  // ICertificatePathValidator - RFC 5280 path validation. The trust-anchor ring is a
+  // class-level cache shared across the many short-lived providers.
+  TCertificatePathValidator = class(TInterfacedObject, ICertificatePathValidator)
+  strict private
+  type
+    // parsed trust anchors keyed by a digest of the anchor set, so a reused
+    // config does not re-parse its (possibly large) anchor store on every verify
+    TTrustAnchorRing = record
+    strict private
+    const
+      TrustAnchorCacheSize = Int32(8);
+    strict private
+      FKeys: TArray<TBytes>;
+      FSets: TArray<TArray<ITrustAnchor>>;
+      FCount: Int32;
+      FNext: Int32;
+    public
+      class function Init: TTrustAnchorRing; static;
+      function TryGet(const AKey: TBytes;
+        out AAnchors: TArray<ITrustAnchor>): Boolean;
+      procedure Remember(const AKey: TBytes;
+        const AAnchors: TArray<ITrustAnchor>);
+    end;
+  class var
+    FTrustAnchors: TTrustAnchorRing;
+    FTrustAnchorLock: TCriticalSection;
+  strict private
+    function TrustAnchorKey(const ATrustAnchors: TArray<TBytes>): TBytes;
+  public
+    class constructor Create;
+    class destructor Destroy;
+    procedure ValidateCertificatePath(const AChain, ATrustAnchors,
+      AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
+      var AEffectiveChain: TArray<TBytes>);
+  end;
+
+  // IRevocationChecker - stapled-OCSP verification and the live OCSP/CRL primitives.
+  TRevocationChecker = class(TInterfacedObject, IRevocationChecker)
+  strict private
+    /// <summary>
+    /// Whether AResponse is signed by the certificate issuer itself or by a
+    /// responder the issuer delegated to (RFC 6960 sec. 4.2.2.2).
+    /// </summary>
+    class function OcspResponseAuthorised(const AResponse: IBasicOcspResp;
+      const AIssuerCert: IX509Certificate;
+      const AIssuerPublicKey: IAsymmetricKeyParameter;
+      AValidityDate: TDateTime): Boolean; static;
+    class function OcspDelegatedResponder(const AResponderCert,
+      AIssuerCert: IX509Certificate;
+      const AIssuerPublicKey: IAsymmetricKeyParameter;
+      AValidityDate: TDateTime): Boolean; static;
+  public
+    function ValidateOcspStaple(const ALeafCert, AIssuerCert,
+      AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
+      out AStatus: TOcspStatus;
+      out AThisUpdate, ANextUpdate: TDateTime): Boolean;
+    function BuildOcspRequest(const ALeafCert, AIssuerCert: TBytes;
+      out ARequestDer: TBytes): Boolean;
+    function TryGetOcspResponderUrl(const ACert: TBytes;
+      out AUrl: string): Boolean;
+    function TryGetCrlDistributionPoints(const ACert: TBytes;
+      out AUrls: TArray<string>): Boolean;
+    function CheckCrlRevocation(const ALeafCert, AIssuerCert, ACrlDer: TBytes;
+      out ARevoked: Boolean): Boolean;
+  end;
+
 { TRandomAdapter }
 
-constructor TRandomAdapter.Create;
+constructor TRandomAdapter.Create(const ARandom: ISecureRandom);
 begin
   inherited Create;
-  FRandom := TSecureRandom.Create;
+  FRandom := ARandom;
 end;
 
 procedure TRandomAdapter.NextBytes(var ABuffer: TBytes);
@@ -1459,20 +1580,125 @@ end;
 
 { TDefaultCryptoProvider }
 
-constructor TDefaultCryptoProvider.Create;
+constructor TDefaultCryptoProvider.Create(const AOverrides: TCryptoProviderOverrides);
+var
+  LRandom: ISecureRandom;
 begin
   inherited Create;
-  FHasHardwareAes := TAesUtilities.IsHardwareAccelerated();
-  FRandom := TSecureRandom.Create;
+  // resolve the effective entropy source first, then thread that ONE instance into the
+  // default Primitives and Signing this ctor builds; a supplied Random governs only the
+  // facets built here, never a supplied Primitives override
+  if AOverrides.Random <> nil then
+    LRandom := TSecureRandom.Create(TRandomGeneratorBridge.Create(AOverrides.Random)
+      as IRandomGenerator)
+  else
+    LRandom := TSecureRandom.Create;
+
+  if AOverrides.Primitives <> nil then
+    FPrimitives := AOverrides.Primitives
+  else
+    FPrimitives := TCryptoPrimitives.Create(LRandom,
+      TAesUtilities.IsHardwareAccelerated()) as ICryptoPrimitives;
+
+  if AOverrides.Signing <> nil then
+    FSigning := AOverrides.Signing
+  else
+    FSigning := TSigningCrypto.Create(LRandom) as ISigningCrypto;
+
+  if AOverrides.Inspector <> nil then
+    FInspector := AOverrides.Inspector
+  else
+    FInspector := TCertificateInspector.Create as ICertificateInspector;
+
+  if AOverrides.PathValidation <> nil then
+    FPathValidation := AOverrides.PathValidation
+  else
+    FPathValidation := TCertificatePathValidator.Create as ICertificatePathValidator;
+
+  if AOverrides.Revocation <> nil then
+    FRevocation := AOverrides.Revocation
+  else
+    FRevocation := TRevocationChecker.Create as IRevocationChecker;
 end;
 
-function TDefaultCryptoProvider.ResolveDigest(AAlgorithm: THashAlgorithm): IDigest;
+constructor TDefaultCryptoProvider.Create;
+var
+  LOverrides: TCryptoProviderOverrides;
+begin
+  // hoist Default() to a local (Delphi Default-in-argument-position insurance)
+  LOverrides := Default(TCryptoProviderOverrides);
+  Create(LOverrides);
+end;
+
+{ TDigestResolver }
+
+class function TDigestResolver.Resolve(AAlgorithm: THashAlgorithm): IDigest;
 begin
   Result := TDigestUtilities.GetDigest(
     TEnumUtilities.GetName<THashAlgorithm>(AAlgorithm));
 end;
 
-class function TDefaultCryptoProvider.SignerMechanismForScheme(
+{ TRandomGeneratorBridge }
+
+constructor TRandomGeneratorBridge.Create(const ARandom: IRandom);
+begin
+  inherited Create;
+  FRandom := ARandom;
+end;
+
+procedure TRandomGeneratorBridge.AddSeedMaterial(const ASeed: TCryptoLibByteArray);
+begin
+  // the wrapped source is already a CSPRNG; reseeding is a no-op
+end;
+
+procedure TRandomGeneratorBridge.AddSeedMaterial(ASeed: Int64);
+begin
+  // the wrapped source is already a CSPRNG; reseeding is a no-op
+end;
+
+procedure TRandomGeneratorBridge.NextBytes(const ABytes: TCryptoLibByteArray);
+var
+  LGen: TBytes;
+begin
+  if System.Length(ABytes) = 0 then
+    Exit;
+  LGen := FRandom.GenerateBytes(System.Length(ABytes));
+  System.Move(LGen[0], ABytes[0], System.Length(ABytes));
+end;
+
+procedure TRandomGeneratorBridge.NextBytes(const ABytes: TCryptoLibByteArray;
+  AStart, ALen: Int32);
+var
+  LGen: TBytes;
+begin
+  if ALen <= 0 then
+    Exit;
+  LGen := FRandom.GenerateBytes(ALen);
+  System.Move(LGen[0], ABytes[AStart], ALen);
+end;
+
+{ TCryptoPrimitives }
+
+constructor TCryptoPrimitives.Create(const ARandom: ISecureRandom;
+  AHasHardwareAes: Boolean);
+begin
+  inherited Create;
+  FRandom := ARandom;
+  FHasHardwareAes := AHasHardwareAes;
+  // one stable IRandom bound to the provider's effective RNG, so GetRandom is a
+  // connected view (not a fresh, disconnected stream on every call)
+  FRandomFacet := TRandomAdapter.Create(ARandom);
+end;
+
+{ TSigningCrypto }
+
+constructor TSigningCrypto.Create(const ARandom: ISecureRandom);
+begin
+  inherited Create;
+  FRandom := ARandom;
+end;
+
+class function TSigningCrypto.SignerMechanismForScheme(
   AScheme: TSignatureScheme): string;
 begin
   // map a TLS 1.3 signature scheme to a CryptoLib signer mechanism. The named
@@ -1510,27 +1736,52 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.GetRandom: IRandom;
+function TDefaultCryptoProvider.Primitives: ICryptoPrimitives;
 begin
-  Result := TRandomAdapter.Create;
+  Result := FPrimitives;
 end;
 
-function TDefaultCryptoProvider.CreateHash(AAlgorithm: THashAlgorithm): IHash;
+function TDefaultCryptoProvider.Signing: ISigningCrypto;
 begin
-  Result := THashAdapter.Create(ResolveDigest(AAlgorithm));
+  Result := FSigning;
 end;
 
-function TDefaultCryptoProvider.CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
+function TDefaultCryptoProvider.Certificates: ICertificateInspector;
 begin
-  Result := THmacAdapter.Create(ResolveDigest(AAlgorithm));
+  Result := FInspector;
 end;
 
-function TDefaultCryptoProvider.CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
+function TDefaultCryptoProvider.PathValidation: ICertificatePathValidator;
+begin
+  Result := FPathValidation;
+end;
+
+function TDefaultCryptoProvider.Revocation: IRevocationChecker;
+begin
+  Result := FRevocation;
+end;
+
+function TCryptoPrimitives.GetRandom: IRandom;
+begin
+  Result := FRandomFacet;
+end;
+
+function TCryptoPrimitives.CreateHash(AAlgorithm: THashAlgorithm): IHash;
+begin
+  Result := THashAdapter.Create(TDigestResolver.Resolve(AAlgorithm));
+end;
+
+function TCryptoPrimitives.CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
+begin
+  Result := THmacAdapter.Create(TDigestResolver.Resolve(AAlgorithm));
+end;
+
+function TCryptoPrimitives.CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
 begin
   Result := THkdfAdapter.Create(AAlgorithm);
 end;
 
-function TDefaultCryptoProvider.CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
+function TCryptoPrimitives.CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
 begin
   case AAlgorithm of
     TAeadAlgorithm.AES_128_GCM:
@@ -1548,18 +1799,18 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.ImportSigningKey(const AData: TBytes): ISigningKey;
+function TSigningCrypto.ImportSigningKey(const AData: TBytes): ISigningKey;
 begin
   Result := TCredentialImport.ImportKey(AData, '', False);
 end;
 
-function TDefaultCryptoProvider.ImportSigningKey(const AData: TBytes;
+function TSigningCrypto.ImportSigningKey(const AData: TBytes;
   const APassword: string): ISigningKey;
 begin
   Result := TCredentialImport.ImportKey(AData, APassword, True);
 end;
 
-function TDefaultCryptoProvider.CreateSignatureSigner(AScheme: TSignatureScheme;
+function TSigningCrypto.CreateSignatureSigner(AScheme: TSignatureScheme;
   const AKey: ISigningKey): ISignatureSigner;
 var
   LProviderKey: IProviderSigningKey;
@@ -1576,7 +1827,7 @@ begin
     TEnumUtilities.GetName<TSignatureScheme>(AScheme));
 end;
 
-function TDefaultCryptoProvider.CreateSignatureVerifier(AScheme: TSignatureScheme;
+function TSigningCrypto.CreateSignatureVerifier(AScheme: TSignatureScheme;
   const APublicKeyDer: TBytes): ISignatureVerifier;
 var
   LKey: IAsymmetricKeyParameter;
@@ -1589,7 +1840,7 @@ begin
     TEnumUtilities.GetName<TSignatureScheme>(AScheme));
 end;
 
-function TDefaultCryptoProvider.LoadCertificateChain(
+function TCertificateInspector.LoadChain(
   const AData: TBytes): TArray<TBytes>;
 var
   LStream: TBytesStream;
@@ -1642,7 +1893,7 @@ begin
     raise EArgumentTlsLibException.CreateRes(@SNoCertificatesFound);
 end;
 
-function TDefaultCryptoProvider.IsWellFormedCertificate(
+function TCertificateInspector.IsWellFormed(
   const ADer: TBytes): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -1658,7 +1909,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.ImportPkcs12(const AData: TBytes;
+function TSigningCrypto.ImportPkcs12(const AData: TBytes;
   const APassword: string): TTlsCredential;
 var
   LStore: IPkcs12Store;
@@ -1729,7 +1980,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CertificatePublicKeyInfo(
+function TCertificateInspector.PublicKeyInfo(
   const ACertificateDer: TBytes): TBytes;
 var
   LParser: IX509CertificateParser;
@@ -1740,7 +1991,7 @@ begin
   Result := LCert.GetSubjectPublicKeyInfo.GetDerEncoded;
 end;
 
-function TDefaultCryptoProvider.CertificateDnsNames(
+function TCertificateInspector.DnsNames(
   const ACertificateDer: TBytes): TArray<string>;
 var
   LParser: IX509CertificateParser;
@@ -1768,7 +2019,7 @@ begin
     end;
 end;
 
-function TDefaultCryptoProvider.CertificateIpAddresses(
+function TCertificateInspector.IpAddresses(
   const ACertificateDer: TBytes): TArray<TBytes>;
 var
   LParser: IX509CertificateParser;
@@ -1796,7 +2047,7 @@ begin
     end;
 end;
 
-class function TDefaultCryptoProvider.TTrustAnchorRing.Init: TTrustAnchorRing;
+class function TCertificatePathValidator.TTrustAnchorRing.Init: TTrustAnchorRing;
 begin
   SetLength(Result.FKeys, TrustAnchorCacheSize);
   SetLength(Result.FSets, TrustAnchorCacheSize);
@@ -1804,7 +2055,7 @@ begin
   Result.FNext := 0;
 end;
 
-function TDefaultCryptoProvider.TTrustAnchorRing.TryGet(const AKey: TBytes;
+function TCertificatePathValidator.TTrustAnchorRing.TryGet(const AKey: TBytes;
   out AAnchors: TArray<ITrustAnchor>): Boolean;
 var
   LI: Int32;
@@ -1819,7 +2070,7 @@ begin
   Result := False;
 end;
 
-procedure TDefaultCryptoProvider.TTrustAnchorRing.Remember(const AKey: TBytes;
+procedure TCertificatePathValidator.TTrustAnchorRing.Remember(const AKey: TBytes;
   const AAnchors: TArray<ITrustAnchor>);
 begin
   FKeys[FNext] := AKey;
@@ -1831,8 +2082,6 @@ end;
 
 class constructor TDefaultCryptoProvider.Create;
 begin
-  FTrustAnchors := TTrustAnchorRing.Init;
-  FTrustAnchorLock := TCriticalSection.Create;
   FSharedLock := TCriticalSection.Create;
 end;
 
@@ -1840,6 +2089,16 @@ class destructor TDefaultCryptoProvider.Destroy;
 begin
   FShared := nil;
   FSharedLock.Free;
+end;
+
+class constructor TCertificatePathValidator.Create;
+begin
+  FTrustAnchors := TTrustAnchorRing.Init;
+  FTrustAnchorLock := TCriticalSection.Create;
+end;
+
+class destructor TCertificatePathValidator.Destroy;
+begin
   FTrustAnchorLock.Free;
 end;
 
@@ -1855,14 +2114,14 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.TrustAnchorKey(
+function TCertificatePathValidator.TrustAnchorKey(
   const ATrustAnchors: TArray<TBytes>): TBytes;
 var
   LDigest: IDigest;
   LI, LN: Int32;
   LLen: TBytes;
 begin
-  LDigest := ResolveDigest(THashAlgorithm.SHA_256);
+  LDigest := TDigestResolver.Resolve(THashAlgorithm.SHA_256);
   System.SetLength(LLen, 4);
   for LI := 0 to System.High(ATrustAnchors) do
   begin
@@ -1876,7 +2135,7 @@ begin
   Result := LDigest.DoFinal;
 end;
 
-procedure TDefaultCryptoProvider.ValidateCertificatePath(const AChain,
+procedure TCertificatePathValidator.ValidateCertificatePath(const AChain,
   ATrustAnchors, AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
   var AEffectiveChain: TArray<TBytes>);
 const
@@ -2036,7 +2295,7 @@ begin
     AEffectiveChain[LI] := LBuilt[LI].GetEncoded;
 end;
 
-class function TDefaultCryptoProvider.OcspDelegatedResponder(const AResponderCert,
+class function TRevocationChecker.OcspDelegatedResponder(const AResponderCert,
   AIssuerCert: IX509Certificate; const AIssuerPublicKey: IAsymmetricKeyParameter;
   AValidityDate: TDateTime): Boolean;
 var
@@ -2064,7 +2323,7 @@ begin
     end;
 end;
 
-class function TDefaultCryptoProvider.OcspResponseAuthorised(
+class function TRevocationChecker.OcspResponseAuthorised(
   const AResponse: IBasicOcspResp; const AIssuerCert: IX509Certificate;
   const AIssuerPublicKey: IAsymmetricKeyParameter; AValidityDate: TDateTime): Boolean;
 var
@@ -2100,7 +2359,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.ValidateOcspStaple(const ALeafCert, AIssuerCert,
+function TRevocationChecker.ValidateOcspStaple(const ALeafCert, AIssuerCert,
   AOcspResponseDer: TBytes; const AValidationTimeUtc: TDateTime;
   out AStatus: TOcspStatus; out AThisUpdate, ANextUpdate: TDateTime): Boolean;
 var
@@ -2177,7 +2436,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.BuildOcspRequest(const ALeafCert,
+function TRevocationChecker.BuildOcspRequest(const ALeafCert,
   AIssuerCert: TBytes; out ARequestDer: TBytes): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2207,7 +2466,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.TryGetOcspResponderUrl(const ACert: TBytes;
+function TRevocationChecker.TryGetOcspResponderUrl(const ACert: TBytes;
   out AUrl: string): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2251,7 +2510,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.TryGetCrlDistributionPoints(const ACert: TBytes;
+function TRevocationChecker.TryGetCrlDistributionPoints(const ACert: TBytes;
   out AUrls: TArray<string>): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2303,7 +2562,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CheckCrlRevocation(const ALeafCert, AIssuerCert,
+function TRevocationChecker.CheckCrlRevocation(const ALeafCert, AIssuerCert,
   ACrlDer: TBytes; out ARevoked: Boolean): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2347,7 +2606,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CertificatePeerInfo(const ACertificateDer: TBytes;
+function TCertificateInspector.PeerInfo(const ACertificateDer: TBytes;
   out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2380,7 +2639,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CertificateTlsFeatures(const ACert: TBytes;
+function TCertificateInspector.TlsFeatures(const ACert: TBytes;
   out AFeatures: TArray<UInt16>): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2434,7 +2693,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CertificateKeyUsagePermits(
+function TCertificateInspector.KeyUsagePermits(
   const ACertificateDer: TBytes; AUsage: TCertKeyUsage;
   out APermitted: Boolean): Boolean;
 var
@@ -2472,7 +2731,7 @@ begin
   APermitted := (LIndex >= 0) and (LIndex <= High(LBits)) and LBits[LIndex];
 end;
 
-function TDefaultCryptoProvider.CertificateHasRsaPssKey(
+function TCertificateInspector.HasRsaPssKey(
   const ACertificateDer: TBytes; out AIsRsaPss: Boolean): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2491,7 +2750,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CertificateKeyKind(const ACertificateDer: TBytes;
+function TCertificateInspector.KeyKind(const ACertificateDer: TBytes;
   out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
 var
   LParser: IX509CertificateParser;
@@ -2535,7 +2794,7 @@ begin
     Result := False;
 end;
 
-function TDefaultCryptoProvider.CreateKeyAgreement(
+function TCryptoPrimitives.CreateKeyAgreement(
   AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
 begin
   case AAlgorithm of
@@ -2554,7 +2813,7 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.CreateKem(AAlgorithm: TKemAlgorithm): IKem;
+function TCryptoPrimitives.CreateKem(AAlgorithm: TKemAlgorithm): IKem;
 begin
   case AAlgorithm of
     TKemAlgorithm.ML_KEM_768:
@@ -2566,9 +2825,58 @@ begin
   end;
 end;
 
-function TDefaultCryptoProvider.HasHardwareAes: Boolean;
+function TCryptoPrimitives.HasHardwareAes: Boolean;
 begin
   Result := FHasHardwareAes;
+end;
+
+{ TCryptoProviderBuilder }
+
+function TCryptoProviderBuilder.WithRandom(
+  const ARandom: IRandom): ICryptoProviderBuilder;
+begin
+  FOverrides.Random := ARandom;
+  Result := Self;
+end;
+
+function TCryptoProviderBuilder.WithPrimitives(
+  const APrimitives: ICryptoPrimitives): ICryptoProviderBuilder;
+begin
+  FOverrides.Primitives := APrimitives;
+  Result := Self;
+end;
+
+function TCryptoProviderBuilder.WithSigning(
+  const ASigning: ISigningCrypto): ICryptoProviderBuilder;
+begin
+  FOverrides.Signing := ASigning;
+  Result := Self;
+end;
+
+function TCryptoProviderBuilder.WithInspector(
+  const AInspector: ICertificateInspector): ICryptoProviderBuilder;
+begin
+  FOverrides.Inspector := AInspector;
+  Result := Self;
+end;
+
+function TCryptoProviderBuilder.WithPathValidation(
+  const APathValidation: ICertificatePathValidator): ICryptoProviderBuilder;
+begin
+  FOverrides.PathValidation := APathValidation;
+  Result := Self;
+end;
+
+function TCryptoProviderBuilder.WithRevocation(
+  const ARevocation: IRevocationChecker): ICryptoProviderBuilder;
+begin
+  FOverrides.Revocation := ARevocation;
+  Result := Self;
+end;
+
+function TCryptoProviderBuilder.Build: ICryptoProvider;
+begin
+  Result := TDefaultCryptoProvider.Create(FOverrides) as ICryptoProvider;
 end;
 
 end.

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -1625,7 +1625,6 @@ constructor TDefaultCryptoProvider.Create;
 var
   LOverrides: TCryptoProviderOverrides;
 begin
-  // hoist Default() to a local (Delphi Default-in-argument-position insurance)
   LOverrides := Default(TCryptoProviderOverrides);
   Create(LOverrides);
 end;
@@ -1657,13 +1656,8 @@ begin
 end;
 
 procedure TRandomGeneratorBridge.NextBytes(const ABytes: TCryptoLibByteArray);
-var
-  LGen: TBytes;
 begin
-  if System.Length(ABytes) = 0 then
-    Exit;
-  LGen := FRandom.GenerateBytes(System.Length(ABytes));
-  System.Move(LGen[0], ABytes[0], System.Length(ABytes));
+  NextBytes(ABytes, 0, System.Length(ABytes));
 end;
 
 procedure TRandomGeneratorBridge.NextBytes(const ABytes: TCryptoLibByteArray;

--- a/TlsLib/src/Crypto/TlpNamedGroups.pas
+++ b/TlsLib/src/Crypto/TlpNamedGroups.pas
@@ -245,9 +245,9 @@ end;
 constructor TX25519MlKem768Group.Create(const AProvider: ICryptoProvider);
 begin
   inherited Create;
-  FX25519 := TKeyAgreementGroup.Create(AProvider.CreateKeyAgreement(TKeyAgreementAlgorithm.X25519),
+  FX25519 := TKeyAgreementGroup.Create(AProvider.Primitives.CreateKeyAgreement(TKeyAgreementAlgorithm.X25519),
     TNamedGroupCatalog.X25519);
-  FMlKem := TKemGroup.Create(AProvider.CreateKem(TKemAlgorithm.ML_KEM_768),
+  FMlKem := TKemGroup.Create(AProvider.Primitives.CreateKem(TKemAlgorithm.ML_KEM_768),
     TNamedGroupCatalog.MlKem768);
 end;
 
@@ -374,7 +374,7 @@ end;
 
 class function TNamedGroups.CreateX25519(const AProvider: ICryptoProvider): INamedGroup;
 begin
-  Result := TKeyAgreementGroup.Create(AProvider.CreateKeyAgreement(TKeyAgreementAlgorithm.X25519),
+  Result := TKeyAgreementGroup.Create(AProvider.Primitives.CreateKeyAgreement(TKeyAgreementAlgorithm.X25519),
     TNamedGroupCatalog.X25519);
 end;
 
@@ -388,12 +388,12 @@ begin
   TNamedGroupCatalog.TryCode(ACurveName, LCode);
   // the curve name resolves to the key-agreement enum (secp256r1 -> SECP256R1)
   TEnumUtilities.TryGetEnumValue<TKeyAgreementAlgorithm>(ACurveName, LAlg);
-  Result := TKeyAgreementGroup.Create(AProvider.CreateKeyAgreement(LAlg), LCode);
+  Result := TKeyAgreementGroup.Create(AProvider.Primitives.CreateKeyAgreement(LAlg), LCode);
 end;
 
 class function TNamedGroups.CreateMlKem768(const AProvider: ICryptoProvider): INamedGroup;
 begin
-  Result := TKemGroup.Create(AProvider.CreateKem(TKemAlgorithm.ML_KEM_768),
+  Result := TKemGroup.Create(AProvider.Primitives.CreateKem(TKemAlgorithm.ML_KEM_768),
     TNamedGroupCatalog.MlKem768);
 end;
 

--- a/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
+++ b/TlsLib/src/Engine/TlpTlsConfigBuilder.pas
@@ -1481,7 +1481,7 @@ function TTlsConfigBuilder.WithTrustAnchors(const AData: TBytes): TTlsConfigBuil
 begin
   GuardMutable;
   TArrayUtilities.Append<ITrustAnchorStore>(FAnchorStores,
-    TTrustAnchorStore.Create(FProvider.LoadCertificateChain(AData))
+    TTrustAnchorStore.Create(FProvider.Certificates.LoadChain(AData))
     as ITrustAnchorStore);
   Result := Self;
 end;
@@ -1542,8 +1542,8 @@ var
 begin
   GuardMutable;
   // a whole fresh record, so nothing (e.g. a staple) bleeds in from a prior credential
-  LCredential.CertificateChain := FProvider.LoadCertificateChain(ACertificateChainData);
-  LCredential.PrivateKey := FProvider.ImportSigningKey(APrivateKeyData);
+  LCredential.CertificateChain := FProvider.Certificates.LoadChain(ACertificateChainData);
+  LCredential.PrivateKey := FProvider.Signing.ImportSigningKey(APrivateKeyData);
   FCredential := LCredential;
   FHasCredential := True;
   Result := Self;
@@ -1556,8 +1556,8 @@ var
 begin
   GuardMutable;
   // a whole fresh record, so nothing (e.g. a staple) bleeds in from a prior credential
-  LCredential.CertificateChain := FProvider.LoadCertificateChain(ACertificateChainData);
-  LCredential.PrivateKey := FProvider.ImportSigningKey(APrivateKeyData, APassword);
+  LCredential.CertificateChain := FProvider.Certificates.LoadChain(ACertificateChainData);
+  LCredential.PrivateKey := FProvider.Signing.ImportSigningKey(APrivateKeyData, APassword);
   FCredential := LCredential;
   FHasCredential := True;
   Result := Self;
@@ -1567,7 +1567,7 @@ function TTlsConfigBuilder.WithCredentialPkcs12(const AData: TBytes;
   const APassword: string): TTlsConfigBuilder;
 begin
   GuardMutable;
-  FCredential := FProvider.ImportPkcs12(AData, APassword);
+  FCredential := FProvider.Signing.ImportPkcs12(AData, APassword);
   FHasCredential := True;
   Result := Self;
 end;
@@ -1591,8 +1591,8 @@ var
   LCredential: TTlsCredential;
 begin
   GuardMutable;
-  LCredential.CertificateChain := FProvider.LoadCertificateChain(ACertificateChainData);
-  LCredential.PrivateKey := FProvider.ImportSigningKey(APrivateKeyData);
+  LCredential.CertificateChain := FProvider.Certificates.LoadChain(ACertificateChainData);
+  LCredential.PrivateKey := FProvider.Signing.ImportSigningKey(APrivateKeyData);
   Result := WithSniCredential(AHost, LCredential);
 end;
 
@@ -1603,8 +1603,8 @@ var
   LCredential: TTlsCredential;
 begin
   GuardMutable;
-  LCredential.CertificateChain := FProvider.LoadCertificateChain(ACertificateChainData);
-  LCredential.PrivateKey := FProvider.ImportSigningKey(APrivateKeyData, APassword);
+  LCredential.CertificateChain := FProvider.Certificates.LoadChain(ACertificateChainData);
+  LCredential.PrivateKey := FProvider.Signing.ImportSigningKey(APrivateKeyData, APassword);
   Result := WithSniCredential(AHost, LCredential);
 end;
 
@@ -1625,7 +1625,7 @@ var
 begin
   if System.Length(ACredential.CertificateChain) = 0 then
     raise EInvalidOperationTlsLibException.CreateResFmt(@SSniCertMissing, [AHost]);
-  LSans := FProvider.CertificateDnsNames(ACredential.CertificateChain[0]);
+  LSans := FProvider.Certificates.DnsNames(ACredential.CertificateChain[0]);
   if Pos('*', AHost) = 0 then
     // an exact host must be covered by the leaf's dNSName SANs (RFC 6125/9525)
     LOk := TEndpointIdentity.Matches(AHost, LSans, nil)
@@ -1797,7 +1797,7 @@ var
 begin
   GuardMutable;
   // parse the bundle and accumulate, so successive calls add more intermediates
-  LCerts := FProvider.LoadCertificateChain(AData);
+  LCerts := FProvider.Certificates.LoadChain(AData);
   for LI := 0 to System.High(LCerts) do
     TArrayUtilities.Append<TBytes>(FIntermediateCertificates, LCerts[LI]);
   Result := Self;

--- a/TlsLib/src/Engine/TlpTlsEngineFactory.pas
+++ b/TlsLib/src/Engine/TlpTlsEngineFactory.pas
@@ -215,8 +215,8 @@ begin
     LVerdictDeadlineMs := 0;
   // the two client machines must share one client random and session id so a 1.2
   // hand-off keeps the ServerKeyExchange/master-secret binding of the sent ClientHello
-  LClientRandom := AConfig.Provider.GetRandom.GenerateBytes(32);
-  LSessionId := AConfig.Provider.GetRandom.GenerateBytes(32);
+  LClientRandom := AConfig.Provider.Primitives.GetRandom.GenerateBytes(32);
+  LSessionId := AConfig.Provider.Primitives.GetRandom.GenerateBytes(32);
   // an injected whole-verifier replaces the built-in pipeline (it consults no anchors)
   if AConfig.CertificateVerifier <> nil then
     LVerifier := AConfig.CertificateVerifier
@@ -335,7 +335,7 @@ var
 begin
   LOffers13 := Offers(AConfig, TlsWireVersionTls13);
   LOffers12 := Offers(AConfig, TlsWireVersionTls12);
-  LServerRandom := AConfig.Provider.GetRandom.GenerateBytes(32);
+  LServerRandom := AConfig.Provider.Primitives.GetRandom.GenerateBytes(32);
   // the async client-certificate verdict parks the handshake after the pipeline accepts the
   // client chain (only meaningful when the server requests client authentication)
   LAsyncVerdict := AConfig.AsyncCertificateVerdict.Enabled and
@@ -371,7 +371,7 @@ begin
   // memoize that compression across connections (a stable certificate deflates once)
   L13.CertificateCompressionCache := AConfig.CertificateCompressionCache;
   // a per-server-instance secret so the server can answer with a stateless HelloRetryRequest
-  L13.CookieSecret := TSecretBuffer.From(AConfig.Provider.GetRandom.GenerateBytes(32));
+  L13.CookieSecret := TSecretBuffer.From(AConfig.Provider.Primitives.GetRandom.GenerateBytes(32));
   // the resolver selects the credential per handshake from the client's SNI (virtual hosting);
   // each credential carries the chain, key, and (when set) the OCSP staple the server sends for
   // its leaf once the client offers status_request

--- a/TlsLib/src/Engine/TlpTlsSignatureBuilder.pas
+++ b/TlsLib/src/Engine/TlpTlsSignatureBuilder.pas
@@ -140,7 +140,7 @@ begin
     Append(AName + PairSep + '<empty>');
     Exit;
   end;
-  LHash := FProvider.CreateHash(THashAlgorithm.SHA_256);
+  LHash := FProvider.Primitives.CreateHash(THashAlgorithm.SHA_256);
   LHash.Update(AData, 0, System.Length(AData));
   LDigest := LHash.DoFinal;
   Append(AName + PairSep + TDataEncoding.HexEncode(LDigest));

--- a/TlsLib/src/Handshake/TlpCertificateVerify.pas
+++ b/TlsLib/src/Handshake/TlpCertificateVerify.pas
@@ -79,7 +79,7 @@ var
 begin
   // CertificatePeerInfo parses the whole certificate and never raises: False means the DER
   // is not a well-formed X.509 certificate, so reject it before any downstream cert use.
-  if not AProvider.CertificatePeerInfo(ALeafCertificate, LSubject, LIssuer,
+  if not AProvider.Certificates.PeerInfo(ALeafCertificate, LSubject, LIssuer,
     LCommonName, LSerialHex) then
     raise EDecodeErrorTlsLibException.CreateRes(@SUnparseableLeafCertificate);
 end;
@@ -129,12 +129,12 @@ var
   LKind: TCertKeyKind;
   LCertGroup, LSchemeGroup: UInt16;
 begin
-  if AProvider.CertificateKeyUsagePermits(ALeafCertificate,
+  if AProvider.Certificates.KeyUsagePermits(ALeafCertificate,
     TCertKeyUsage.DigitalSignature, LPermitted) and not LPermitted then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.BadCertificate, @SLeafKeyUsageForbidsSigning);
   if AScheme.IsRsaPssRsae and
-    AProvider.CertificateHasRsaPssKey(ALeafCertificate, LIsRsaPss) and LIsRsaPss then
+    AProvider.Certificates.HasRsaPssKey(ALeafCertificate, LIsRsaPss) and LIsRsaPss then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.IllegalParameter, @SPssLeafKeyUnsupported);
   // TLS 1.3 binds the ECDSA curve to the signature scheme: an ecdsa_secp384r1_sha384
@@ -143,7 +143,7 @@ begin
   begin
     LSchemeGroup := EcdsaSchemeNamedGroup(AScheme);
     if (LSchemeGroup <> 0) and
-      AProvider.CertificateKeyKind(ALeafCertificate, LKind, LCertGroup) and
+      AProvider.Certificates.KeyKind(ALeafCertificate, LKind, LCertGroup) and
       (LKind = TCertKeyKind.Ecdsa) and (LCertGroup <> LSchemeGroup) then
       raise EFatalAlertTlsLibException.CreateRes(
         TTlsAlertDescription.IllegalParameter, @SEcdsaSchemeCurveMismatch);

--- a/TlsLib/src/Handshake/TlpHandshakeDriver.pas
+++ b/TlsLib/src/Handshake/TlpHandshakeDriver.pas
@@ -87,7 +87,7 @@ begin
   // driver needs no up-front suite (a live client does not know the version or suite
   // until the ServerHello)
   LProtection := TRecordProtectionFactory.Build(AEffect.Version, AEffect.Keys,
-    FProvider.CreateAead(AEffect.Aead));
+    FProvider.Primitives.CreateAead(AEffect.Aead));
   // the negotiated version rides every key install; surface it for connection info
   if FVersionSink <> nil then
     FVersionSink.OnVersionNegotiated(AEffect.Version);

--- a/TlsLib/src/Handshake/TlpHelloRetryCookie.pas
+++ b/TlsLib/src/Handshake/TlpHelloRetryCookie.pas
@@ -71,7 +71,7 @@ function THelloRetryCookie.Mac(const AContent: TBytes): TBytes;
 var
   LHmac: IHmac;
 begin
-  LHmac := FProvider.CreateHmac(THashAlgorithm.SHA_256);
+  LHmac := FProvider.Primitives.CreateHmac(THashAlgorithm.SHA_256);
   LHmac.Init(FSecret);
   LHmac.Update(AContent, 0, System.Length(AContent));
   Result := LHmac.DoFinal;

--- a/TlsLib/src/Handshake/TlpTls12ClientStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls12ClientStateMachine.pas
@@ -341,7 +341,7 @@ begin
           FOfferedSessionId := FResumptionOffer.SessionId
         else if System.Length(FResumptionOffer.SessionTicket) > 0 then
           // a ticket-only session still carries an id so the server's echo signals resumption
-          FOfferedSessionId := FParams.Provider.GetRandom.GenerateBytes(32);
+          FOfferedSessionId := FParams.Provider.Primitives.GetRandom.GenerateBytes(32);
         LHello.LegacySessionId := FOfferedSessionId;
       end;
     end;
@@ -422,7 +422,7 @@ begin
 
   FServerRandom := LHello.Random;
   FServerSessionId := LHello.LegacySessionIdEcho;
-  FTranscript.Activate(FParams.Provider.CreateHash(FSelectedSuite.Common.Hash));
+  FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash));
   Absorb(AMessage.Raw);
 
   LContext := TExtensionContext.Create;
@@ -520,7 +520,7 @@ begin
   // a server leaf that is not a well-formed certificate is a decode error
   TCertificateVerify.EnsureWellFormedLeaf(FParams.Provider, FCertChain[0]);
 
-  if FParams.Provider.CertificateKeyKind(FCertChain[0], LKind, LEcGroup) then
+  if FParams.Provider.Certificates.KeyKind(FCertChain[0], LKind, LEcGroup) then
   begin
     // the leaf key algorithm must match the negotiated suite's authentication method (a
     // CertificateCipherMismatch, RFC 5246 7.4.2): an *_RSA suite needs an RSA leaf; an
@@ -597,8 +597,8 @@ begin
   LContent := TArrayUtilities.Concat(
     TArrayUtilities.Concat(FParams.ClientRandom, FServerRandom),
     THandshakeMessages.EcdheServerParams(LSke.NamedCurve, LSke.PublicKey));
-  LPublicKeyInfo := FParams.Provider.CertificatePublicKeyInfo(FCertChain[0]);
-  LVerifier := FParams.Provider.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
+  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FCertChain[0]);
+  LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(LContent, 0, System.Length(LContent));
   if not LVerifier.Verify(LSke.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
@@ -656,7 +656,7 @@ begin
   // usable signature scheme must exist; otherwise present an empty Certificate (RFC 5246 7.4.4)
   LCertType := 0;
   if (System.Length(LChain) > 0) and
-    FParams.Provider.CertificateKeyKind(LChain[0], LKind, LEcGroup) then
+    FParams.Provider.Certificates.KeyKind(LChain[0], LKind, LEcGroup) then
   begin
     if LKind = TCertKeyKind.Rsa then
       LCertType := RsaSignCertType
@@ -722,7 +722,7 @@ begin
   // a CertificateVerify proves possession over the raw handshake log through the CKE
   if LSentCertificate then
   begin
-    LSigner := FParams.Provider.CreateSignatureSigner(LScheme,
+    LSigner := FParams.Provider.Signing.CreateSignatureSigner(LScheme,
       FParams.ClientCredential.PrivateKey);
     LSigner.Update(FHandshakeLog, 0, System.Length(FHandshakeLog));
     LVerify.Algorithm := LScheme.ToCode;

--- a/TlsLib/src/Handshake/TlpTls12ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls12ServerStateMachine.pas
@@ -403,7 +403,7 @@ begin
   Result := True;
   if System.Length(FResolvedCredential.CertificateChain) = 0 then
     Exit;
-  if not FParams.Provider.CertificateKeyKind(
+  if not FParams.Provider.Certificates.KeyKind(
     FResolvedCredential.CertificateChain[0], LKind, LCurve) then
     Exit;
   if LKind <> TCertKeyKind.Ecdsa then
@@ -501,7 +501,7 @@ begin
   // a full handshake issues a fresh session id (when a store is configured) and, when
   // the client supports tickets, a NewSessionTicket sealed under the STEK
   if FParams.SessionStore <> nil then
-    FSessionId := FParams.Provider.GetRandom.GenerateBytes(SessionIdLength)
+    FSessionId := FParams.Provider.Primitives.GetRandom.GenerateBytes(SessionIdLength)
   else
     FSessionId := nil;
   FIssueNewTicket := (FTicketStrategy <> nil) and FClientOfferedSessionTicket;
@@ -517,7 +517,7 @@ begin
   // transcript and the raw handshake log (the client CertificateVerify signs the log)
   FHandshakeLog := System.Copy(AMessage.Raw);
   FTranscript.Update(AMessage.Raw);
-  FTranscript.Activate(FParams.Provider.CreateHash(FSelectedSuite.Common.Hash));
+  FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash));
   // staple when the client offered status_request and a staple is configured; the
   // ServerHello echoes an empty status_request and a CertificateStatus follows the
   // Certificate (RFC 6066 8)
@@ -656,7 +656,7 @@ begin
   // the SKE signature covers client_random + server_random + the ECDHE params (RFC 8422 5.4)
   LContent := TArrayUtilities.Concat(
     TArrayUtilities.Concat(FClientRandom, FServerRandom), AParams);
-  LSigner := FParams.Provider.CreateSignatureSigner(FSelectedScheme,
+  LSigner := FParams.Provider.Signing.CreateSignatureSigner(FSelectedScheme,
     FResolvedCredential.PrivateKey);
   LSigner.Update(LContent, 0, System.Length(LContent));
   Result := LSigner.Sign;
@@ -784,8 +784,8 @@ begin
     FClientCertChain[0], LScheme, False);
   // the 1.2 CertificateVerify signs the raw handshake log through ClientKeyExchange;
   // the scheme applies its own hash, so the suite PRF hash does not matter here
-  LPublicKeyInfo := FParams.Provider.CertificatePublicKeyInfo(FClientCertChain[0]);
-  LVerifier := FParams.Provider.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
+  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FClientCertChain[0]);
+  LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(FHandshakeLog, 0, System.Length(FHandshakeLog));
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
@@ -891,7 +891,7 @@ begin
   // the abbreviated transcript is ClientHello, ServerHello, [NewSessionTicket]; the raw
   // handshake log is unused (no CertificateVerify on an abbreviated handshake)
   FTranscript.Update(AClientHelloRaw);
-  FTranscript.Activate(FParams.Provider.CreateHash(FSelectedSuite.Common.Hash));
+  FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash));
   LServerHello := BuildServerHello;
   FTranscript.Update(LServerHello);
 

--- a/TlsLib/src/Handshake/TlpTls13ClientStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ClientStateMachine.pas
@@ -458,7 +458,7 @@ begin
       // choose the seed once; a HelloRetryRequest retry reuses it so its GREASE codepoints
       // match the first ClientHello exactly (RFC 8446 4.1.4)
       if FGreaseSeed < 0 then
-        FGreaseSeed := FParams.Provider.GetRandom.GenerateBytes(1)[0];
+        FGreaseSeed := FParams.Provider.Primitives.GetRandom.GenerateBytes(1)[0];
       LSeed := FGreaseSeed;
       LContext.SupportedVersions := TGrease.Prepend(LContext.SupportedVersions,
         TGrease.ValueAt(LSeed));
@@ -517,7 +517,7 @@ begin
         else
           LContext.OfferedPskAges[LI] := 0;
         SetLength(LContext.OfferedPskBinders[LI],
-          FParams.Provider.CreateHash(FPskOffers[LI].Hash).HashSize);
+          FParams.Provider.Primitives.CreateHash(FPskOffers[LI].Hash).HashSize);
       end;
     end;
 
@@ -561,7 +561,7 @@ function TTls13ClientStateMachine.HashUnder(AHash: THashAlgorithm;
 var
   LHash: IHash;
 begin
-  LHash := FParams.Provider.CreateHash(AHash);
+  LHash := FParams.Provider.Primitives.CreateHash(AHash);
   LHash.Update(AData, 0, System.Length(AData));
   Result := LHash.DoFinal;
 end;
@@ -575,7 +575,7 @@ begin
   // the binders vector: a 2-byte list length, then per PSK a 1-byte entry length + binder
   LBindersLen := 2;
   for LI := 0 to High(FPskOffers) do
-    Inc(LBindersLen, 1 + FParams.Provider.CreateHash(FPskOffers[LI].Hash).HashSize);
+    Inc(LBindersLen, 1 + FParams.Provider.Primitives.CreateHash(FPskOffers[LI].Hash).HashSize);
   LTotal := System.Length(AClientHello);
   LPartial := System.Copy(AClientHello, 0, LTotal - LBindersLen);
 
@@ -586,7 +586,7 @@ begin
   LOffset := (LTotal - LBindersLen) + 2; // past the 2-byte binders list length
   for LI := 0 to High(FPskOffers) do
   begin
-    LHashLen := FParams.Provider.CreateHash(FPskOffers[LI].Hash).HashSize;
+    LHashLen := FParams.Provider.Primitives.CreateHash(FPskOffers[LI].Hash).HashSize;
     if FTranscript.IsActive then
       LPrefixHash := FTranscript.HashPrefixExcludingBinders(LPartial)
     else
@@ -729,7 +729,7 @@ begin
   // resumption / 0-RTT path relies on it); several offers defer activation to ServerHello
   if System.Length(FPskOffers) = 1 then
   begin
-    FTranscript.Activate(FParams.Provider.CreateHash(FPskOffers[0].Hash));
+    FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FPskOffers[0].Hash));
     FTranscriptPreActivated := True;
     FPreActivatedHash := FPskOffers[0].Hash;
   end;
@@ -803,7 +803,7 @@ var
   LFresh: ITranscriptHash;
 begin
   LFresh := TTranscriptHash.Create(
-    FParams.Provider.CreateHash(FSelectedSuite.Common.Hash));
+    FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash));
   LFresh.Update(FSentClientHelloRaw);
   FTranscript := LFresh;
 end;
@@ -872,7 +872,7 @@ begin
   // a different hash (a 0-RTT reject that changes the PRF), rebuild the transcript from the
   // raw first ClientHello under the newly selected hash so the derivations match the peer.
   if not FTranscript.IsActive then
-    FTranscript.Activate(FParams.Provider.CreateHash(FSelectedSuite.Common.Hash))
+    FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash))
   else if FTranscriptPreActivated and
     (FPreActivatedHash <> FSelectedSuite.Common.Hash) then
     RebuildTranscriptUnderSelectedHash;
@@ -1097,10 +1097,10 @@ begin
   // retry-selected hash (RFC 8446 4.4.1), computed from the RAW first ClientHello. Using the
   // raw bytes keeps this correct even when a single-PSK resumption pre-activated the transcript
   // under a different hash the retry then rejects (a non-resumable-cipher HRR). Then add the HRR.
-  LCh1Hash := FParams.Provider.CreateHash(FSelectedSuite.Common.Hash);
+  LCh1Hash := FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash);
   LCh1Hash.Update(FSentClientHelloRaw, 0, System.Length(FSentClientHelloRaw));
   FTranscript.SeedWithMessageHash(
-    FParams.Provider.CreateHash(FSelectedSuite.Common.Hash), LCh1Hash.DoFinal);
+    FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash), LCh1Hash.DoFinal);
   FTranscript.Update(AMessage.Raw);
   // the retry-selected hash is now the transcript's hash, so the pre-activation reconciliation
   // (the different-PRF rebuild in ProcessServerHello) no longer applies to the next ServerHello
@@ -1308,8 +1308,8 @@ begin
 
   // the signature is over the transcript through the Certificate (this message not yet folded in)
   LContent := TCertificateVerify.SignatureContent(True, FTranscript.CurrentHash);
-  LPublicKeyInfo := FParams.Provider.CertificatePublicKeyInfo(FCertificateChain[0]);
-  LVerifier := FParams.Provider.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
+  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FCertificateChain[0]);
+  LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(LContent, 0, System.Length(LContent));
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
@@ -1395,7 +1395,7 @@ begin
     Exit;
   // the CertificateVerify signs the transcript through the client Certificate
   LContent := TCertificateVerify.SignatureContent(False, FTranscript.CurrentHash);
-  LSigner := FParams.Provider.CreateSignatureSigner(LScheme,
+  LSigner := FParams.Provider.Signing.CreateSignatureSigner(LScheme,
     FParams.ClientCredential.PrivateKey);
   LSigner.Update(LContent, 0, System.Length(LContent));
   LVerify.Algorithm := LScheme.ToCode;

--- a/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
@@ -452,7 +452,7 @@ function TTls13ServerStateMachine.HashOf(const AData: TBytes): TBytes;
 var
   LHash: IHash;
 begin
-  LHash := FParams.Provider.CreateHash(FSelectedSuite.Common.Hash);
+  LHash := FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash);
   LHash.Update(AData, 0, System.Length(AData));
   Result := LHash.DoFinal;
 end;
@@ -984,7 +984,7 @@ begin
     begin
       // transcript: ClientHello, then (activated) ServerHello inside EmitServerFlight
       FTranscript.Update(AMessage.Raw);
-      FTranscript.Activate(FParams.Provider.CreateHash(FSelectedSuite.Common.Hash));
+      FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash));
       // the client_early_traffic secret is over the ClientHello-only transcript
       if FEarlyDataAccepted then
         FEarlyTranscriptHash := FTranscript.CurrentHash;
@@ -1092,7 +1092,7 @@ begin
     // reconstructed HelloRetryRequest (byte-identical to the one sent, from the
     // echoed cookie), then this ClientHello
     FTranscript := TTranscriptHash.Create;
-    FTranscript.SeedWithMessageHash(FParams.Provider.CreateHash(FSelectedSuite.Common.Hash),
+    FTranscript.SeedWithMessageHash(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash),
       LCh1Hash);
     LHrr := BuildHelloRetryRequest(LClientHello.LegacySessionId, LSelectedGroup,
       LContext.Cookie);
@@ -1451,8 +1451,8 @@ begin
     FClientCertChain[0], LScheme, True);
   // the client signs the transcript through its Certificate, client-side context string
   LContent := TCertificateVerify.SignatureContent(False, FTranscript.CurrentHash);
-  LPublicKeyInfo := FParams.Provider.CertificatePublicKeyInfo(FClientCertChain[0]);
-  LVerifier := FParams.Provider.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
+  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FClientCertChain[0]);
+  LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(LContent, 0, System.Length(LContent));
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
@@ -1469,7 +1469,7 @@ var
   LVerify: TTlsCertificateVerify;
 begin
   LContent := TCertificateVerify.SignatureContent(True, ATranscriptHash);
-  LSigner := FParams.Provider.CreateSignatureSigner(
+  LSigner := FParams.Provider.Signing.CreateSignatureSigner(
     FSelectedSignatureScheme, FResolvedCredential.PrivateKey);
   LSigner.Update(LContent, 0, System.Length(LContent));
   LVerify.Algorithm := FSelectedSignatureScheme.ToCode;
@@ -1546,11 +1546,11 @@ begin
     LLifetime := MaxTicketLifetimeSeconds;
   for LI := 0 to FParams.IssueTicketCount - 1 do
   begin
-    LNonce := FParams.Provider.GetRandom.GenerateBytes(TicketNonceLength);
+    LNonce := FParams.Provider.Primitives.GetRandom.GenerateBytes(TicketNonceLength);
     // a fresh random ticket_age_add per ticket obfuscates the wire age (RFC 8446 4.6.1);
     // the same value is sealed into the session so the offered age reconciles on resumption
     LAgeAdd := TBinaryPrimitives.ReadUInt32BigEndian(
-      FParams.Provider.GetRandom.GenerateBytes(4), 0);
+      FParams.Provider.Primitives.GetRandom.GenerateBytes(4), 0);
     LPsk := FSchedule.ResumptionPsk(FResumptionTranscriptHash, LNonce);
     // the ticket identity is the sealed/handle output, so the session's own id is unused;
     // MaxEarlyData authorizes 0-RTT on the resumed connection

--- a/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
+++ b/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
@@ -23,6 +23,12 @@ uses
   TlpISecretBuffer;
 
 type
+  /// <summary>An AEAD's usage-limit family: AES-GCM must proactively rekey by a
+  /// record-count bound, ChaCha20-Poly1305 is bounded only by the record sequence.</summary>
+  TAeadUsageCategory = (AesGcm, ChaCha20);
+
+{ ===== Primitive interfaces ===== }
+
   /// <summary>
   /// The CSPRNG. Failure is a hard fail - a randomness failure raises, never a
   /// weak or zero fallback.
@@ -80,10 +86,6 @@ type
       ALength: Int32): ISecretBuffer;
   end;
 
-  /// <summary>An AEAD's usage-limit family: AES-GCM must proactively rekey by a
-  /// record-count bound, ChaCha20-Poly1305 is bounded only by the record sequence.</summary>
-  TAeadUsageCategory = (AesGcm, ChaCha20);
-
   /// <summary>
   /// An AEAD cipher. The key is set once via <see cref="Init" />; the nonce and
   /// associated data are per message. <see cref="Open" /> raises on an
@@ -107,29 +109,6 @@ type
     function Seal(const ANonce, AAad, APlaintext: TBytes): TBytes;
     /// <summary>Authenticates and decrypts ciphertext||tag; raises on auth failure.</summary>
     function Open(const ANonce, AAad, ACiphertext: TBytes): TBytes;
-  end;
-
-  /// <summary>
-  /// Produces a signature over fed data with a loaded private key, for a TLS 1.3
-  /// signature scheme (RSA-PSS / ECDSA / EdDSA). Feed the to-be-signed bytes via
-  /// <see cref="Update" />, then <see cref="Sign" />.
-  /// </summary>
-  ISignatureSigner = interface(IInterface)
-    ['{9B1CAFD9-7162-4B3A-8615-6DD9AC6C0A7E}']
-    function AlgorithmName: string;
-    procedure Update(const AData: TBytes; AOffset, ALength: Int32);
-    function Sign: TBytes;
-  end;
-
-  /// <summary>
-  /// Verifies a signature over fed data against a loaded public key. Verification
-  /// is fail-closed: any malformed input returns False, never raises.
-  /// </summary>
-  ISignatureVerifier = interface(IInterface)
-    ['{AE23AEDF-7BCD-42A3-A5A9-2D49868D4FDC}']
-    function AlgorithmName: string;
-    procedure Update(const AData: TBytes; AOffset, ALength: Int32);
-    function Verify(const ASignature: TBytes): Boolean;
   end;
 
   /// <summary>
@@ -170,18 +149,58 @@ type
   end;
 
   /// <summary>
-  /// The single, total crypto seam. Vends the provider primitives by descriptor
-  /// and reports machine-checkable capabilities. It does not select or fall back
-  /// between algorithms - that is the negotiation policy's job; the provider only
-  /// reports capability and returns correct results.
+  /// Vends the raw crypto primitives by descriptor and reports machine-checkable
+  /// capabilities. It does not select or fall back between algorithms - that is
+  /// the negotiation policy's job; it only reports capability and returns correct
+  /// results.
   /// </summary>
-  ICryptoProvider = interface(IInterface)
-    ['{4FE6E7A9-2E66-4D31-8CF3-AE6BE6632664}']
+  ICryptoPrimitives = interface(IInterface)
+    ['{55A260D5-E22D-4876-894B-5FB957433E38}']
     function GetRandom: IRandom;
     function CreateHash(AAlgorithm: THashAlgorithm): IHash;
     function CreateHmac(AAlgorithm: THashAlgorithm): IHmac;
     function CreateHkdf(AAlgorithm: THashAlgorithm): IHkdf;
     function CreateAead(AAlgorithm: TAeadAlgorithm): IAead;
+    function CreateKeyAgreement(AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
+    function CreateKem(AAlgorithm: TKemAlgorithm): IKem;
+    /// <summary>Whether hardware accelerated AES is present on this host.</summary>
+    function HasHardwareAes: Boolean;
+  end;
+
+{ ===== Signing interfaces ===== }
+
+  /// <summary>
+  /// Produces a signature over fed data with a loaded private key, for a TLS 1.3
+  /// signature scheme (RSA-PSS / ECDSA / EdDSA). Feed the to-be-signed bytes via
+  /// <see cref="Update" />, then <see cref="Sign" />.
+  /// </summary>
+  ISignatureSigner = interface(IInterface)
+    ['{9B1CAFD9-7162-4B3A-8615-6DD9AC6C0A7E}']
+    function AlgorithmName: string;
+    procedure Update(const AData: TBytes; AOffset, ALength: Int32);
+    function Sign: TBytes;
+  end;
+
+  /// <summary>
+  /// Verifies a signature over fed data against a loaded public key. Verification
+  /// is fail-closed: any malformed input returns False, never raises.
+  /// </summary>
+  ISignatureVerifier = interface(IInterface)
+    ['{AE23AEDF-7BCD-42A3-A5A9-2D49868D4FDC}']
+    function AlgorithmName: string;
+    procedure Update(const AData: TBytes; AOffset, ALength: Int32);
+    function Verify(const ASignature: TBytes): Boolean;
+  end;
+
+  /// <summary>
+  /// The signing-credential seam: imports private keys and PKCS#12 identities
+  /// into opaque backend handles and mints signers/verifiers over them. An
+  /// <see cref="ISigningKey" /> handle is meaningful only to the same backend's
+  /// <see cref="CreateSignatureSigner" />, so import and signer-minting are one
+  /// coherence domain.
+  /// </summary>
+  ISigningCrypto = interface(IInterface)
+    ['{367BAFEA-1828-4B5A-BA87-82CEDB994DD0}']
     /// <summary>
     /// Imports a signing private key in any supported encoding - PKCS#8, PKCS#1
     /// (RSAPrivateKey) or SEC1 (ECPrivateKey), in DER or PEM - into an opaque handle
@@ -196,25 +215,6 @@ type
     /// </summary>
     function ImportSigningKey(const AData: TBytes;
       const APassword: string): ISigningKey; overload;
-    /// <summary>A signer for AScheme over the imported signing key AKey.</summary>
-    function CreateSignatureSigner(AScheme: TSignatureScheme;
-      const AKey: ISigningKey): ISignatureSigner;
-    /// <summary>A verifier for AScheme over the SubjectPublicKeyInfo in APublicKeyDer.</summary>
-    function CreateSignatureVerifier(AScheme: TSignatureScheme;
-      const APublicKeyDer: TBytes): ISignatureVerifier;
-    /// <summary>
-    /// Decodes certificates from AData - a PEM block (a single certificate or a whole
-    /// leaf-first chain/bundle) or a single DER certificate - into their ordered raw
-    /// DER encodings. Serves both credential chains and trust anchors. Raises
-    /// EArgumentTlsLibException if nothing parses.
-    /// </summary>
-    function LoadCertificateChain(const AData: TBytes): TArray<TBytes>;
-    /// <summary>
-    /// True if ADer decodes as a structurally well-formed X.509 certificate. A
-    /// parse-only gate (no trust, expiry or signature check) used to screen raw
-    /// OS-harvested trust anchors before they reach path validation.
-    /// </summary>
-    function IsWellFormedCertificate(const ADer: TBytes): Boolean;
     /// <summary>
     /// Imports a PKCS#12 (.pfx/.p12) blob decrypted with APassword into a complete
     /// credential: the leaf and any intermediates as the chain (leaf first, DER) and an
@@ -226,12 +226,91 @@ type
     /// </summary>
     function ImportPkcs12(const AData: TBytes;
       const APassword: string): TTlsCredential;
+    /// <summary>A signer for AScheme over the imported signing key AKey.</summary>
+    function CreateSignatureSigner(AScheme: TSignatureScheme;
+      const AKey: ISigningKey): ISignatureSigner;
+    /// <summary>A verifier for AScheme over the SubjectPublicKeyInfo in APublicKeyDer.</summary>
+    function CreateSignatureVerifier(AScheme: TSignatureScheme;
+      const APublicKeyDer: TBytes): ISignatureVerifier;
+  end;
+
+{ ===== Certificate operations ===== }
+
+  /// <summary>
+  /// Pure, per-certificate, side-effect-free X.509 inspection. Every method is
+  /// fail-closed: it never raises on malformed input, returning False (or an empty
+  /// result) so the caller decides the alert.
+  /// </summary>
+  ICertificateInspector = interface(IInterface)
+    ['{243AB9CD-2900-4A04-B952-FEC3CD105B05}']
+    /// <summary>
+    /// Decodes certificates from AData - a PEM block (a single certificate or a whole
+    /// leaf-first chain/bundle) or a single DER certificate - into their ordered raw
+    /// DER encodings. Serves both credential chains and trust anchors. Raises
+    /// EArgumentTlsLibException if nothing parses.
+    /// </summary>
+    function LoadChain(const AData: TBytes): TArray<TBytes>;
+    /// <summary>
+    /// True if ADer decodes as a structurally well-formed X.509 certificate. A
+    /// parse-only gate (no trust, expiry or signature check) used to screen raw
+    /// OS-harvested trust anchors before they reach path validation.
+    /// </summary>
+    function IsWellFormed(const ADer: TBytes): Boolean;
     /// <summary>The DER SubjectPublicKeyInfo of the X.509 certificate in ACertificateDer.</summary>
-    function CertificatePublicKeyInfo(const ACertificateDer: TBytes): TBytes;
+    function PublicKeyInfo(const ACertificateDer: TBytes): TBytes;
     /// <summary>The dNSName SubjectAltName entries of the X.509 certificate in ACertificateDer.</summary>
-    function CertificateDnsNames(const ACertificateDer: TBytes): TArray<string>;
+    function DnsNames(const ACertificateDer: TBytes): TArray<string>;
     /// <summary>The iPAddress SAN entries (raw 4- or 16-byte octets) in ACertificateDer.</summary>
-    function CertificateIpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
+    function IpAddresses(const ACertificateDer: TBytes): TArray<TBytes>;
+    /// <summary>
+    /// Extracts a certificate's human-readable identity: the subject and issuer
+    /// distinguished names, the subject common name, and the serial number in hex. Returns
+    /// False (all empty) on a malformed certificate; never raises.
+    /// </summary>
+    function PeerInfo(const ACertificateDer: TBytes;
+      out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
+    /// <summary>
+    /// Reads the RFC 7633 TLS Feature extension (id-pe-tlsfeature, OID
+    /// 1.3.6.1.5.5.7.1.24) of the certificate and returns its feature codepoints.
+    /// An absent extension yields True with an empty list. A present value that is
+    /// not a well-formed ASN.1 SEQUENCE OF INTEGER yields False, so the caller can
+    /// abort with bad_certificate.
+    /// </summary>
+    function TlsFeatures(const ACert: TBytes;
+      out AFeatures: TArray<UInt16>): Boolean;
+    /// <summary>
+    /// Whether the certificate's keyUsage extension (RFC 5280 4.2.1.3) permits AUsage.
+    /// APermitted is True when the extension is absent (no restriction) or asserts the
+    /// bit; False only when the extension is present and the bit is clear. Returns
+    /// False (could not determine) on a malformed certificate, leaving APermitted True.
+    /// </summary>
+    function KeyUsagePermits(const ACertificateDer: TBytes;
+      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
+    /// <summary>
+    /// Whether the certificate's SubjectPublicKeyInfo algorithm is id-RSASSA-PSS
+    /// (OID 1.2.840.113549.1.1.10), the restricted RSA-PSS key type that the
+    /// rsa_pss_rsae_* schemes must not be used with (RFC 8446 4.2.3). Returns False
+    /// (could not determine) on a malformed certificate, leaving AIsRsaPss False.
+    /// </summary>
+    function HasRsaPssKey(const ACertificateDer: TBytes;
+      out AIsRsaPss: Boolean): Boolean;
+    /// <summary>
+    /// Classifies the certificate leaf key: AKind is the public-key algorithm, and for an
+    /// ECDSA key AEcNamedGroup is the named-group code of its curve (secp256r1 = 0x0017,
+    /// secp384r1 = 0x0018, secp521r1 = 0x0019), 0 otherwise. Returns False (could not
+    /// determine) on a malformed or unrecognized certificate, leaving AKind = Other.
+    /// </summary>
+    function KeyKind(const ACertificateDer: TBytes;
+      out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+  end;
+
+  /// <summary>
+  /// The trust decision: RFC 5280 path validation. The highest-stakes call in the
+  /// library - it raises a fatal-alert exception on failure rather than returning a
+  /// boolean.
+  /// </summary>
+  ICertificatePathValidator = interface(IInterface)
+    ['{2457CB06-FD52-43D1-BAF4-ADF7D932FCD5}']
     /// <summary>
     /// Validates the DER chain (leaf first) to one of the DER trust anchors (RFC
     /// 5280 path validation; revocation is out of band). Returns normally when the
@@ -252,6 +331,15 @@ type
     procedure ValidateCertificatePath(const AChain, ATrustAnchors,
       AIntermediates: TArray<TBytes>; const AValidationTimeUtc: TDateTime;
       var AEffectiveChain: TArray<TBytes>);
+  end;
+
+  /// <summary>
+  /// Revocation checks (OCSP / CRL). Indeterminate-tolerant: a Boolean result means
+  /// "could I determine", never raises a backend exception, so an unreachable or
+  /// malformed responder degrades to indeterminate rather than a hard failure.
+  /// </summary>
+  IRevocationChecker = interface(IInterface)
+    ['{B8D6113D-83F1-413C-921C-5D4CE9DCCEEF}']
     /// <summary>
     /// Verifies a stapled OCSP response (RFC 6960) about the leaf certificate,
     /// in-band only - no network. Confirms the response is signed by the leaf's
@@ -300,51 +388,44 @@ type
     /// </summary>
     function CheckCrlRevocation(const ALeafCert, AIssuerCert, ACrlDer: TBytes;
       out ARevoked: Boolean): Boolean;
-    /// <summary>
-    /// Extracts a certificate's human-readable identity: the subject and issuer
-    /// distinguished names, the subject common name, and the serial number in hex. Returns
-    /// False (all empty) on a malformed certificate; never raises.
-    /// </summary>
-    function CertificatePeerInfo(const ACertificateDer: TBytes;
-      out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-    /// <summary>
-    /// Reads the RFC 7633 TLS Feature extension (id-pe-tlsfeature, OID
-    /// 1.3.6.1.5.5.7.1.24) of the certificate and returns its feature codepoints.
-    /// An absent extension yields True with an empty list. A present value that is
-    /// not a well-formed ASN.1 SEQUENCE OF INTEGER yields False, so the caller can
-    /// abort with bad_certificate.
-    /// </summary>
-    function CertificateTlsFeatures(const ACert: TBytes;
-      out AFeatures: TArray<UInt16>): Boolean;
-    /// <summary>
-    /// Whether the certificate's keyUsage extension (RFC 5280 4.2.1.3) permits AUsage.
-    /// APermitted is True when the extension is absent (no restriction) or asserts the
-    /// bit; False only when the extension is present and the bit is clear. Returns
-    /// False (could not determine) on a malformed certificate, leaving APermitted True.
-    /// </summary>
-    function CertificateKeyUsagePermits(const ACertificateDer: TBytes;
-      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    /// <summary>
-    /// Whether the certificate's SubjectPublicKeyInfo algorithm is id-RSASSA-PSS
-    /// (OID 1.2.840.113549.1.1.10), the restricted RSA-PSS key type that the
-    /// rsa_pss_rsae_* schemes must not be used with (RFC 8446 4.2.3). Returns False
-    /// (could not determine) on a malformed certificate, leaving AIsRsaPss False.
-    /// </summary>
-    function CertificateHasRsaPssKey(const ACertificateDer: TBytes;
-      out AIsRsaPss: Boolean): Boolean;
-    /// <summary>
-    /// Classifies the certificate leaf key: AKind is the public-key algorithm, and for an
-    /// ECDSA key AEcNamedGroup is the named-group code of its curve (secp256r1 = 0x0017,
-    /// secp384r1 = 0x0018, secp521r1 = 0x0019), 0 otherwise. Returns False (could not
-    /// determine) on a malformed or unrecognized certificate, leaving AKind = Other.
-    /// </summary>
-    function CertificateKeyKind(const ACertificateDer: TBytes;
-      out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
-    function CreateKeyAgreement(AAlgorithm: TKeyAgreementAlgorithm): IKeyAgreement;
-    function CreateKem(AAlgorithm: TKemAlgorithm): IKem;
+  end;
 
-    /// <summary>Whether hardware accelerated AES is present on this host.</summary>
-    function HasHardwareAes: Boolean;
+{ ===== Composition root ===== }
+
+  /// <summary>
+  /// The coherent composition root - one backend family, so its
+  /// <see cref="ISigningKey" /> handles, SPKI encodings, and path-validation
+  /// semantics all agree. Each accessor returns a stable, thread-safe, never-nil
+  /// facet reference (the same reference every call); consumers hold this
+  /// aggregator and reach a facet through its accessor.
+  /// </summary>
+  ICryptoProvider = interface(IInterface)
+    ['{8945BF7C-FB99-42DC-B3BD-69C6E3FFB3C0}']
+    function Primitives: ICryptoPrimitives;
+    function Signing: ISigningCrypto;
+    function Certificates: ICertificateInspector;
+    function PathValidation: ICertificatePathValidator;
+    function Revocation: IRevocationChecker;
+  end;
+
+  /// <summary>
+  /// Fluent builder for a composed <see cref="ICryptoProvider" />: each With*
+  /// overrides one facet (or the entropy source), and <see cref="Build" />
+  /// composes the provider. An unset facet defaults; composing coherent facets
+  /// (and supplying only thread-safe overrides) is the caller's responsibility.
+  /// </summary>
+  ICryptoProviderBuilder = interface(IInterface)
+    ['{443FE34F-D1CA-4247-ADA3-D2F9D1274193}']
+    /// <summary>Entropy source threaded into the default Primitives and Signing (not a
+    /// supplied Primitives override).</summary>
+    function WithRandom(const ARandom: IRandom): ICryptoProviderBuilder;
+    function WithPrimitives(const APrimitives: ICryptoPrimitives): ICryptoProviderBuilder;
+    function WithSigning(const ASigning: ISigningCrypto): ICryptoProviderBuilder;
+    function WithInspector(const AInspector: ICertificateInspector): ICryptoProviderBuilder;
+    function WithPathValidation(const APathValidation: ICertificatePathValidator): ICryptoProviderBuilder;
+    function WithRevocation(const ARevocation: IRevocationChecker): ICryptoProviderBuilder;
+    /// <summary>Composes the provider from the accumulated overrides.</summary>
+    function Build: ICryptoProvider;
   end;
 
 implementation

--- a/TlsLib/src/KeySchedule/TlpTls12KeySchedule.pas
+++ b/TlsLib/src/KeySchedule/TlpTls12KeySchedule.pas
@@ -120,7 +120,7 @@ var
   var
     LHmac: IHmac;
   begin
-    LHmac := AProvider.CreateHmac(AHash);
+    LHmac := AProvider.Primitives.CreateHmac(AHash);
     LHmac.Init(ASecret);
     LHmac.Update(AData, 0, System.Length(AData));
     Result := LHmac.DoFinal;

--- a/TlsLib/src/KeySchedule/TlpTls13KeySchedule.pas
+++ b/TlsLib/src/KeySchedule/TlpTls13KeySchedule.pas
@@ -115,8 +115,8 @@ begin
   FHash := AHash;
   FKeyLength := AKeyLength;
   FIvLength := Tls13IvLength;
-  FHkdf := AProvider.CreateHkdf(AHash);
-  LHash := AProvider.CreateHash(AHash);
+  FHkdf := AProvider.Primitives.CreateHkdf(AHash);
+  LHash := AProvider.Primitives.CreateHash(AHash);
   FHashLength := LHash.HashSize;
   FHashEmpty := LHash.DoFinal; // hash of the empty input
 end;
@@ -131,7 +131,7 @@ var
   LHash: IHash;
 begin
   Result := nil;
-  LHash := FProvider.CreateHash(FHash);
+  LHash := FProvider.Primitives.CreateHash(FHash);
   if System.Length(AData) > 0 then
     LHash.Update(AData, 0, System.Length(AData));
   Result := LHash.DoFinal;
@@ -290,7 +290,7 @@ var
   LHmac: IHmac;
 begin
   Result := nil;
-  LHmac := FProvider.CreateHmac(FHash);
+  LHmac := FProvider.Primitives.CreateHmac(FHash);
   LHmac.Init(FinishedKey(ADirection));
   LHmac.Update(ATranscriptHash, 0, System.Length(ATranscriptHash));
   Result := LHmac.DoFinal;
@@ -387,7 +387,7 @@ begin
   LBinderKey := BinderKey(AKind);
   LFinishedKey := THkdfLabel.HkdfExpandLabel(FHkdf, LBinderKey, 'finished', nil,
     FHashLength);
-  LHmac := FProvider.CreateHmac(FHash);
+  LHmac := FProvider.Primitives.CreateHmac(FHash);
   LHmac.Init(LFinishedKey);
   LHmac.Update(ATruncatedTranscriptHash, 0,
     System.Length(ATruncatedTranscriptHash));

--- a/TlsLib/src/Negotiation/TlpCipherSuiteRegistry.pas
+++ b/TlsLib/src/Negotiation/TlpCipherSuiteRegistry.pas
@@ -69,8 +69,8 @@ class function TCipherSuiteRegistry.SuiteRunnable(const AProvider: ICryptoProvid
 begin
   Result := True;
   try
-    AProvider.CreateAead(AAead);
-    AProvider.CreateHash(AHash);
+    AProvider.Primitives.CreateAead(AAead);
+    AProvider.Primitives.CreateHash(AHash);
   except
     on E: Exception do
       Result := False;

--- a/TlsLib/src/Negotiation/TlpNegotiationPolicy.pas
+++ b/TlsLib/src/Negotiation/TlpNegotiationPolicy.pas
@@ -172,7 +172,7 @@ begin
       else
         Append(LAes, LSuite.Common.Code);
   // AES-GCM first when hardware AES is present; otherwise ChaCha20-Poly1305 first
-  if AProvider.HasHardwareAes then
+  if AProvider.Primitives.HasHardwareAes then
     Result := System.Concat(LAes, LChaCha)
   else
     Result := System.Concat(LChaCha, LAes);

--- a/TlsLib/src/Session/TlpExternalPskImporter.pas
+++ b/TlsLib/src/Session/TlpExternalPskImporter.pas
@@ -110,14 +110,14 @@ begin
 
   // the derivation is keyed on the provisioned hash (ASpec.Hash); only the output length
   // follows the target hash (RFC 9258 4.1)
-  LHash := AProvider.CreateHash(ASpec.Hash);
+  LHash := AProvider.Primitives.CreateHash(ASpec.Hash);
   LHash.Update(LIdentity, 0, System.Length(LIdentity));
   LIdentityHash := LHash.DoFinal;
 
-  LHkdf := AProvider.CreateHkdf(ASpec.Hash);
+  LHkdf := AProvider.Primitives.CreateHkdf(ASpec.Hash);
   // epskx = HKDF-Extract(0, epsk): an empty salt is HashLen zeros
   LEpsk := LHkdf.Extract(nil, ASpec.Secret);
-  LOutLen := AProvider.CreateHash(ATargetHash).HashSize;
+  LOutLen := AProvider.Primitives.CreateHash(ATargetHash).HashSize;
   // ipskx = HKDF-Expand-Label(epskx, "derived psk", Hash(ImportedIdentity), L)
   LIpsk := THkdfLabel.HkdfExpandLabel(LHkdf, LEpsk, DerivedPskLabel, LIdentityHash,
     LOutLen);

--- a/TlsLib/src/Session/TlpSessionTicketKeys.pas
+++ b/TlsLib/src/Session/TlpSessionTicketKeys.pas
@@ -99,7 +99,7 @@ const
 class function TStekTicketKeyManager.CreateDefault(const AProvider: ICryptoProvider;
   const AClock: ITlsClock): ISessionTicketKeyManager;
 begin
-  Result := TStekTicketKeyManager.Create(AProvider.GetRandom, 0, AClock,
+  Result := TStekTicketKeyManager.Create(AProvider.Primitives.GetRandom, 0, AClock,
     DefaultStekRotateSeconds) as ISessionTicketKeyManager;
 end;
 

--- a/TlsLib/src/Session/TlpSessionTicketStrategy.pas
+++ b/TlsLib/src/Session/TlpSessionTicketStrategy.pas
@@ -246,8 +246,8 @@ begin
   Result := nil;
   if not FKeys.CurrentKey(LKeyName, LKey) then
     Exit;
-  LNonce := FProvider.GetRandom.GenerateBytes(TicketNonceLength);
-  LAead := FProvider.CreateAead(TAeadAlgorithm.AES_256_GCM);
+  LNonce := FProvider.Primitives.GetRandom.GenerateBytes(TicketNonceLength);
+  LAead := FProvider.Primitives.CreateAead(TAeadAlgorithm.AES_256_GCM);
   LAead.Init(LKey);
   LPlain := SerializeSession(ASession);
   try
@@ -275,7 +275,7 @@ begin
   ASession := nil;
   Result := False;
   LNameLen := FKeys.KeyNameLength;
-  LAead := FProvider.CreateAead(TAeadAlgorithm.AES_256_GCM);
+  LAead := FProvider.Primitives.CreateAead(TAeadAlgorithm.AES_256_GCM);
   // key_name || nonce || ciphertext+tag; reject anything shorter than the framing
   if System.Length(ATicket) < LNameLen + TicketNonceLength + LAead.TagSize then
     Exit;

--- a/TlsLib/src/Trust/TlpCertificateVerifier.pas
+++ b/TlsLib/src/Trust/TlpCertificateVerifier.pas
@@ -259,8 +259,8 @@ begin
   // some certificate in the chain must present a pinned public key (SPKI-SHA256)
   for LI := 0 to System.High(AChain) do
   begin
-    LSpki := FProvider.CertificatePublicKeyInfo(AChain[LI]);
-    LHash := FProvider.CreateHash(THashAlgorithm.SHA_256);
+    LSpki := FProvider.Certificates.PublicKeyInfo(AChain[LI]);
+    LHash := FProvider.Primitives.CreateHash(THashAlgorithm.SHA_256);
     LHash.Update(LSpki, 0, System.Length(LSpki));
     LDigest := LHash.DoFinal;
     for LJ := 0 to System.High(FCertificatePins) do
@@ -282,7 +282,7 @@ begin
   // a staple needs the issuer (the next chain entry) to authenticate it
   if (System.Length(AOcspStaple) = 0) or (System.Length(AChain) < 2) then
     Exit;
-  if not FProvider.ValidateOcspStaple(AChain[0], AChain[1], AOcspStaple,
+  if not FProvider.Revocation.ValidateOcspStaple(AChain[0], AChain[1], AOcspStaple,
     ValidationTimeUtc, LStatus, LThisUpdate, LNextUpdate) then
     Exit;
   if LStatus = TOcspStatus.Revoked then
@@ -315,7 +315,7 @@ var
 begin
   // the RFC 7633 TLS Feature extension well-formedness is a hard invariant, enforced
   // regardless of posture: a value that is not a SEQUENCE OF INTEGER is fatal
-  if not FProvider.CertificateTlsFeatures(AChain[0], LFeatures) then
+  if not FProvider.Certificates.TlsFeatures(AChain[0], LFeatures) then
   begin
     AAlert := TTlsAlertDescription.BadCertificate;
     Result := False;
@@ -398,7 +398,7 @@ begin
   // back the chain it actually validated (the assembled path when it completed an incomplete one)
   LEffectiveChain := AChain;
   try
-    FProvider.ValidateCertificatePath(AChain, FTrustStore.RootCertificates,
+    FProvider.PathValidation.ValidateCertificatePath(AChain, FTrustStore.RootCertificates,
       FIntermediates, ValidationTimeUtc, LEffectiveChain);
   except
     on E: EFatalAlertTlsLibException do
@@ -416,8 +416,8 @@ begin
   // endpoint identity (RFC 6125) over the leaf's dNSName / iPAddress SAN entries
   if FCheckHostName and (AHostName <> '') then
     if not TEndpointIdentity.Matches(AHostName,
-      FProvider.CertificateDnsNames(AChain[0]),
-      FProvider.CertificateIpAddresses(AChain[0])) then
+      FProvider.Certificates.DnsNames(AChain[0]),
+      FProvider.Certificates.IpAddresses(AChain[0])) then
     begin
       AAlert := TTlsAlertDescription.BadCertificate;
       Exit;

--- a/TlsLib/src/Trust/TlpLiveRevocation.pas
+++ b/TlsLib/src/Trust/TlpLiveRevocation.pas
@@ -116,7 +116,7 @@ begin
   Result := TLiveRevocationOutcome.Indeterminate;
   if (AResponderUrl = '') or (FFetcher = nil) then
     Exit;
-  if not FProvider.BuildOcspRequest(ALeaf, AIssuer, LRequest) then
+  if not FProvider.Revocation.BuildOcspRequest(ALeaf, AIssuer, LRequest) then
     Exit;
   // unreachable / non-2xx / empty body -> indeterminate (never a silent pass)
   if not FFetcher.Post(AResponderUrl, OcspRequestContentType, LRequest, FTimeoutMs,
@@ -125,7 +125,7 @@ begin
   // reuse the in-band parser: it authenticates the response (issuer- or delegated-signed)
   // and binds the CertID to this leaf; a malformed/unauthorized response is indeterminate.
   // the responder-validity date comes from the injected clock, like the window below
-  if not FProvider.ValidateOcspStaple(ALeaf, AIssuer, LResponse,
+  if not FProvider.Revocation.ValidateOcspStaple(ALeaf, AIssuer, LResponse,
     TDateTimeUtilities.UnixMsToDateTime(Int64(FClock.NowUnixMillis)), LStatus,
     LThisUpdate, LNextUpdate) then
     Exit;
@@ -156,7 +156,7 @@ begin
   if not FFetcher.Get(ACrlUrl, FTimeoutMs, LCrl) then
     Exit;
   // an unparseable or issuer-unverifiable CRL is indeterminate, never trusted
-  if not FProvider.CheckCrlRevocation(ALeaf, AIssuer, LCrl, LRevoked) then
+  if not FProvider.Revocation.CheckCrlRevocation(ALeaf, AIssuer, LCrl, LRevoked) then
     Exit;
   if LRevoked then
     Result := TLiveRevocationOutcome.Revoked
@@ -185,7 +185,7 @@ begin
   LIssuer := AChain[1];
 
   if FMethod in [TLiveRevocationMethod.Ocsp, TLiveRevocationMethod.OcspThenCrl] then
-    if FProvider.TryGetOcspResponderUrl(LLeaf, LUrl) then
+    if FProvider.Revocation.TryGetOcspResponderUrl(LLeaf, LUrl) then
     begin
       Result := EvaluateOcsp(LLeaf, LIssuer, LUrl);
       if Result <> TLiveRevocationOutcome.Indeterminate then
@@ -193,7 +193,7 @@ begin
     end;
 
   if FMethod in [TLiveRevocationMethod.Crl, TLiveRevocationMethod.OcspThenCrl] then
-    if FProvider.TryGetCrlDistributionPoints(LLeaf, LUrls) then
+    if FProvider.Revocation.TryGetCrlDistributionPoints(LLeaf, LUrls) then
       for LI := 0 to System.High(LUrls) do
       begin
         Result := EvaluateCrl(LLeaf, LIssuer, LUrls[LI]);


### PR DESCRIPTION
ICryptoProvider was a flat "total seam" -- ~17 certificate/PKI methods interleaved with primitive factories -- and TDefaultCryptoProvider was a ~2500-line god-class implementing all of it.

Split the interface into six cohesive facets in one unit (ICryptoPrimitives, ISigningCrypto, ICertificateInspector, ICertificatePathValidator, IRevocationChecker) behind a thin ICryptoProvider aggregator of five stable accessors, and dissolve the concrete to match: TDefaultCryptoProvider now implements only ICryptoProvider and delegates to five single-responsibility facet classes. A three-tier reference rule (aggregator -> facets -> leaf deps, never upward or sideways) keeps the object graph acyclic; heaptrc is clean. Method bodies moved unchanged.

Add immutable facet-level composition: a TCryptoProviderOverrides record and a single Create(AOverrides) composition point (nil field -> default facet, else the supplied override; the effective RNG is resolved once and threaded into the default facets), plus an ITlsConfigBuilder-style ICryptoProviderBuilder that funnels into the same constructor -- zero duplication. Callers can now override one facet (e.g. HSM-backed signing, or a deterministic RNG) while the rest stay default; the config builder still exposes only WithCryptoProvider.

Fix a latent bug the RNG seam exposed: GetRandom minted a fresh, disconnected random on every call, so overriding randomness never governed key generation; it now returns a stable view of the provider's effective RNG. Move the trust-anchor cache onto the path-validator as class state; Shared remains the all-defaults singleton. No new units, so no manifest changes; consumers keep depending on ICryptoProvider (no signature changes). Purely structural -- no wire behavior change.

The test mocks collapse onto the new composition seam (a fixed-RNG mock and a hardware-AES-flag mock each reduce to a few lines), exercising facet override end-to-end.