### PR TITLE
Amortize per-iteration array accumulation (record write, trust harvest, cert inspection)

### DIFF
--- a/TlsLib.Tests/src/SystemTrustTests.pas
+++ b/TlsLib.Tests/src/SystemTrustTests.pas
@@ -69,6 +69,8 @@ type
     FFile: string;      // a fixture bundle file holding the test root
     FMissing: string;   // a path that does not exist
     FCertDir: string;   // a fixture directory holding one root file
+    FRootDer: TBytes;   // the test root DER
+    FRoot2Der: TBytes;  // a second, distinct root DER
     procedure WriteBytes(const APath: string; const AData: TBytes);
   protected
     procedure SetUp; override;
@@ -78,6 +80,8 @@ type
     procedure TestFirstExistingFileCandidateWins;
     procedure TestNoReadableStoreFailsClosed;
     procedure TestDirectoryHarvestReadsCerts;
+    procedure TestDuplicateCertsAreDeduplicated;
+    procedure TestDistinctCertsAreNotMerged;
     procedure TestFactoryAnchorStoreMatchesSupports;
     procedure TestFactoryDelegateVerifierMatchesSupports;
   end;
@@ -178,6 +182,8 @@ begin
   LVectors := LoadVectorFields('Certs/EcP256Chain.txt');
   try
     LDer := DecodeHex(LVectors.Values['root_cert']);
+    FRootDer := LDer;
+    FRoot2Der := DecodeHex(LVectors.Values['root2_cert']);
   finally
     LVectors.Free;
   end;
@@ -245,6 +251,50 @@ begin
     TArray<string>.Create(FCertDir)) as ITrustAnchorStore;
   CheckTrue(System.Length(LStore.RootCertificates) >= 1,
     'the certificate directory is enumerated into anchors');
+end;
+
+procedure TTestSystemTrustFixtures.TestDuplicateCertsAreDeduplicated;
+var
+  LDir: string;
+  LStore: ITrustAnchorStore;
+begin
+  LDir := IncludeTrailingPathDelimiter(FDir) + 'dupdir';
+  ForceDirectories(LDir);
+  try
+    WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'a.der', FRootDer);
+    WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'b.der', FRootDer);
+    LStore := TFileSystemAnchorStore.Create(FProvider, '', '', nil,
+      TArray<string>.Create(LDir)) as ITrustAnchorStore;
+    CheckEquals(1, System.Length(LStore.RootCertificates),
+      'the same certificate under two names is de-duplicated to one anchor');
+  finally
+    LStore := nil;
+    SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'a.der');
+    SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'b.der');
+    SysUtils.RemoveDir(LDir);
+  end;
+end;
+
+procedure TTestSystemTrustFixtures.TestDistinctCertsAreNotMerged;
+var
+  LDir: string;
+  LStore: ITrustAnchorStore;
+begin
+  LDir := IncludeTrailingPathDelimiter(FDir) + 'distinctdir';
+  ForceDirectories(LDir);
+  try
+    WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'r1.der', FRootDer);
+    WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'r2.der', FRoot2Der);
+    LStore := TFileSystemAnchorStore.Create(FProvider, '', '', nil,
+      TArray<string>.Create(LDir)) as ITrustAnchorStore;
+    CheckEquals(2, System.Length(LStore.RootCertificates),
+      'two distinct certificates are harvested as two anchors');
+  finally
+    LStore := nil;
+    SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'r1.der');
+    SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'r2.der');
+    SysUtils.RemoveDir(LDir);
+  end;
 end;
 
 procedure TTestSystemTrustFixtures.TestFactoryAnchorStoreMatchesSupports;

--- a/TlsLib.Trust.System/src/TlpAppleSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpAppleSystemTrust.pas
@@ -27,6 +27,7 @@ uses
   TlpSystemTrustBase,
 {$ENDIF}
 {$IFEND}
+  Generics.Collections,
   SysUtils,
   TlpTlsAlert;
 
@@ -214,7 +215,7 @@ type
     class function DomainDeniesCertificate(ACertificate: SecCertificateRef;
       ADomain: SecTrustSettingsDomain): Boolean; static;
     class procedure HarvestDomain(ADomain: SecTrustSettingsDomain;
-      var ACerts: TArray<TBytes>); static;
+      const ADest: TList<TBytes>); static;
 {$ENDIF}
   private
     class procedure ResolveDynamicImports; static;
@@ -495,11 +496,11 @@ begin
 end;
 
 class procedure TAppleTrustApi.HarvestDomain(ADomain: SecTrustSettingsDomain;
-  var ACerts: TArray<TBytes>);
+  const ADest: TList<TBytes>);
 var
   LCerts: CFArrayRef;
   LStatus: OSStatus;
