### PR TITLE
Parse the peer certificate once and reuse the connection's HKDF

### DIFF
--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -32,6 +32,7 @@ uses
   ClpIHkdfParameters,
   ClpHkdfParameters,
   ClpHkdfBytesGenerator,
+  ClpIHkdfBytesGenerator,
   ClpIKeyParameter,
   ClpKeyParameter,
   ClpIBlockCipher,
@@ -285,6 +286,8 @@ type
   strict private
   var
     FAlgorithm: THashAlgorithm;
+    FExtractMac: IMac;
+    FExpandGen: IHkdfBytesGenerator;
     function NewDigest: IDigest;
   public
     constructor Create(AAlgorithm: THashAlgorithm);
@@ -527,15 +530,33 @@ type
       const APublicKeyDer: TBytes): ISignatureVerifier;
   end;
 
+  // IInspectedCertificate - one X.509 certificate decoded once, answering the
+  // per-certificate queries from that single parse.
+  TInspectedCertificate = class(TInterfacedObject, IInspectedCertificate)
+  strict private
+  const
+    // PKCS#1 id-RSASSA-PSS: the restricted RSA-PSS key type (RFC 4055)
+    RsaSsaPssKeyOid = '1.2.840.113549.1.1.10';
+  var
+    FCert: IX509Certificate;
+  public
+    constructor Create(const ADer: TBytes);
+    function PublicKeyInfo: TBytes;
+    function DnsNames: TArray<string>;
+    function IpAddresses: TArray<TBytes>;
+    function KeyUsagePermits(AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
+    function HasRsaPssKey(out AIsRsaPss: Boolean): Boolean;
+    function KeyKind(out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+  end;
+
   // ICertificateInspector - pure, per-certificate, side-effect-free X.509 inspection.
   TCertificateInspector = class(TInterfacedObject, ICertificateInspector)
   strict private
   const
     // RFC 7633 id-pe-tlsfeature
     TlsFeatureExtensionOid = '1.3.6.1.5.5.7.1.24';
-    // PKCS#1 id-RSASSA-PSS: the restricted RSA-PSS key type (RFC 4055)
-    RsaSsaPssKeyOid = '1.2.840.113549.1.1.10';
   public
+    function Parse(const ADer: TBytes): IInspectedCertificate;
     function LoadChain(const AData: TBytes): TArray<TBytes>;
     function IsWellFormed(const ADer: TBytes): Boolean;
     function PublicKeyInfo(const ACertificateDer: TBytes): TBytes;
@@ -734,6 +755,8 @@ constructor THkdfAdapter.Create(AAlgorithm: THashAlgorithm);
 begin
   inherited Create;
   FAlgorithm := AAlgorithm;
+  FExtractMac := THMac.Create(NewDigest) as IMac;
+  FExpandGen := THkdfBytesGenerator.Create(NewDigest) as IHkdfBytesGenerator;
 end;
 
 function THkdfAdapter.NewDigest: IDigest;
@@ -747,7 +770,7 @@ var
   LMac: IMac;
   LSalt, LIkmBytes, LPrk: TBytes;
 begin
-  LMac := THMac.Create(NewDigest) as IMac;
+  LMac := FExtractMac;
   LSalt := ASalt;
   if System.Length(LSalt) = 0 then
     SetLength(LSalt, LMac.GetMacSize); // HashLen zero bytes
@@ -769,11 +792,11 @@ end;
 function THkdfAdapter.Expand(const APrk: ISecretBuffer; const AInfo: TBytes;
   ALength: Int32): ISecretBuffer;
 var
-  LGen: THkdfBytesGenerator;
+  LGen: IHkdfBytesGenerator;
   LParams: IHkdfParameters;
   LPrkBytes, LOkm: TBytes;
 begin
-  LGen := THkdfBytesGenerator.Create(NewDigest);
+  LGen := FExpandGen;
   LPrkBytes := APrk.ToBytes;
   try
     LParams := THkdfParameters.SkipExtractParameters(LPrkBytes, AInfo);
@@ -789,7 +812,6 @@ begin
     end;
   finally
     TSecureMemory.WipeBytes(LPrkBytes);
-    LGen.Free;
   end;
 end;
 
@@ -1890,17 +1912,20 @@ begin
     raise EArgumentTlsLibException.CreateRes(@SNoCertificatesFound);
 end;
 
+function TCertificateInspector.Parse(const ADer: TBytes): IInspectedCertificate;
+begin
+  Result := TInspectedCertificate.Create(ADer) as IInspectedCertificate;
+end;
+
 function TCertificateInspector.IsWellFormed(
   const ADer: TBytes): Boolean;
-var
-  LParser: IX509CertificateParser;
 begin
   Result := False;
   if System.Length(ADer) = 0 then
     Exit;
   try
-    LParser := TX509CertificateParser.Create;
-    Result := LParser.ReadCertificate(ADer) <> nil;
+    Parse(ADer);
+    Result := True;
   except
     Result := False;
   end;
@@ -1979,29 +2004,47 @@ end;
 
 function TCertificateInspector.PublicKeyInfo(
   const ACertificateDer: TBytes): TBytes;
-var
-  LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
 begin
-  LParser := TX509CertificateParser.Create;
-  LCert := LParser.ReadCertificate(ACertificateDer);
-  Result := LCert.GetSubjectPublicKeyInfo.GetDerEncoded;
+  Result := Parse(ACertificateDer).PublicKeyInfo;
 end;
 
 function TCertificateInspector.DnsNames(
   const ACertificateDer: TBytes): TArray<string>;
+begin
+  Result := Parse(ACertificateDer).DnsNames;
+end;
+
+function TCertificateInspector.IpAddresses(
+  const ACertificateDer: TBytes): TArray<TBytes>;
+begin
+  Result := Parse(ACertificateDer).IpAddresses;
+end;
+
+constructor TInspectedCertificate.Create(const ADer: TBytes);
 var
   LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
+begin
+  inherited Create;
+  LParser := TX509CertificateParser.Create;
+  FCert := LParser.ReadCertificate(ADer);
+  if FCert = nil then
+    raise EArgumentTlsLibException.CreateRes(@SMalformedCertificate);
+end;
+
+function TInspectedCertificate.PublicKeyInfo: TBytes;
+begin
+  Result := FCert.GetSubjectPublicKeyInfo.GetDerEncoded;
+end;
+
+function TInspectedCertificate.DnsNames: TArray<string>;
+var
   LGeneralNames: IGeneralNames;
   LNames: TArray<IGeneralName>;
   LString: IAsn1String;
   LI, LCount: Int32;
 begin
   Result := nil;
-  LParser := TX509CertificateParser.Create;
-  LCert := LParser.ReadCertificate(ACertificateDer);
-  LGeneralNames := LCert.GetSubjectAlternativeNameExtension;
+  LGeneralNames := FCert.GetSubjectAlternativeNameExtension;
   if LGeneralNames = nil then
     Exit;
   LNames := LGeneralNames.GetNames;
@@ -2017,20 +2060,15 @@ begin
   SetLength(Result, LCount);
 end;
 
-function TCertificateInspector.IpAddresses(
-  const ACertificateDer: TBytes): TArray<TBytes>;
+function TInspectedCertificate.IpAddresses: TArray<TBytes>;
 var
-  LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
   LGeneralNames: IGeneralNames;
   LNames: TArray<IGeneralName>;
   LOctets: IAsn1OctetString;
   LI, LCount: Int32;
 begin
   Result := nil;
-  LParser := TX509CertificateParser.Create;
-  LCert := LParser.ReadCertificate(ACertificateDer);
-  LGeneralNames := LCert.GetSubjectAlternativeNameExtension;
+  LGeneralNames := FCert.GetSubjectAlternativeNameExtension;
   if LGeneralNames = nil then
     Exit;
   LNames := LGeneralNames.GetNames;
@@ -2695,21 +2733,53 @@ end;
 function TCertificateInspector.KeyUsagePermits(
   const ACertificateDer: TBytes; AUsage: TCertKeyUsage;
   out APermitted: Boolean): Boolean;
+begin
+  try
+    Result := Parse(ACertificateDer).KeyUsagePermits(AUsage, APermitted);
+  except
+    // an unparseable certificate cannot be determined; imposes no restriction
+    APermitted := True;
+    Result := False;
+  end;
+end;
+
+function TCertificateInspector.HasRsaPssKey(
+  const ACertificateDer: TBytes; out AIsRsaPss: Boolean): Boolean;
+begin
+  try
+    Result := Parse(ACertificateDer).HasRsaPssKey(AIsRsaPss);
+  except
+    // an unparseable certificate cannot be determined; AIsRsaPss stays False
+    AIsRsaPss := False;
+    Result := False;
+  end;
+end;
+
+function TCertificateInspector.KeyKind(const ACertificateDer: TBytes;
+  out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+begin
+  try
+    Result := Parse(ACertificateDer).KeyKind(AKind, AEcNamedGroup);
+  except
+    // an unparseable certificate cannot be classified
+    AKind := TCertKeyKind.Rsa;
+    AEcNamedGroup := 0;
+    Result := False;
+  end;
+end;
+
+function TInspectedCertificate.KeyUsagePermits(AUsage: TCertKeyUsage;
+  out APermitted: Boolean): Boolean;
 var
-  LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
   LBits: TArray<Boolean>;
   LIndex: Int32;
 begin
   // absent extension or an undeterminable certificate imposes no restriction
   APermitted := True;
   try
-    LParser := TX509CertificateParser.Create;
-    LCert := LParser.ReadCertificate(ACertificateDer);
-    LBits := LCert.GetKeyUsage; // nil when the keyUsage extension is absent
+    LBits := FCert.GetKeyUsage; // nil when the keyUsage extension is absent
     Result := True;
   except
-    // an unparseable certificate cannot be determined; APermitted stays True
     Exit(False);
   end;
   if LBits = nil then
@@ -2730,42 +2800,30 @@ begin
   APermitted := (LIndex >= 0) and (LIndex <= High(LBits)) and LBits[LIndex];
 end;
 
-function TCertificateInspector.HasRsaPssKey(
-  const ACertificateDer: TBytes; out AIsRsaPss: Boolean): Boolean;
-var
-  LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
+function TInspectedCertificate.HasRsaPssKey(out AIsRsaPss: Boolean): Boolean;
 begin
   AIsRsaPss := False;
   try
-    LParser := TX509CertificateParser.Create;
-    LCert := LParser.ReadCertificate(ACertificateDer);
-    AIsRsaPss := LCert.GetSubjectPublicKeyInfo.GetAlgorithm.GetAlgorithm.GetID
+    AIsRsaPss := FCert.GetSubjectPublicKeyInfo.GetAlgorithm.GetAlgorithm.GetID
       = RsaSsaPssKeyOid;
     Result := True;
   except
-    // an unparseable certificate cannot be determined; AIsRsaPss stays False
     Result := False;
   end;
 end;
 
-function TCertificateInspector.KeyKind(const ACertificateDer: TBytes;
-  out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+function TInspectedCertificate.KeyKind(out AKind: TCertKeyKind;
+  out AEcNamedGroup: UInt16): Boolean;
 var
-  LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
   LAlg: IAlgorithmIdentifier;
   LOid, LCurve: IDerObjectIdentifier;
 begin
   AKind := TCertKeyKind.Rsa; // ignored unless Result is True
   AEcNamedGroup := 0;
   try
-    LParser := TX509CertificateParser.Create;
-    LCert := LParser.ReadCertificate(ACertificateDer);
-    LAlg := LCert.GetSubjectPublicKeyInfo.GetAlgorithm;
+    LAlg := FCert.GetSubjectPublicKeyInfo.GetAlgorithm;
     LOid := LAlg.Algorithm;
   except
-    // an unparseable certificate cannot be classified
     Exit(False);
   end;
   Result := True;

--- a/TlsLib/src/Handshake/TlpCertificateVerify.pas
+++ b/TlsLib/src/Handshake/TlpCertificateVerify.pas
@@ -125,16 +125,19 @@ class procedure TCertificateVerify.EnforceSigningLeafPolicy(
   const AProvider: ICryptoProvider; const ALeafCertificate: TBytes;
   const AScheme: TSignatureScheme; ABindEcdsaCurve: Boolean);
 var
+  LLeaf: IInspectedCertificate;
   LPermitted, LIsRsaPss: Boolean;
   LKind: TCertKeyKind;
   LCertGroup, LSchemeGroup: UInt16;
 begin
-  if AProvider.Certificates.KeyUsagePermits(ALeafCertificate,
-    TCertKeyUsage.DigitalSignature, LPermitted) and not LPermitted then
+  // the caller has already screened the leaf with EnsureWellFormedLeaf, so this decode
+  // succeeds and answers all three signing-policy queries from one parse
+  LLeaf := AProvider.Certificates.Parse(ALeafCertificate);
+  if LLeaf.KeyUsagePermits(TCertKeyUsage.DigitalSignature, LPermitted) and
+    not LPermitted then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.BadCertificate, @SLeafKeyUsageForbidsSigning);
-  if AScheme.IsRsaPssRsae and
-    AProvider.Certificates.HasRsaPssKey(ALeafCertificate, LIsRsaPss) and LIsRsaPss then
+  if AScheme.IsRsaPssRsae and LLeaf.HasRsaPssKey(LIsRsaPss) and LIsRsaPss then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.IllegalParameter, @SPssLeafKeyUnsupported);
   // TLS 1.3 binds the ECDSA curve to the signature scheme: an ecdsa_secp384r1_sha384
@@ -142,8 +145,7 @@ begin
   if ABindEcdsaCurve then
   begin
     LSchemeGroup := EcdsaSchemeNamedGroup(AScheme);
-    if (LSchemeGroup <> 0) and
-      AProvider.Certificates.KeyKind(ALeafCertificate, LKind, LCertGroup) and
+    if (LSchemeGroup <> 0) and LLeaf.KeyKind(LKind, LCertGroup) and
       (LKind = TCertKeyKind.Ecdsa) and (LCertGroup <> LSchemeGroup) then
       raise EFatalAlertTlsLibException.CreateRes(
         TTlsAlertDescription.IllegalParameter, @SEcdsaSchemeCurveMismatch);

--- a/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
+++ b/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
@@ -75,7 +75,7 @@ type
   /// <summary>
   /// Raw HKDF (RFC 5869): <see cref="Extract" /> derives a pseudo-random key,
   /// <see cref="Expand" /> stretches it. The TLS HKDF-Expand-Label wrapper is a
-  /// higher layer.
+  /// higher layer. An instance is stateful and is not shared across threads.
   /// </summary>
   IHkdf = interface(IInterface)
     ['{CE8C6F1F-9C1E-46F2-95EC-8F8FA500A5DD}']
@@ -237,12 +237,38 @@ type
 { ===== Certificate operations ===== }
 
   /// <summary>
-  /// Pure, per-certificate, side-effect-free X.509 inspection. Every method is
-  /// fail-closed: it never raises on malformed input, returning False (or an empty
-  /// result) so the caller decides the alert.
+  /// A single certificate parsed once into an opaque handle, answering the
+  /// per-certificate queries from that one decode. It lets a caller that inspects the
+  /// same leaf several times in a handshake pay the ASN.1 decode a single time. The
+  /// handle is obtained from <see cref="ICertificateInspector.Parse" /> and is not
+  /// shared across threads.
+  /// </summary>
+  IInspectedCertificate = interface(IInterface)
+    ['{5A0E2B77-3C41-4E28-9B6E-7E9F0C6D1A44}']
+    function PublicKeyInfo: TBytes;
+    function DnsNames: TArray<string>;
+    function IpAddresses: TArray<TBytes>;
+    function KeyUsagePermits(AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
+    function HasRsaPssKey(out AIsRsaPss: Boolean): Boolean;
+    function KeyKind(out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+  end;
+
+  /// <summary>
+  /// Pure, per-certificate, side-effect-free X.509 inspection. The Boolean-returning
+  /// queries are fail-closed: they never raise on malformed input, returning False (or
+  /// an empty result) so the caller decides the alert. Parse, LoadChain, and the
+  /// extractor methods (PublicKeyInfo, DnsNames, IpAddresses) raise on malformed input.
   /// </summary>
   ICertificateInspector = interface(IInterface)
     ['{243AB9CD-2900-4A04-B952-FEC3CD105B05}']
+    /// <summary>
+    /// Decodes ADer once into a handle that answers the per-certificate queries from
+    /// that single decode. Raises when ADer does not decode to a certificate (empty or
+    /// malformed); otherwise returns a handle over a well-formed certificate. Unlike the
+    /// fail-closed DER-taking queries it raises rather than returning False, so use it
+    /// where the certificate is already known well-formed.
+    /// </summary>
+    function Parse(const ADer: TBytes): IInspectedCertificate;
     /// <summary>
     /// Decodes certificates from AData - a PEM block (a single certificate or a whole
     /// leaf-first chain/bundle) or a single DER certificate - into their ordered raw

--- a/TlsLib/src/Trust/TlpCertificateVerifier.pas
+++ b/TlsLib/src/Trust/TlpCertificateVerifier.pas
@@ -383,6 +383,7 @@ var
   // building completed from the configured intermediates, this carries the assembled path
   // (with the recovered issuer), so revocation and pinning see it rather than the bare leaf
   LEffectiveChain: TArray<TBytes>;
+  LLeaf: IInspectedCertificate;
 begin
   Result := False;
   AAlert := TTlsAlertDescription.BadCertificate;
@@ -424,13 +425,14 @@ begin
 
   // endpoint identity (RFC 6125) over the leaf's dNSName / iPAddress SAN entries
   if FCheckHostName and (AHostName <> '') then
-    if not TEndpointIdentity.Matches(AHostName,
-      FProvider.Certificates.DnsNames(AChain[0]),
-      FProvider.Certificates.IpAddresses(AChain[0])) then
+  begin
+    LLeaf := FProvider.Certificates.Parse(AChain[0]);
+    if not TEndpointIdentity.Matches(AHostName, LLeaf.DnsNames, LLeaf.IpAddresses) then
     begin
       AAlert := TTlsAlertDescription.BadCertificate;
       Exit;
     end;
+  end;
 
   // optional SPKI pinning augments the validated chain; it never bypasses it. Pin against the
   // validated chain so a pin on a recovered intermediate matches even for a leaf-only peer


### PR DESCRIPTION
The handshake decoded the same peer leaf six or seven times. each inspector query (public key, SAN names, key kind, RSA-PSS, key usage) re-ran the full X.509 parse, and the signing-policy check parsed it three more times. Certificate inspection now vends an opaque IInspectedCertificate handle that decodes the DER once and answers every query from that single parse; the DER-taking methods become thin wrappers over it, the endpoint identity check and the signing-leaf policy each take one handle, and the handle enforces a parsed-once invariant so its contract is honest. The per-connection HKDF adapter likewise held one HMAC and one generator that it re-initialises per call instead of allocating a fresh digest, HMAC and generator for every Extract and Expand.