-  LI, LCount, LN: CFIndex;
+  LI, LCount: CFIndex;
   LCert: SecCertificateRef;
   LDer: TBytes;
 begin
@@ -509,6 +510,7 @@ begin
     Exit;
   try
     LCount := FCFArrayGetCount(LCerts);
+    ADest.Capacity := ADest.Count + LCount;
     for LI := 0 to LCount - 1 do
     begin
       LCert := FCFArrayGetValueAtIndex(LCerts, LI);
@@ -518,11 +520,7 @@ begin
         Continue;
       LDer := CopyCertificateDer(LCert);
       if Length(LDer) > 0 then
-      begin
-        LN := Length(ACerts);
-        SetLength(ACerts, LN + 1);
-        ACerts[LN] := LDer;
-      end;
+        ADest.Add(LDer);
     end;
   finally
     FCFRelease(LCerts);
@@ -530,13 +528,21 @@ begin
 end;
 
 class function TAppleTrustApi.CopyTrustSettingsCertificates: TArray<TBytes>;
+var
+  LList: TList<TBytes>;
 begin
   Result := nil;
   if not FReady then
     Exit;
-  HarvestDomain(KSecTrustSettingsDomainSystem, Result);
-  HarvestDomain(KSecTrustSettingsDomainAdmin, Result);
-  HarvestDomain(KSecTrustSettingsDomainUser, Result);
+  LList := TList<TBytes>.Create;
+  try
+    HarvestDomain(KSecTrustSettingsDomainSystem, LList);
+    HarvestDomain(KSecTrustSettingsDomainAdmin, LList);
+    HarvestDomain(KSecTrustSettingsDomainUser, LList);
+    Result := LList.ToArray;
+  finally
+    LList.Free;
+  end;
 end;
 
 { TAppleAnchorStore }
@@ -545,11 +551,18 @@ function TAppleAnchorStore.HarvestRoots: TArray<TBytes>;
 var
   LRaw: TArray<TBytes>;
   LI: Integer;
+  LAcc: TSystemRootAccumulator;
 begin
   Result := nil;
   LRaw := TAppleTrustApi.CopyTrustSettingsCertificates;
-  for LI := 0 to Length(LRaw) - 1 do
-    AddUnique(Result, LRaw[LI]);
+  LAcc := TSystemRootAccumulator.Create;
+  try
+    for LI := 0 to Length(LRaw) - 1 do
+      AddUnique(LAcc, LRaw[LI]);
+    Result := LAcc.ToArray;
+  finally
+    LAcc.Free;
+  end;
 end;
 
 function TAppleAnchorStore.SourceName: string;

--- a/TlsLib.Trust.System/src/TlpFileSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpFileSystemTrust.pas
@@ -45,8 +45,10 @@ type
 
     class function ReadAllBytes(const APath: string): TBytes; static;
     function ParseBundle(const AData: TBytes): TArray<TBytes>;
-    procedure HarvestFile(const APath: string; var ARoots: TArray<TBytes>);
-    procedure HarvestDir(const APath: string; var ARoots: TArray<TBytes>);
+    procedure HarvestFile(const APath: string;
+      const AAccumulator: TSystemRootAccumulator);
+    procedure HarvestDir(const APath: string;
+      const AAccumulator: TSystemRootAccumulator);
     function FirstExistingFile: string;
     function FirstExistingDir: string;
   strict protected
@@ -108,7 +110,7 @@ begin
 end;
 
 procedure TFileSystemAnchorStore.HarvestFile(const APath: string;
-  var ARoots: TArray<TBytes>);
+  const AAccumulator: TSystemRootAccumulator);
 var
   LCerts: TArray<TBytes>;
   LI: Integer;
@@ -122,11 +124,11 @@ begin
   end;
 
   for LI := 0 to Length(LCerts) - 1 do
-    AddUnique(ARoots, LCerts[LI]);
+    AddUnique(AAccumulator, LCerts[LI]);
 end;
 
 procedure TFileSystemAnchorStore.HarvestDir(const APath: string;
-  var ARoots: TArray<TBytes>);
+  const AAccumulator: TSystemRootAccumulator);
 var
   LSearch: TSearchRec;
   LBase, LFull: string;
@@ -149,7 +151,7 @@ begin
         LCerts := nil;
       end;
       for LI := 0 to Length(LCerts) - 1 do
-        AddUnique(ARoots, LCerts[LI]);
+        AddUnique(AAccumulator, LCerts[LI]);
     until FindNext(LSearch) <> 0;
   finally
     FindClose(LSearch);
@@ -189,42 +191,45 @@ end;
 function TFileSystemAnchorStore.HarvestRoots: TArray<TBytes>;
 var
   LFile, LDir: string;
+  LAcc: TSystemRootAccumulator;
 begin
   Result := nil;
-
-  // Explicit environment overrides take precedence and are strict: if named, the
-  // source must be usable, otherwise fail closed (no fallback to the table).
-  if FEnvFile <> '' then
-  begin
-    if not FileExists(FEnvFile) then
-      raise ESystemTrustUnavailableTlsLibException.CreateResFmt(
-        @SEnvFileMissing, [FEnvFile]);
-    HarvestFile(FEnvFile, Result);
-    Exit;
+  LAcc := TSystemRootAccumulator.Create;
+  try
+    // Explicit environment overrides take precedence and are strict: if named, the
+    // source must be usable, otherwise fail closed (no fallback to the table).
+    if FEnvFile <> '' then
+    begin
+      if not FileExists(FEnvFile) then
+        raise ESystemTrustUnavailableTlsLibException.CreateResFmt(
+          @SEnvFileMissing, [FEnvFile]);
+      HarvestFile(FEnvFile, LAcc);
+    end
+    else if FEnvDir <> '' then
+    begin
+      if not DirectoryExists(FEnvDir) then
+        raise ESystemTrustUnavailableTlsLibException.CreateResFmt(
+          @SEnvDirMissing, [FEnvDir]);
+      HarvestDir(FEnvDir, LAcc);
+    end
+    // Otherwise the first candidate that exists is authoritative.
+    else
+    begin
+      LFile := FirstExistingFile;
+      if LFile <> '' then
+        HarvestFile(LFile, LAcc)
+      else
+      begin
+        LDir := FirstExistingDir;
+        if LDir <> '' then
+          HarvestDir(LDir, LAcc);
+        // If nothing existed, the accumulator stays empty and the base fails closed.
+      end;
+    end;
+    Result := LAcc.ToArray;
+  finally
+    LAcc.Free;
   end;
-
-  if FEnvDir <> '' then
-  begin
-    if not DirectoryExists(FEnvDir) then
-      raise ESystemTrustUnavailableTlsLibException.CreateResFmt(
-        @SEnvDirMissing, [FEnvDir]);
-    HarvestDir(FEnvDir, Result);
-    Exit;
-  end;
-
-  // Otherwise the first candidate that exists is authoritative.
-  LFile := FirstExistingFile;
-  if LFile <> '' then
-  begin
-    HarvestFile(LFile, Result);
-    Exit;
-  end;
-
-  LDir := FirstExistingDir;
-  if LDir <> '' then
-    HarvestDir(LDir, Result);
-
-  // If nothing existed, Result stays empty and the base fails closed.
 end;
 
 function TFileSystemAnchorStore.SourceName: string;

--- a/TlsLib.Trust.System/src/TlpSystemTrustBase.pas
+++ b/TlsLib.Trust.System/src/TlpSystemTrustBase.pas
@@ -18,12 +18,27 @@ interface
 uses
   SysUtils,
   SyncObjs,
-  TlpArrayUtilities,
+  Generics.Collections,
   TlpICryptoProvider,
   TlpICertificateTrust,
   TlpSystemTrustExceptions;
 
 type
+  /// <summary>
+  /// Deduplicates harvested roots by exact bytes: a filesystem store walking
+  /// hashed-symlink directories sees the same certificate under several names.
+  /// </summary>
+  TSystemRootAccumulator = class sealed(TObject)
+  strict private
+    FRoots: TList<TBytes>;
+    FSeen: TDictionary<TBytes, Boolean>;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure Add(const ADer: TBytes);
+    function ToArray: TArray<TBytes>;
+  end;
+
   /// <summary>
   /// Abstract base for the platform trust-anchor harvesters. Caches the harvested
   /// roots behind a lock (refreshable), validates each blob is a well-formed DER
@@ -46,10 +61,11 @@ type
     /// <summary>The crypto provider, for subclasses that must parse (e.g. PEM).</summary>
     property Provider: ICryptoProvider read FProvider;
   protected
-    /// <summary>Appends ADer to ARoots only if the provider confirms it a
-    /// well-formed X.509 certificate not already present (exact-byte de-dup for
-    /// hashed-symlink directories).</summary>
-    procedure AddUnique(var ARoots: TArray<TBytes>; const ADer: TBytes);
+    /// <summary>Adds ADer to AAccumulator only if the provider confirms it a
+    /// well-formed X.509 certificate; the accumulator handles the exact-byte
+    /// de-dup for hashed-symlink directories.</summary>
+    procedure AddUnique(const AAccumulator: TSystemRootAccumulator;
+      const ADer: TBytes);
   public
     constructor Create(const AProvider: ICryptoProvider);
     destructor Destroy; override;
@@ -65,6 +81,38 @@ resourcestring
   SSystemTrustEmpty =
     'the %s trust store could not be read or contained no usable root certificates';
   SNoProvider = 'a crypto provider is required to read the system trust store';
+
+{ TSystemRootAccumulator }
+
+constructor TSystemRootAccumulator.Create;
+begin
+  inherited Create;
+  FRoots := TList<TBytes>.Create;
+  FSeen := TDictionary<TBytes, Boolean>.Create;
+end;
+
+destructor TSystemRootAccumulator.Destroy;
+begin
+  FSeen.Free;
+  FRoots.Free;
+  inherited Destroy;
+end;
+
+procedure TSystemRootAccumulator.Add(const ADer: TBytes);
+var
+  LCopy: TBytes;
+begin
+  if FSeen.ContainsKey(ADer) then
+    Exit;
+  LCopy := Copy(ADer, 0, Length(ADer));
+  FSeen.Add(LCopy, True);
+  FRoots.Add(LCopy);
+end;
+
+function TSystemRootAccumulator.ToArray: TArray<TBytes>;
+begin
+  Result := FRoots.ToArray;
+end;
 
 { TSystemTrustBase }
 
@@ -84,23 +132,12 @@ begin
   inherited Destroy;
 end;
 
-procedure TSystemTrustBase.AddUnique(var ARoots: TArray<TBytes>;
+procedure TSystemTrustBase.AddUnique(const AAccumulator: TSystemRootAccumulator;
   const ADer: TBytes);
-var
-  LI, LN: Integer;
 begin
   if not FProvider.Certificates.IsWellFormed(ADer) then
     Exit;
-
-  for LI := 0 to Length(ARoots) - 1 do
-  begin
-    if TArrayUtilities.AreEqual(ARoots[LI], ADer) then
-      Exit;
-  end;
-
-  LN := Length(ARoots);
-  SetLength(ARoots, LN + 1);
-  ARoots[LN] := Copy(ADer, 0, Length(ADer));
+  AAccumulator.Add(ADer);
 end;
 
 class function TSystemTrustBase.CloneRoots(

--- a/TlsLib.Trust.System/src/TlpWindowsSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpWindowsSystemTrust.pas
@@ -23,6 +23,7 @@ uses
 {$ELSE}
   Winapi.Windows,
 {$ENDIF}
+  Generics.Collections,
   SysUtils,
   TlpTlsAlert,
   TlpICertificateTrust,
@@ -57,9 +58,6 @@ type
 implementation
 
 {$IFDEF TLSLIB_MSWINDOWS}
-
-uses
-  TlpArrayUtilities;
 
 const
   CRYPT32_DLL = 'crypt32.dll';
@@ -183,10 +181,9 @@ type
     FCertFreeCertificateChain: TCertFreeCertificateChainProc;
     FCertVerifyCertificateChainPolicy: TCertVerifyCertificateChainPolicyFunc;
     class function GetProc(const AName: AnsiString): Pointer; static;
-    class function InSet(const ASet: TArray<TBytes>;
-      const ADer: TBytes): Boolean; static;
     class procedure CollectStore(AStoreName: PWideChar;
-      const AExclude: TArray<TBytes>; var ACerts: TArray<TBytes>); static;
+      const AExclude: TDictionary<TBytes, Boolean>;
+      const ADest: TList<TBytes>); static;
   private
     class procedure ResolveDynamicImports; static;
     /// <summary>Frees the loaded crypt32 module (unit teardown).</summary>
@@ -255,26 +252,12 @@ begin
   end;
 end;
 
-class function TWindowsTrustApi.InSet(const ASet: TArray<TBytes>;
-  const ADer: TBytes): Boolean;
-var
-  LI: Integer;
-begin
-  for LI := 0 to Length(ASet) - 1 do
-  begin
-    if TArrayUtilities.AreEqual(ASet[LI], ADer) then
-      Exit(True);
-  end;
-  Result := False;
-end;
-
 class procedure TWindowsTrustApi.CollectStore(AStoreName: PWideChar;
-  const AExclude: TArray<TBytes>; var ACerts: TArray<TBytes>);
+  const AExclude: TDictionary<TBytes, Boolean>; const ADest: TList<TBytes>);
 var
   LStore: HCERTSTORE;
   LContext: PCERT_CONTEXT;
   LDer: TBytes;
-  LN: Integer;
 begin
   LDer := nil;
   LStore := FCertOpenSystemStoreW(nil, AStoreName);
@@ -288,12 +271,8 @@ begin
       begin
         SetLength(LDer, LContext^.cbCertEncoded);
         Move(LContext^.pbCertEncoded^, LDer[0], LContext^.cbCertEncoded);
-        if (Length(AExclude) = 0) or (not InSet(AExclude, LDer)) then
-        begin
-          LN := Length(ACerts);
-          SetLength(ACerts, LN + 1);
-          ACerts[LN] := Copy(LDer, 0, Length(LDer));
-        end;
+        if (AExclude = nil) or (not AExclude.ContainsKey(LDer)) then
+          ADest.Add(Copy(LDer, 0, Length(LDer)));
       end;
       LContext := FCertEnumCertificatesInStore(LStore, LContext);
     end;
@@ -304,16 +283,35 @@ end;
 
 class function TWindowsTrustApi.HarvestAnchors: TArray<TBytes>;
 var
-  LDisallowed: TArray<TBytes>;
+  LDisallowed, LTrusted: TList<TBytes>;
+  LExclude: TDictionary<TBytes, Boolean>;
+  LI: Integer;
 begin
   Result := nil;
   if not FReady then
     Exit;
-  LDisallowed := nil;
-  // Distrust first, so it can be subtracted from the trusted stores.
-  CollectStore('Disallowed', nil, LDisallowed);
-  CollectStore('ROOT', LDisallowed, Result);
-  CollectStore('CA', LDisallowed, Result);
+  LDisallowed := TList<TBytes>.Create;
+  try
+    // Distrust first, so it can be subtracted from the trusted stores.
+    CollectStore('Disallowed', nil, LDisallowed);
+    LExclude := TDictionary<TBytes, Boolean>.Create;
+    try
+      for LI := 0 to LDisallowed.Count - 1 do
+        LExclude.AddOrSetValue(LDisallowed[LI], True);
+      LTrusted := TList<TBytes>.Create;
+      try
+        CollectStore('ROOT', LExclude, LTrusted);
+        CollectStore('CA', LExclude, LTrusted);
+        Result := LTrusted.ToArray;
+      finally
+        LTrusted.Free;
+      end;
+    finally
+      LExclude.Free;
+    end;
+  finally
+    LDisallowed.Free;
+  end;
 end;
 
 class function TWindowsTrustApi.EvaluateChain(const AChain: TArray<TBytes>;
@@ -438,11 +436,18 @@ function TWindowsAnchorStore.HarvestRoots: TArray<TBytes>;
 var
   LRaw: TArray<TBytes>;
   LI: Integer;
+  LAcc: TSystemRootAccumulator;
 begin
   Result := nil;
   LRaw := TWindowsTrustApi.HarvestAnchors;
-  for LI := 0 to Length(LRaw) - 1 do
-    AddUnique(Result, LRaw[LI]);
+  LAcc := TSystemRootAccumulator.Create;
+  try
+    for LI := 0 to Length(LRaw) - 1 do
+      AddUnique(LAcc, LRaw[LI]);
+    Result := LAcc.ToArray;
+  finally
+    LAcc.Free;
+  end;
 end;
 
 function TWindowsAnchorStore.SourceName: string;

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -20,6 +20,7 @@ uses
   Classes,
   Rtti,
   SyncObjs,
+  Generics.Collections,
   ClpISecureRandom,
   ClpSecureRandom,
   ClpIRandomGenerator,
@@ -1842,7 +1843,7 @@ var
   LValue: TValue;
   LCert: IX509Certificate;
   LParser: IX509CertificateParser;
-  LN: Int32;
+  LChain: TList<TBytes>;
 begin
   // PEM may carry a whole chain/bundle (leaf first); DER is a single certificate.
   // Either way the result is the ordered list of raw DER certificates.
@@ -1850,27 +1851,29 @@ begin
   try
     if TCredentialImport.IsPemArmored(AData) then
     begin
-      LStream := TBytesStream.Create(AData);
+      LChain := TList<TBytes>.Create;
       try
-        LReader := TOpenSslPemReader.Create(LStream);
+        LStream := TBytesStream.Create(AData);
         try
-          while True do
-          begin
-            LValue := LReader.ReadObject;
-            if LValue.IsEmpty then
-              Break;
-            if LValue.TryGetAsType<IX509Certificate>(LCert) then
+          LReader := TOpenSslPemReader.Create(LStream);
+          try
+            while True do
             begin
-              LN := System.Length(Result);
-              SetLength(Result, LN + 1);
-              Result[LN] := LCert.GetEncoded;
+              LValue := LReader.ReadObject;
+              if LValue.IsEmpty then
+                Break;
+              if LValue.TryGetAsType<IX509Certificate>(LCert) then
+                LChain.Add(LCert.GetEncoded);
             end;
+          finally
+            LReader := nil;
           end;
         finally
-          LReader := nil;
+          LStream.Free;
         end;
+        Result := LChain.ToArray;
       finally
-        LStream.Free;
+        LChain.Free;
       end;
     end
     else
@@ -2002,15 +2005,16 @@ begin
   if LGeneralNames = nil then
     Exit;
   LNames := LGeneralNames.GetNames;
+  SetLength(Result, System.Length(LNames));
   LCount := 0;
   for LI := 0 to System.Length(LNames) - 1 do
     if (LNames[LI].TagNo = TGeneralName.DnsName) and
       Supports(LNames[LI].GetName, IAsn1String, LString) then
     begin
-      SetLength(Result, LCount + 1);
       Result[LCount] := LString.GetString;
       Inc(LCount);
     end;
+  SetLength(Result, LCount);
 end;
 
 function TCertificateInspector.IpAddresses(
@@ -2030,15 +2034,16 @@ begin
   if LGeneralNames = nil then
     Exit;
   LNames := LGeneralNames.GetNames;
+  SetLength(Result, System.Length(LNames));
   LCount := 0;
   for LI := 0 to System.Length(LNames) - 1 do
     if (LNames[LI].TagNo = TGeneralName.IPAddress) and
       Supports(LNames[LI].GetName, IAsn1OctetString, LOctets) then
     begin
-      SetLength(Result, LCount + 1);
       Result[LCount] := LOctets.GetOctets;
       Inc(LCount);
     end;
+  SetLength(Result, LCount);
 end;
 
 class function TCertificatePathValidator.TTrustAnchorRing.Init: TTrustAnchorRing;

--- a/TlsLib/src/Handshake/TlpTls12ClientStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls12ClientStateMachine.pas
@@ -17,6 +17,7 @@ interface
 
 uses
   SysUtils,
+  Classes,
   TlpArrayUtilities,
   TlpTlsAlert,
   TlpTlsVersion,
@@ -164,7 +165,7 @@ type
     FClientAuthCertTypes: TBytes;
     /// <summary>The raw concatenation of every handshake message, signed over by the
     /// client CertificateVerify (RFC 5246 7.4.8).</summary>
-    FHandshakeLog: TBytes;
+    FHandshakeLog: TBytesStream;
     /// <summary>Folds a message into both the transcript hash and the raw handshake log.</summary>
     procedure Absorb(const ARaw: TBytes);
     procedure RememberOffered(const AFramedClientHello: TBytes);
@@ -224,6 +225,7 @@ type
       : TArray<THandshakeEffect>; override;
   public
     constructor Create(const AParams: TClient12HandshakeParams);
+    destructor Destroy; override;
     function Initiates: Boolean; override;
     function Start: TArray<THandshakeEffect>; override;
     function ExportKeyingMaterial(const ALabel: string; const AContext: TBytes;
@@ -268,12 +270,20 @@ begin
   FPhase := TPhase.Initial;
   FClientSupportsTls13 := TArrayUtilities.Contains<UInt16>(AParams.OfferedVersions,
     TlsWireVersionTls13);
+  FHandshakeLog := TBytesStream.Create;
+end;
+
+destructor TTls12ClientStateMachine.Destroy;
+begin
+  FHandshakeLog.Free;
+  inherited Destroy;
 end;
 
 procedure TTls12ClientStateMachine.Absorb(const ARaw: TBytes);
 begin
   FTranscript.Update(ARaw);
-  FHandshakeLog := TArrayUtilities.Concat(FHandshakeLog, ARaw);
+  if System.Length(ARaw) > 0 then
+    FHandshakeLog.Write(ARaw[0], System.Length(ARaw));
 end;
 
 procedure TTls12ClientStateMachine.RememberOffered(
@@ -724,7 +734,7 @@ begin
   begin
     LSigner := FParams.Provider.Signing.CreateSignatureSigner(LScheme,
       FParams.ClientCredential.PrivateKey);
-    LSigner.Update(FHandshakeLog, 0, System.Length(FHandshakeLog));
+    LSigner.Update(FHandshakeLog.Bytes, 0, FHandshakeLog.Size);
     LVerify.Algorithm := LScheme.ToCode;
     LVerify.Signature := LSigner.Sign;
     LCertVerifyBytes := THandshakeFraming.Frame(TTlsHandshakeType.CertificateVerify,

--- a/TlsLib/src/Handshake/TlpTls12ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls12ServerStateMachine.pas
@@ -17,6 +17,7 @@ interface
 
 uses
   SysUtils,
+  Classes,
   TlpArrayUtilities,
   TlpTlsAlert,
   TlpTlsVersion,
@@ -180,7 +181,7 @@ type
     /// <summary>The raw concatenation of every handshake message, which the TLS 1.2
     /// client CertificateVerify is signed over (RFC 5246 7.4.8) - its scheme hashes this,
     /// independent of the suite PRF hash the transcript uses.</summary>
-    FHandshakeLog: TBytes;
+    FHandshakeLog: TBytesStream;
     /// <summary>Selects the first registry 1.2 suite the client offered whose auth the
     /// credential can satisfy against the client's signature_algorithms; sets
     /// FSelectedSuite and FSelectedScheme. False when nothing is compatible.</summary>
@@ -252,6 +253,7 @@ type
       : TArray<THandshakeEffect>; override;
   public
     constructor Create(const AParams: TServer12HandshakeParams);
+    destructor Destroy; override;
     function Start: TArray<THandshakeEffect>; override;
     function ExportKeyingMaterial(const ALabel: string; const AContext: TBytes;
       AUseContext: Boolean; ALength: Int32): TBytes; override;
@@ -293,6 +295,13 @@ begin
   // TLS 1.2 tickets are stateless STEK only; the session-id path uses SessionStore
   FTicketStrategy := TSessionTicketStrategies.ForServer(AParams.Provider,
     AParams.SessionTicketKeys, nil);
+  FHandshakeLog := TBytesStream.Create;
+end;
+
+destructor TTls12ServerStateMachine.Destroy;
+begin
+  FHandshakeLog.Free;
+  inherited Destroy;
 end;
 
 function TTls12ServerStateMachine.Start: TArray<THandshakeEffect>;
@@ -515,7 +524,9 @@ begin
 
   // the transcript hash is now known; the plaintext flight is folded into both the
   // transcript and the raw handshake log (the client CertificateVerify signs the log)
-  FHandshakeLog := System.Copy(AMessage.Raw);
+  FHandshakeLog.Clear;
+  if System.Length(AMessage.Raw) > 0 then
+    FHandshakeLog.Write(AMessage.Raw[0], System.Length(AMessage.Raw));
   FTranscript.Update(AMessage.Raw);
   FTranscript.Activate(FParams.Provider.Primitives.CreateHash(FSelectedSuite.Common.Hash));
   // staple when the client offered status_request and a staple is configured; the
@@ -619,7 +630,8 @@ end;
 procedure TTls12ServerStateMachine.Absorb(const ARaw: TBytes);
 begin
   FTranscript.Update(ARaw);
-  FHandshakeLog := TArrayUtilities.Concat(FHandshakeLog, ARaw);
+  if System.Length(ARaw) > 0 then
+    FHandshakeLog.Write(ARaw[0], System.Length(ARaw));
 end;
 
 function TTls12ServerStateMachine.BuildCertificate: TBytes;
@@ -786,7 +798,7 @@ begin
   // the scheme applies its own hash, so the suite PRF hash does not matter here
   LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FClientCertChain[0]);
   LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
-  LVerifier.Update(FHandshakeLog, 0, System.Length(FHandshakeLog));
+  LVerifier.Update(FHandshakeLog.Bytes, 0, FHandshakeLog.Size);
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.DecryptError, @SBadClientCertVerify);

--- a/TlsLib/src/Record/TlpRecordLayer.pas
+++ b/TlsLib/src/Record/TlpRecordLayer.pas
@@ -486,7 +486,8 @@ end;
 procedure TRecordLayer.Write(AContentType: TTlsContentType; const AData: TBytes;
   AOffset, ALength: Int32);
 var
-  LOffset, LRemaining, LChunk: Int32;
+  LOffset, LRemaining, LChunk, LCount, LI, LBase, LAddLen, LPos, LLen: Int32;
+  LRecords: TArray<TBytes>;
 begin
   // reject an out-of-range slice at the single chokepoint before Protect
   if (AOffset < 0) or (ALength < 0) or
@@ -498,16 +499,35 @@ begin
   LRemaining := ALength;
   // fragment to at most the negotiated outbound plaintext cap (<= 2^14) per record;
   // an empty write emits one empty record
-  repeat
+  if ALength <= 0 then
+    LCount := 1
+  else
+    LCount := (ALength + FMaxOutboundPlaintext - 1) div FMaxOutboundPlaintext;
+  // Protect advances the write epoch's record sequence number, so it must run
+  // exactly once per record
+  SetLength(LRecords, LCount);
+  LAddLen := 0;
+  for LI := 0 to LCount - 1 do
+  begin
     if LRemaining < FMaxOutboundPlaintext then
       LChunk := LRemaining
     else
       LChunk := FMaxOutboundPlaintext;
-    FOutbound := TArrayUtilities.Concat(FOutbound,
-      FWriteProtection.Protect(AContentType, AData, LOffset, LChunk));
+    LRecords[LI] := FWriteProtection.Protect(AContentType, AData, LOffset, LChunk);
+    Inc(LAddLen, System.Length(LRecords[LI]));
     Inc(LOffset, LChunk);
     Dec(LRemaining, LChunk);
-  until LRemaining <= 0;
+  end;
+  LBase := System.Length(FOutbound);
+  SetLength(FOutbound, LBase + LAddLen);
+  LPos := LBase;
+  for LI := 0 to LCount - 1 do
+  begin
+    LLen := System.Length(LRecords[LI]);
+    if LLen > 0 then
+      System.Move(LRecords[LI][0], FOutbound[LPos], LLen);
+    Inc(LPos, LLen);
+  end;
 end;
 
 function TRecordLayer.TakeOutgoing: TBytes;

--- a/TlsLib/src/Trust/TlpCertificateVerifier.pas
+++ b/TlsLib/src/Trust/TlpCertificateVerifier.pas
@@ -174,18 +174,27 @@ end;
 
 function TUnionTrustAnchorStore.RootCertificates: TArray<TBytes>;
 var
-  LI, LJ: Int32;
-  LChild: TArray<TBytes>;
+  LI, LJ, LPos, LTotal: Int32;
+  LChildResults: TArray<TArray<TBytes>>;
 begin
-  Result := nil;
+  SetLength(LChildResults, System.Length(FStores));
+  LTotal := 0;
   for LI := 0 to System.High(FStores) do
   begin
     if FStores[LI] = nil then
       Continue;
-    LChild := FStores[LI].RootCertificates;
-    for LJ := 0 to System.High(LChild) do
-      TArrayUtilities.Append<TBytes>(Result, System.Copy(LChild[LJ]));
+    LChildResults[LI] := FStores[LI].RootCertificates;
+    Inc(LTotal, System.Length(LChildResults[LI]));
   end;
+  Result := nil;
+  SetLength(Result, LTotal);
+  LPos := 0;
+  for LI := 0 to System.High(LChildResults) do
+    for LJ := 0 to System.High(LChildResults[LI]) do
+    begin
+      Result[LPos] := LChildResults[LI][LJ];
+      Inc(LPos);
+    end;
 end;
 
 { TCertificateVerifier }


### PR DESCRIPTION
## Summary

Several accumulators grew a dynamic array one element at a time inside a loop
(`SetLength(N+1)` or `Concat` per iteration), reallocating on every step (O(n²)).
This replaces them with pre-sized, amortized, or set-backed builds. Every change is
behavior-preserving (identical output contents **and** order); no wire behavior change.

## The two real wins

- **Record write throughput.** `TlpRecordLayer.Write` concatenated the whole growing
  outbound buffer once per 16 KB record (a 1 MB write did ~64 growing concats, ≈ 32 MB
  of memcpy). Now the per-record protected outputs are appended in a single
  `SetLength`+`Move`. Inbound already drains incrementally and is untouched.
- **Trust-root dedup.** The system-trust harvest de-duplicated roots with an O(n)
  `Contains`-before-append scan (plus a sibling O(n) `InSet` scan on Windows). Now O(1)
  via a default-comparer `TDictionary<TBytes, Boolean>` behind a small
  `TSystemRootAccumulator`; the Windows/Apple harvesters accumulate into `TList`.

## Modest tidies (same family)

- SAN inspection (`DnsNames`/`IpAddresses`) pre-sizes to the SAN count and trims once.
- PEM `LoadChain` reads into a `TList` freed in `try/finally`.
- The TLS 1.2 handshake log (`FHandshakeLog`) accumulates in a `TBytesStream` instead
  of a per-message `Concat`.

## Tests

Adds a deterministic test pinning the dedup invariant (the RTL giving `TBytes` keys
**content**, not reference, equality): the same certificate under two names collapses
to one anchor, and two distinct certificates both survive, so a silent
reference-equality degradation or a false-merge fails on every platform.