### PR TITLE
Wire the single-use ephemeral ECDH agreement into the TLS 1.3 handshake

### DIFF
--- a/TlsLib.Tests/src/CertificateCheckTests.pas
+++ b/TlsLib.Tests/src/CertificateCheckTests.pas
@@ -53,7 +53,7 @@ type
     procedure TestAbsentKeyUsagePermitsSigning;
     procedure TestKeyEnciphermentCertPermitsEncipherment;
     procedure TestMalformedCertLeavesUsagePermitted;
-    // id-RSASSA-PSS key type (CertificateHasRsaPssKey)
+    // id-RSASSA-PSS key type (CertificateKeyIsRsaPss)
     procedure TestRsaPssKeyIsDetected;
     procedure TestNormalRsaKeyIsNotPss;
     procedure TestEcKeyIsNotPss;
@@ -83,10 +83,14 @@ end;
 
 function TTestCertificateChecks.Permits(const ACertName: string;
   AUsage: TCertKeyUsage): Boolean;
+var
+  LAnswer: TCertAnswer;
 begin
-  // asserts the certificate parsed (method result True) and reports the permission
-  CheckTrue(Provider.Certificates.KeyUsagePermits(V(ACertName), AUsage, Result),
-    'the certificate should parse');
+  // asserts the certificate yields a determined answer (never Undetermined) and reports
+  // whether it permits the usage
+  LAnswer := Provider.Certificates.KeyUsagePermits(V(ACertName), AUsage);
+  CheckTrue(LAnswer <> TCertAnswer.Undetermined, 'the certificate should parse');
+  Result := LAnswer = TCertAnswer.Yes;
 end;
 
 procedure TTestCertificateChecks.TestDigitalSignatureCertPermitsSigning;
@@ -120,50 +124,40 @@ begin
 end;
 
 procedure TTestCertificateChecks.TestMalformedCertLeavesUsagePermitted;
-var
-  LPermitted: Boolean;
 begin
-  // a certificate that does not parse cannot restrict usage: result False, permitted True
-  CheckFalse(Provider.Certificates.KeyUsagePermits(
-    TBytes.Create(1, 2, 3, 4), TCertKeyUsage.DigitalSignature, LPermitted),
+  // a certificate that does not parse cannot restrict usage: the answer is Undetermined
+  CheckEquals(Ord(TCertAnswer.Undetermined),
+    Ord(Provider.Certificates.KeyUsagePermits(
+    TBytes.Create(1, 2, 3, 4), TCertKeyUsage.DigitalSignature)),
     'a malformed certificate cannot be determined');
-  CheckTrue(LPermitted, 'an undeterminable certificate imposes no restriction');
 end;
 
 procedure TTestCertificateChecks.TestRsaPssKeyIsDetected;
-var
-  LIsRsaPss: Boolean;
 begin
-  CheckTrue(Provider.Certificates.HasRsaPssKey(V('rsapss_cert'), LIsRsaPss),
-    'the certificate should parse');
-  CheckTrue(LIsRsaPss, 'an id-RSASSA-PSS SubjectPublicKeyInfo is detected');
+  CheckEquals(Ord(TCertAnswer.Yes),
+    Ord(Provider.Certificates.KeyIsRsaPss(V('rsapss_cert'))),
+    'an id-RSASSA-PSS SubjectPublicKeyInfo is detected');
 end;
 
 procedure TTestCertificateChecks.TestNormalRsaKeyIsNotPss;
-var
-  LIsRsaPss: Boolean;
 begin
-  CheckTrue(Provider.Certificates.HasRsaPssKey(V('rsa_normal_cert'), LIsRsaPss),
-    'the certificate should parse');
-  CheckFalse(LIsRsaPss, 'an rsaEncryption key is not id-RSASSA-PSS');
+  CheckEquals(Ord(TCertAnswer.No),
+    Ord(Provider.Certificates.KeyIsRsaPss(V('rsa_normal_cert'))),
+    'an rsaEncryption key is not id-RSASSA-PSS');
 end;
 
 procedure TTestCertificateChecks.TestEcKeyIsNotPss;
-var
-  LIsRsaPss: Boolean;
 begin
-  CheckTrue(Provider.Certificates.HasRsaPssKey(V('ku_digsig_cert'), LIsRsaPss),
-    'the certificate should parse');
-  CheckFalse(LIsRsaPss, 'an ecPublicKey key is not id-RSASSA-PSS');
+  CheckEquals(Ord(TCertAnswer.No),
+    Ord(Provider.Certificates.KeyIsRsaPss(V('ku_digsig_cert'))),
+    'an ecPublicKey key is not id-RSASSA-PSS');
 end;
 
 procedure TTestCertificateChecks.TestMalformedCertIsNotPss;
-var
-  LIsRsaPss: Boolean;
 begin
-  CheckFalse(Provider.Certificates.HasRsaPssKey(TBytes.Create(9, 9, 9), LIsRsaPss),
+  CheckEquals(Ord(TCertAnswer.Undetermined),
+    Ord(Provider.Certificates.KeyIsRsaPss(TBytes.Create(9, 9, 9))),
     'a malformed certificate cannot be determined');
-  CheckFalse(LIsRsaPss, 'an undeterminable certificate is not reported as PSS');
 end;
 
 initialization

--- a/TlsLib/src/Crypto/TlpCryptoAlgorithms.pas
+++ b/TlsLib/src/Crypto/TlpCryptoAlgorithms.pas
@@ -31,6 +31,10 @@ type
   /// <summary>The AEAD ciphers the library selects between (internal identifiers).</summary>
   TAeadAlgorithm = (AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305);
 
+  /// <summary>An AEAD's usage-limit family: AES-GCM must proactively rekey by a
+  /// record-count bound, ChaCha20-Poly1305 is bounded only by the record sequence.</summary>
+  TAeadUsageCategory = (AesGcm, ChaCha20);
+
   /// <summary>The Diffie-Hellman key-agreement primitives (X25519 and NIST prime curves).</summary>
   TKeyAgreementAlgorithm = (X25519, SECP256R1, SECP384R1, SECP521R1);
 
@@ -62,6 +66,10 @@ type
   /// signature scheme's curve to the leaf key's curve (RFC 8446 4.2.3).
   /// </summary>
   TCertKeyKind = (Rsa, Ecdsa, Ed25519, Ed448);
+
+  /// <summary>Fail-closed answer to a Boolean certificate query: Undetermined when the
+  /// certificate or the queried field is malformed, otherwise No / Yes.</summary>
+  TCertAnswer = (Undetermined, No, Yes);
 
   /// <summary>
   /// How a named group performs its key exchange: Ecdhe is a classical ephemeral

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -57,6 +57,9 @@ uses
   ClpIECGenerators,
   ClpECDHBasicAgreement,
   ClpIECDHBasicAgreement,
+  ClpEphemeralECDHAgreement,
+  ClpIEphemeralECDHAgreement,
+  ClpECCurveConstants,
   ClpMlKemParameters,
   ClpIMlKemParameters,
   ClpMlKemGenerators,
@@ -544,9 +547,10 @@ type
     function PublicKeyInfo: TBytes;
     function DnsNames: TArray<string>;
     function IpAddresses: TArray<TBytes>;
-    function KeyUsagePermits(AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    function HasRsaPssKey(out AIsRsaPss: Boolean): Boolean;
+    function KeyUsagePermits(AUsage: TCertKeyUsage): TCertAnswer;
+    function KeyIsRsaPss: TCertAnswer;
     function KeyKind(out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+    function PeerInfo(out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
   end;
 
   // ICertificateInspector - pure, per-certificate, side-effect-free X.509 inspection.
@@ -567,9 +571,8 @@ type
     function TlsFeatures(const ACert: TBytes;
       out AFeatures: TArray<UInt16>): Boolean;
     function KeyUsagePermits(const ACertificateDer: TBytes;
-      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    function HasRsaPssKey(const ACertificateDer: TBytes;
-      out AIsRsaPss: Boolean): Boolean;
+      AUsage: TCertKeyUsage): TCertAnswer;
+    function KeyIsRsaPss(const ACertificateDer: TBytes): TCertAnswer;
     function KeyKind(const ACertificateDer: TBytes;
       out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
   end;
@@ -1068,11 +1071,13 @@ end;
 function TNistEcAgreement.AgreeParams(const APriv: IECPrivateKeyParameters;
   const APeer: IECPublicKeyParameters): ISecretBuffer;
 var
-  LAgreement: IECDHBasicAgreement;
+  LAgreement: IEphemeralECDHAgreement;
   LZ: TBytes;
 begin
-  LAgreement := TECDHBasicAgreement.Create;
-  LAgreement.Init(APriv);
+  // The handshake scalar is generated fresh and used once, so a single-use
+  // agreement with the deterministic fixed-length posture is safe here.
+  LAgreement := TEphemeralECDHAgreement.Create(APriv,
+    TECCurveConstants.SCALAR_BLIND_DETERMINISTIC);
   LZ := TBigIntegerUtilities.AsUnsignedByteArray(FFieldSize, LAgreement.CalculateAgreement(APeer));
   try
     Result := TSecretBuffer.From(LZ);
@@ -2645,28 +2650,10 @@ end;
 
 function TCertificateInspector.PeerInfo(const ACertificateDer: TBytes;
   out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
-var
-  LParser: IX509CertificateParser;
-  LCert: IX509Certificate;
-  LCns: TCryptoLibStringArray;
 begin
-  Result := False;
-  ASubject := '';
-  AIssuer := '';
-  ACommonName := '';
-  ASerialHex := '';
-  if System.Length(ACertificateDer) = 0 then
-    Exit;
   try
-    LParser := TX509CertificateParser.Create;
-    LCert := LParser.ReadCertificate(ACertificateDer);
-    ASubject := LCert.SubjectDN.ToString;
-    AIssuer := LCert.IssuerDN.ToString;
-    LCns := LCert.SubjectDN.GetValueList(TX509Name.CN);
-    if System.Length(LCns) > 0 then
-      ACommonName := LCns[0];
-    ASerialHex := LCert.SerialNumber.ToString(16);
-    Result := True;
+    Result := Parse(ACertificateDer).PeerInfo(ASubject, AIssuer, ACommonName,
+      ASerialHex);
   except
     Result := False;
     ASubject := '';
@@ -2731,27 +2718,24 @@ begin
 end;
 
 function TCertificateInspector.KeyUsagePermits(
-  const ACertificateDer: TBytes; AUsage: TCertKeyUsage;
-  out APermitted: Boolean): Boolean;
+  const ACertificateDer: TBytes; AUsage: TCertKeyUsage): TCertAnswer;
 begin
   try
-    Result := Parse(ACertificateDer).KeyUsagePermits(AUsage, APermitted);
+    Result := Parse(ACertificateDer).KeyUsagePermits(AUsage);
   except
     // an unparseable certificate cannot be determined; imposes no restriction
-    APermitted := True;
-    Result := False;
+    Result := TCertAnswer.Undetermined;
   end;
 end;
 
-function TCertificateInspector.HasRsaPssKey(
-  const ACertificateDer: TBytes; out AIsRsaPss: Boolean): Boolean;
+function TCertificateInspector.KeyIsRsaPss(
+  const ACertificateDer: TBytes): TCertAnswer;
 begin
   try
-    Result := Parse(ACertificateDer).HasRsaPssKey(AIsRsaPss);
+    Result := Parse(ACertificateDer).KeyIsRsaPss;
   except
-    // an unparseable certificate cannot be determined; AIsRsaPss stays False
-    AIsRsaPss := False;
-    Result := False;
+    // an unparseable certificate cannot be determined
+    Result := TCertAnswer.Undetermined;
   end;
 end;
 
@@ -2768,22 +2752,19 @@ begin
   end;
 end;
 
-function TInspectedCertificate.KeyUsagePermits(AUsage: TCertKeyUsage;
-  out APermitted: Boolean): Boolean;
+function TInspectedCertificate.KeyUsagePermits(AUsage: TCertKeyUsage): TCertAnswer;
 var
   LBits: TArray<Boolean>;
   LIndex: Int32;
 begin
-  // absent extension or an undeterminable certificate imposes no restriction
-  APermitted := True;
   try
     LBits := FCert.GetKeyUsage; // nil when the keyUsage extension is absent
-    Result := True;
   except
-    Exit(False);
+    Exit(TCertAnswer.Undetermined);
   end;
+  // an absent extension imposes no restriction
   if LBits = nil then
-    Exit;
+    Exit(TCertAnswer.Yes);
   // RFC 5280 4.2.1.3 bit order: digitalSignature(0), keyEncipherment(2), keyAgreement(4)
   case AUsage of
     TCertKeyUsage.DigitalSignature:
@@ -2797,18 +2778,48 @@ begin
   end;
   // the extension is present, so the bit must be asserted; a bit past the encoded
   // length is an omitted trailing zero, i.e. not asserted
-  APermitted := (LIndex >= 0) and (LIndex <= High(LBits)) and LBits[LIndex];
+  if (LIndex >= 0) and (LIndex <= High(LBits)) and LBits[LIndex] then
+    Result := TCertAnswer.Yes
+  else
+    Result := TCertAnswer.No;
 end;
 
-function TInspectedCertificate.HasRsaPssKey(out AIsRsaPss: Boolean): Boolean;
+function TInspectedCertificate.KeyIsRsaPss: TCertAnswer;
 begin
-  AIsRsaPss := False;
   try
-    AIsRsaPss := FCert.GetSubjectPublicKeyInfo.GetAlgorithm.GetAlgorithm.GetID
-      = RsaSsaPssKeyOid;
+    if FCert.GetSubjectPublicKeyInfo.GetAlgorithm.GetAlgorithm.GetID
+      = RsaSsaPssKeyOid then
+      Result := TCertAnswer.Yes
+    else
+      Result := TCertAnswer.No;
+  except
+    Result := TCertAnswer.Undetermined;
+  end;
+end;
+
+function TInspectedCertificate.PeerInfo(out ASubject, AIssuer, ACommonName,
+  ASerialHex: string): Boolean;
+var
+  LCns: TCryptoLibStringArray;
+begin
+  ASubject := '';
+  AIssuer := '';
+  ACommonName := '';
+  ASerialHex := '';
+  try
+    ASubject := FCert.SubjectDN.ToString;
+    AIssuer := FCert.IssuerDN.ToString;
+    LCns := FCert.SubjectDN.GetValueList(TX509Name.CN);
+    if System.Length(LCns) > 0 then
+      ACommonName := LCns[0];
+    ASerialHex := FCert.SerialNumber.ToString(16);
     Result := True;
   except
     Result := False;
+    ASubject := '';
+    AIssuer := '';
+    ACommonName := '';
+    ASerialHex := '';
   end;
 end;
 

--- a/TlsLib/src/Engine/TlpTlsEngineFactory.pas
+++ b/TlsLib/src/Engine/TlpTlsEngineFactory.pas
@@ -235,7 +235,10 @@ begin
   L13.OfferedGroups := RegisteredGroupCodes(AConfig, AConfig.PreferredGroups);
   L13.GroupRegistry := AConfig.NamedGroups;
   L13.CipherSuites := AConfig.CipherSuites;
-  L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
+  // the extension registry (its ~20 handlers) is built only for a version whose machine is
+  // actually created below; a single-version client would otherwise build and discard one
+  if LOffers13 then
+    L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   L13.OfferedSuites := SuiteCodes(AConfig.CipherSuites);
   L13.OfferedSchemes := SchemeCodes(AConfig.SignatureSchemes);
   L13.AlpnProtocols := AConfig.AlpnProtocols;
@@ -261,7 +264,8 @@ begin
   L12.Provider := AConfig.Provider;
   L12.GroupRegistry := AConfig.NamedGroups;
   L12.CipherSuites := AConfig.CipherSuites;
-  L12.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
+  if LOffers12 then
+    L12.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   L12.Clock := AConfig.Clock;
   L12.OfferedSuites := SuiteCodes(AConfig.CipherSuites);
   // TLS 1.2 key exchange is ECDHE-only: a 1.2 supported_groups carries no KEM/hybrid group,
@@ -352,7 +356,9 @@ begin
     AConfig.NamedGroups, AConfig.SignatureSchemes, AConfig.PreferredGroups,
     AConfig.SupportedVersions, AConfig.CipherSuitePreference);
   L13.CipherSuites := AConfig.CipherSuites;
-  L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
+  // build the extension registry only for a version whose machine is created below
+  if LOffers13 then
+    L13.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   // the server offers all its preferred groups the registry holds and selects one the client
   // offered (RFC 8446 4.2.8); a group pruned from the registry is never selected, so it cannot fail
   // to resolve mid-handshake. secp256r1 is mandatory to implement (RFC 8446 9.1), never a single group
@@ -398,7 +404,8 @@ begin
   L12.Provider := AConfig.Provider;
   L12.Clock := AConfig.Clock;
   L12.CipherSuites := AConfig.CipherSuites;
-  L12.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
+  if LOffers12 then
+    L12.ExtensionRegistry := TCoreExtensions.CreateDefaultRegistry;
   // TLS 1.2 needs a classical ECDHE group (KEM/hybrid are 1.3-only); the server picks
   // the first of these the client also advertised, so OfferedGroups drives selection
   // and Group is only the low-level single-group fallback

--- a/TlsLib/src/Handshake/TlpCertificateVerify.pas
+++ b/TlsLib/src/Handshake/TlpCertificateVerify.pas
@@ -48,14 +48,14 @@ type
     /// EC key to be on the scheme's named curve (RFC 8446 4.2.3) - TLS 1.2 leaves the curve
     /// to the supported_groups list, so it passes False. Applies symmetrically to a client
     /// verifying the server leaf and a server verifying the client leaf.</summary>
-    class procedure EnforceSigningLeafPolicy(const AProvider: ICryptoProvider;
-      const ALeafCertificate: TBytes; const AScheme: TSignatureScheme;
-      ABindEcdsaCurve: Boolean); static;
-    /// <summary>Rejects a peer leaf that is not a well-formed X.509 certificate with a
-    /// decode_error alert, before it reaches signature verification or the trust pipeline.
-    /// Applies to a received server or client leaf.</summary>
-    class procedure EnsureWellFormedLeaf(const AProvider: ICryptoProvider;
-      const ALeafCertificate: TBytes); static;
+    class procedure EnforceSigningLeafPolicy(const ALeaf: IInspectedCertificate;
+      const AScheme: TSignatureScheme; ABindEcdsaCurve: Boolean); static;
+    /// <summary>Parses a peer leaf, rejecting one that is not a well-formed X.509
+    /// certificate with a decode_error alert before it reaches signature verification or
+    /// the trust pipeline, and returns the parsed handle so the caller reuses the single
+    /// decode. Applies to a received server or client leaf.</summary>
+    class function ParseWellFormedLeaf(const AProvider: ICryptoProvider;
+      const ALeafCertificate: TBytes): IInspectedCertificate; static;
   end;
 
 implementation
@@ -72,15 +72,21 @@ resourcestring
 
 { TCertificateVerify }
 
-class procedure TCertificateVerify.EnsureWellFormedLeaf(
-  const AProvider: ICryptoProvider; const ALeafCertificate: TBytes);
+class function TCertificateVerify.ParseWellFormedLeaf(
+  const AProvider: ICryptoProvider;
+  const ALeafCertificate: TBytes): IInspectedCertificate;
 var
   LSubject, LIssuer, LCommonName, LSerialHex: string;
 begin
-  // CertificatePeerInfo parses the whole certificate and never raises: False means the DER
-  // is not a well-formed X.509 certificate, so reject it before any downstream cert use.
-  if not AProvider.Certificates.PeerInfo(ALeafCertificate, LSubject, LIssuer,
-    LCommonName, LSerialHex) then
+  // the catch-all except covers uncaught backend exception types from the ASN.1 decode
+  try
+    Result := AProvider.Certificates.Parse(ALeafCertificate);
+  except
+    raise EDecodeErrorTlsLibException.CreateRes(@SUnparseableLeafCertificate);
+  end;
+  // PeerInfo probes the whole certificate and never raises: False means a field is not a
+  // well-formed X.509 structure, so reject it before any downstream cert use.
+  if not Result.PeerInfo(LSubject, LIssuer, LCommonName, LSerialHex) then
     raise EDecodeErrorTlsLibException.CreateRes(@SUnparseableLeafCertificate);
 end;
 
@@ -122,22 +128,19 @@ begin
 end;
 
 class procedure TCertificateVerify.EnforceSigningLeafPolicy(
-  const AProvider: ICryptoProvider; const ALeafCertificate: TBytes;
-  const AScheme: TSignatureScheme; ABindEcdsaCurve: Boolean);
+  const ALeaf: IInspectedCertificate; const AScheme: TSignatureScheme;
+  ABindEcdsaCurve: Boolean);
 var
-  LLeaf: IInspectedCertificate;
-  LPermitted, LIsRsaPss: Boolean;
   LKind: TCertKeyKind;
   LCertGroup, LSchemeGroup: UInt16;
 begin
-  // the caller has already screened the leaf with EnsureWellFormedLeaf, so this decode
-  // succeeds and answers all three signing-policy queries from one parse
-  LLeaf := AProvider.Certificates.Parse(ALeafCertificate);
-  if LLeaf.KeyUsagePermits(TCertKeyUsage.DigitalSignature, LPermitted) and
-    not LPermitted then
+  // the caller passes the leaf already parsed by ParseWellFormedLeaf, answering all three
+  // signing-policy queries from that one decode; only a definite No/Yes trips the raise,
+  // an Undetermined field passes (fail-open per check)
+  if ALeaf.KeyUsagePermits(TCertKeyUsage.DigitalSignature) = TCertAnswer.No then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.BadCertificate, @SLeafKeyUsageForbidsSigning);
-  if AScheme.IsRsaPssRsae and LLeaf.HasRsaPssKey(LIsRsaPss) and LIsRsaPss then
+  if AScheme.IsRsaPssRsae and (ALeaf.KeyIsRsaPss = TCertAnswer.Yes) then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.IllegalParameter, @SPssLeafKeyUnsupported);
   // TLS 1.3 binds the ECDSA curve to the signature scheme: an ecdsa_secp384r1_sha384
@@ -145,7 +148,7 @@ begin
   if ABindEcdsaCurve then
   begin
     LSchemeGroup := EcdsaSchemeNamedGroup(AScheme);
-    if (LSchemeGroup <> 0) and LLeaf.KeyKind(LKind, LCertGroup) and
+    if (LSchemeGroup <> 0) and ALeaf.KeyKind(LKind, LCertGroup) and
       (LKind = TCertKeyKind.Ecdsa) and (LCertGroup <> LSchemeGroup) then
       raise EFatalAlertTlsLibException.CreateRes(
         TTlsAlertDescription.IllegalParameter, @SEcdsaSchemeCurveMismatch);

--- a/TlsLib/src/Handshake/TlpTls12ClientStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls12ClientStateMachine.pas
@@ -133,6 +133,10 @@ type
     FCurrentGroup: INamedGroup;
     FServerEcdhePublic: TBytes;
     FCertChain: TArray<TBytes>;
+    // the server leaf parsed once for the well-formed gate, reused for the key-kind check,
+    // the signing-policy check and its SubjectPublicKeyInfo; released once the SKE signature
+    // is verified
+    FParsedServerLeaf: IInspectedCertificate;
     FUseExtendedMasterSecret: Boolean;
     FClientSupportsTls13: Boolean;
     /// <summary>Whether the ServerHello echoed status_request, so a CertificateStatus
@@ -523,14 +527,16 @@ var
   LEcGroup: UInt16;
 begin
   Result := nil;
+  FParsedServerLeaf := nil;
   FCertChain := THandshakeMessages.DecodeCertificate12(AMessage.Body);
   if System.Length(FCertChain) = 0 then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.DecodeError, @SEmptyCertificate);
   // a server leaf that is not a well-formed certificate is a decode error
-  TCertificateVerify.EnsureWellFormedLeaf(FParams.Provider, FCertChain[0]);
+  FParsedServerLeaf := TCertificateVerify.ParseWellFormedLeaf(FParams.Provider,
+    FCertChain[0]);
 
-  if FParams.Provider.Certificates.KeyKind(FCertChain[0], LKind, LEcGroup) then
+  if FParsedServerLeaf.KeyKind(LKind, LEcGroup) then
   begin
     // the leaf key algorithm must match the negotiated suite's authentication method (a
     // CertificateCipherMismatch, RFC 5246 7.4.2): an *_RSA suite needs an RSA leaf; an
@@ -592,8 +598,7 @@ begin
 
   // the leaf that signs the ServerKeyExchange must permit digitalSignature and, for an
   // rsa_pss_rsae_* scheme, not be an id-RSASSA-PSS key
-  TCertificateVerify.EnforceSigningLeafPolicy(FParams.Provider,
-    FCertChain[0], LScheme, False);
+  TCertificateVerify.EnforceSigningLeafPolicy(FParsedServerLeaf, LScheme, False);
 
   // the server's curve must be one we offered and a classical ECDHE group we hold;
   // the client key-exchanges on exactly this curve
@@ -607,9 +612,11 @@ begin
   LContent := TArrayUtilities.Concat(
     TArrayUtilities.Concat(FParams.ClientRandom, FServerRandom),
     THandshakeMessages.EcdheServerParams(LSke.NamedCurve, LSke.PublicKey));
-  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FCertChain[0]);
+  LPublicKeyInfo := FParsedServerLeaf.PublicKeyInfo;
   LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(LContent, 0, System.Length(LContent));
+  // the parsed leaf is no longer needed; release it rather than pin the ASN.1 graph
+  FParsedServerLeaf := nil;
   if not LVerifier.Verify(LSke.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.DecryptError, @SBadServerKeyExchangeSig);

--- a/TlsLib/src/Handshake/TlpTls12ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls12ServerStateMachine.pas
@@ -177,6 +177,9 @@ type
     /// <summary>The client's certificate chain (leaf first) and whether it sent one, for
     /// the client CertificateVerify and the required-auth policy.</summary>
     FClientCertChain: TArray<TBytes>;
+    // the client leaf parsed once for the well-formed gate, reused for the signing-policy
+    // check and its SubjectPublicKeyInfo; released once the signature is verified
+    FParsedClientLeaf: IInspectedCertificate;
     FClientSentCertificate: Boolean;
     /// <summary>The raw concatenation of every handshake message, which the TLS 1.2
     /// client CertificateVerify is signed over (RFC 5246 7.4.8) - its scheme hashes this,
@@ -717,6 +720,7 @@ var
 begin
   Result := nil;
   FClientCertChain := THandshakeMessages.DecodeCertificate12(AMessage.Body);
+  FParsedClientLeaf := nil;
   Absorb(AMessage.Raw);
   FClientSentCertificate := System.Length(FClientCertChain) > 0;
 
@@ -730,7 +734,8 @@ begin
   begin
     // a client leaf that is not a well-formed certificate is a decode error, caught before
     // the verifier (which, for -require-any-client-certificate, does not parse the chain)
-    TCertificateVerify.EnsureWellFormedLeaf(FParams.Provider, FClientCertChain[0]);
+    FParsedClientLeaf := TCertificateVerify.ParseWellFormedLeaf(FParams.Provider,
+      FClientCertChain[0]);
     // fail-closed: without a verifier there is no basis to trust the chain (LAlert would
     // otherwise be read unassigned when the nil check short-circuits the Verify call)
     if FParams.ClientCertificateVerifier = nil then
@@ -792,13 +797,14 @@ begin
       TTlsAlertDescription.IllegalParameter, @SBadClientCertVerify);
   // the client leaf must permit digitalSignature and, for an rsa_pss_rsae_* scheme, not
   // be an id-RSASSA-PSS key (symmetric with the client verifying the server leaf)
-  TCertificateVerify.EnforceSigningLeafPolicy(FParams.Provider,
-    FClientCertChain[0], LScheme, False);
+  TCertificateVerify.EnforceSigningLeafPolicy(FParsedClientLeaf, LScheme, False);
   // the 1.2 CertificateVerify signs the raw handshake log through ClientKeyExchange;
   // the scheme applies its own hash, so the suite PRF hash does not matter here
-  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FClientCertChain[0]);
+  LPublicKeyInfo := FParsedClientLeaf.PublicKeyInfo;
   LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(FHandshakeLog.Bytes, 0, FHandshakeLog.Size);
+  // the parsed leaf is no longer needed; release it rather than pin the ASN.1 graph
+  FParsedClientLeaf := nil;
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.DecryptError, @SBadClientCertVerify);

--- a/TlsLib/src/Handshake/TlpTls13ClientStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ClientStateMachine.pas
@@ -165,6 +165,9 @@ type
     FMiddleboxCcsSent: Boolean;
     FOfferedExtensions: TArray<UInt16>;
     FCertificateChain: TArray<TBytes>;
+    // the server leaf parsed once for the well-formed gate, reused for the signing-policy
+    // check and its SubjectPublicKeyInfo; released once the signature is verified
+    FParsedServerLeaf: IInspectedCertificate;
     /// <summary>The stapled OCSP response the server delivered in the leaf CertificateEntry
     /// (RFC 8446 4.4.2.1); empty when none was stapled. Fed to the trust verdict.</summary>
     FReceivedOcspStaple: TBytes;
@@ -898,6 +901,8 @@ begin
 
     FCurrentGroup.Decapsulate(FEphemeralPrivate,
       LContext.SelectedKeyShare.KeyExchange, LShared);
+    // the ephemeral private is spent; release it now so its buffer is wiped
+    FEphemeralPrivate := nil;
 
     // the server accepted a PSK iff it echoed pre_shared_key with our identity index; that
     // index must be within the list we offered (RFC 8446 4.2.11), and the selected suite's
@@ -1213,13 +1218,15 @@ begin
   end;
   // keep the chain (leaf first) for the CertificateVerify and the trust verdict
   FCertificateChain := nil;
+  FParsedServerLeaf := nil;
   SetLength(FCertificateChain, System.Length(LCert.Entries));
   for LI := 0 to High(LCert.Entries) do
     FCertificateChain[LI] := LCert.Entries[LI].CertData;
 
   // a server leaf that is not a well-formed certificate is a decode error, caught before
   // the CertificateVerify signature check and the trust verdict
-  TCertificateVerify.EnsureWellFormedLeaf(FParams.Provider, FCertificateChain[0]);
+  FParsedServerLeaf := TCertificateVerify.ParseWellFormedLeaf(FParams.Provider,
+    FCertificateChain[0]);
 
   // capture any stapled OCSP response carried in the leaf entry (RFC 8446 4.4.2.1)
   FReceivedOcspStaple := nil;
@@ -1303,14 +1310,15 @@ begin
 
   // the server leaf must permit digitalSignature and, for an rsa_pss_rsae_* scheme, not
   // be an id-RSASSA-PSS key (shared with the server verifying the client leaf)
-  TCertificateVerify.EnforceSigningLeafPolicy(FParams.Provider,
-    FCertificateChain[0], LScheme, True);
+  TCertificateVerify.EnforceSigningLeafPolicy(FParsedServerLeaf, LScheme, True);
 
   // the signature is over the transcript through the Certificate (this message not yet folded in)
   LContent := TCertificateVerify.SignatureContent(True, FTranscript.CurrentHash);
-  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FCertificateChain[0]);
+  LPublicKeyInfo := FParsedServerLeaf.PublicKeyInfo;
   LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(LContent, 0, System.Length(LContent));
+  // the parsed leaf is no longer needed; release it rather than pin the ASN.1 graph
+  FParsedServerLeaf := nil;
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.DecryptError, @SBadCertificateVerify);

--- a/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
@@ -208,6 +208,9 @@ type
     /// <summary>The client's certificate chain (leaf first), captured for the client
     /// CertificateVerify once the client Certificate is processed.</summary>
     FClientCertChain: TArray<TBytes>;
+    // the client leaf parsed once for the well-formed gate, reused for the signing-policy
+    // check and its SubjectPublicKeyInfo; released once the signature is verified
+    FParsedClientLeaf: IInspectedCertificate;
     /// <summary>Whether this handshake authenticated via a pre_shared_key (a resumption
     /// ticket or an out-of-band external PSK): the server skips its Certificate/
     /// CertificateVerify and seeds the schedule with the PSK.</summary>
@@ -1385,6 +1388,7 @@ begin
   FTranscript.Update(AMessage.Raw);
 
   FClientCertChain := nil;
+  FParsedClientLeaf := nil;
   SetLength(FClientCertChain, System.Length(LCert.Entries));
   for LI := 0 to High(LCert.Entries) do
     FClientCertChain[LI] := LCert.Entries[LI].CertData;
@@ -1402,7 +1406,8 @@ begin
 
   // a client leaf that is not a well-formed certificate is a decode error, caught before
   // the verifier (which, for -require-any-client-certificate, does not parse the chain)
-  TCertificateVerify.EnsureWellFormedLeaf(FParams.Provider, FClientCertChain[0]);
+  FParsedClientLeaf := TCertificateVerify.ParseWellFormedLeaf(FParams.Provider,
+    FClientCertChain[0]);
 
   // RFC 8446 4.4.2: extensions on a client CertificateEntry must correspond to ones in the
   // CertificateRequest; we request none, so any leaf extension is unsupported_extension.
@@ -1447,13 +1452,14 @@ begin
       TTlsAlertDescription.IllegalParameter, @SLegacyPkcs1InClientCertVerify);
   // the client leaf must permit digitalSignature and, for an rsa_pss_rsae_* scheme, not
   // be an id-RSASSA-PSS key (symmetric with the client verifying the server leaf)
-  TCertificateVerify.EnforceSigningLeafPolicy(FParams.Provider,
-    FClientCertChain[0], LScheme, True);
+  TCertificateVerify.EnforceSigningLeafPolicy(FParsedClientLeaf, LScheme, True);
   // the client signs the transcript through its Certificate, client-side context string
   LContent := TCertificateVerify.SignatureContent(False, FTranscript.CurrentHash);
-  LPublicKeyInfo := FParams.Provider.Certificates.PublicKeyInfo(FClientCertChain[0]);
+  LPublicKeyInfo := FParsedClientLeaf.PublicKeyInfo;
   LVerifier := FParams.Provider.Signing.CreateSignatureVerifier(LScheme, LPublicKeyInfo);
   LVerifier.Update(LContent, 0, System.Length(LContent));
+  // the parsed leaf is no longer needed; release it rather than pin the ASN.1 graph
+  FParsedClientLeaf := nil;
   if not LVerifier.Verify(LCertVerify.Signature) then
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.DecryptError, @SBadClientCertVerify);

--- a/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
+++ b/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
@@ -23,9 +23,6 @@ uses
   TlpISecretBuffer;
 
 type
-  /// <summary>An AEAD's usage-limit family: AES-GCM must proactively rekey by a
-  /// record-count bound, ChaCha20-Poly1305 is bounded only by the record sequence.</summary>
-  TAeadUsageCategory = (AesGcm, ChaCha20);
 
 { ===== Primitive interfaces ===== }
 
@@ -248,9 +245,26 @@ type
     function PublicKeyInfo: TBytes;
     function DnsNames: TArray<string>;
     function IpAddresses: TArray<TBytes>;
-    function KeyUsagePermits(AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
-    function HasRsaPssKey(out AIsRsaPss: Boolean): Boolean;
+    /// <summary>
+    /// Whether the certificate's keyUsage extension (RFC 5280 4.2.1.3) permits AUsage.
+    /// Yes when the extension is absent (no restriction) or asserts the bit; No only when
+    /// the extension is present and the bit is clear; Undetermined on a malformed certificate.
+    /// </summary>
+    function KeyUsagePermits(AUsage: TCertKeyUsage): TCertAnswer;
+    /// <summary>
+    /// Whether the certificate's SubjectPublicKeyInfo algorithm is id-RSASSA-PSS
+    /// (OID 1.2.840.113549.1.1.10), the restricted RSA-PSS key type that the
+    /// rsa_pss_rsae_* schemes must not be used with (RFC 8446 4.2.3). Yes when it is,
+    /// No when it is not, Undetermined on a malformed certificate.
+    /// </summary>
+    function KeyIsRsaPss: TCertAnswer;
     function KeyKind(out AKind: TCertKeyKind; out AEcNamedGroup: UInt16): Boolean;
+    /// <summary>
+    /// Extracts the certificate's human-readable identity from the already-decoded handle:
+    /// the subject and issuer distinguished names, the subject common name, and the serial
+    /// number in hex. Returns False (all empty) on a malformed field; never raises.
+    /// </summary>
+    function PeerInfo(out ASubject, AIssuer, ACommonName, ASerialHex: string): Boolean;
   end;
 
   /// <summary>
@@ -306,20 +320,18 @@ type
       out AFeatures: TArray<UInt16>): Boolean;
     /// <summary>
     /// Whether the certificate's keyUsage extension (RFC 5280 4.2.1.3) permits AUsage.
-    /// APermitted is True when the extension is absent (no restriction) or asserts the
-    /// bit; False only when the extension is present and the bit is clear. Returns
-    /// False (could not determine) on a malformed certificate, leaving APermitted True.
+    /// Yes when the extension is absent (no restriction) or asserts the bit; No only when
+    /// the extension is present and the bit is clear; Undetermined on a malformed certificate.
     /// </summary>
     function KeyUsagePermits(const ACertificateDer: TBytes;
-      AUsage: TCertKeyUsage; out APermitted: Boolean): Boolean;
+      AUsage: TCertKeyUsage): TCertAnswer;
     /// <summary>
     /// Whether the certificate's SubjectPublicKeyInfo algorithm is id-RSASSA-PSS
     /// (OID 1.2.840.113549.1.1.10), the restricted RSA-PSS key type that the
-    /// rsa_pss_rsae_* schemes must not be used with (RFC 8446 4.2.3). Returns False
-    /// (could not determine) on a malformed certificate, leaving AIsRsaPss False.
+    /// rsa_pss_rsae_* schemes must not be used with (RFC 8446 4.2.3). Yes when it is,
+    /// No when it is not, Undetermined on a malformed certificate.
     /// </summary>
-    function HasRsaPssKey(const ACertificateDer: TBytes;
-      out AIsRsaPss: Boolean): Boolean;
+    function KeyIsRsaPss(const ACertificateDer: TBytes): TCertAnswer;
     /// <summary>
     /// Classifies the certificate leaf key: AKind is the public-key algorithm, and for an
     /// ECDSA key AEcNamedGroup is the named-group code of its curve (secp256r1 = 0x0017,

--- a/TlsLib/src/KeySchedule/TlpHkdfLabel.pas
+++ b/TlsLib/src/KeySchedule/TlpHkdfLabel.pas
@@ -19,10 +19,8 @@ uses
   SysUtils,
   TlpISecretBuffer,
   TlpICryptoProvider,
-  TlpTlsLibExceptions,
-  TlpWireVectorMarker,
-  TlpIWireWriter,
-  TlpWireWriter;
+  TlpBinaryPrimitives,
+  TlpTlsLibExceptions;
 
 type
   /// <summary>
@@ -67,28 +65,38 @@ resourcestring
 class function THkdfLabel.BuildHkdfLabel(const ALabel: string;
   const AContext: TBytes; ALength: Int32): TBytes;
 var
-  LWriter: IWireWriter;
-  LFullLabel: TBytes;
-  LMarker: TWireVectorMarker;
+  LPrefixLen, LLabelLen, LFullLabelLen, LContextLen, LPos, LI: Int32;
 begin
+  // HkdfLabel (RFC 8446 7.1): uint16 length || opaque label<7..255> = "tls13 " + ALabel
+  // || opaque context<0..255>.
   Result := nil;
-  LFullLabel := TEncoding.ASCII.GetBytes(Tls13LabelPrefix + ALabel);
-  if (System.Length(LFullLabel) < MinFullLabelLength) or
-    (System.Length(LFullLabel) > MaxFullLabelLength) then
-    raise EArgumentTlsLibException.CreateResFmt(@SLabelLength,
-      [System.Length(LFullLabel)]);
-  if System.Length(AContext) > MaxContextLength then
-    raise EArgumentTlsLibException.CreateResFmt(@SContextLength,
-      [System.Length(AContext)]);
-  LWriter := TWireWriter.Create;
-  LWriter.WriteUInt16(UInt16(ALength));
-  LMarker := LWriter.OpenVector(1);
-  LWriter.WriteBytes(LFullLabel);
-  LWriter.CloseVector(LMarker);
-  LMarker := LWriter.OpenVector(1);
-  LWriter.WriteBytes(AContext);
-  LWriter.CloseVector(LMarker);
-  Result := LWriter.ToBytes;
+  LPrefixLen := System.Length(Tls13LabelPrefix);
+  LLabelLen := System.Length(ALabel);
+  LFullLabelLen := LPrefixLen + LLabelLen;
+  if (LFullLabelLen < MinFullLabelLength) or (LFullLabelLen > MaxFullLabelLength) then
+    raise EArgumentTlsLibException.CreateResFmt(@SLabelLength, [LFullLabelLen]);
+  LContextLen := System.Length(AContext);
+  if LContextLen > MaxContextLength then
+    raise EArgumentTlsLibException.CreateResFmt(@SContextLength, [LContextLen]);
+
+  SetLength(Result, 2 + 1 + LFullLabelLen + 1 + LContextLen);
+  TBinaryPrimitives.WriteUInt16BigEndian(Result, 0, UInt16(ALength));
+  Result[2] := Byte(LFullLabelLen);
+  LPos := 3;
+  for LI := 1 to LPrefixLen do
+  begin
+    Result[LPos] := Byte(Ord(Tls13LabelPrefix[LI]));
+    Inc(LPos);
+  end;
+  for LI := 1 to LLabelLen do
+  begin
+    Result[LPos] := Byte(Ord(ALabel[LI]));
+    Inc(LPos);
+  end;
+  Result[LPos] := Byte(LContextLen);
+  Inc(LPos);
+  if LContextLen > 0 then
+    Move(AContext[0], Result[LPos], LContextLen);
 end;
 
 class function THkdfLabel.HkdfExpandLabel(const AHkdf: IHkdf;

--- a/TlsLib/src/Record/TlpRecordProtection.pas
+++ b/TlsLib/src/Record/TlpRecordProtection.pas
@@ -21,6 +21,7 @@ uses
   TlpBinaryPrimitives,
   TlpISecretBuffer,
   TlpICryptoProvider,
+  TlpCryptoAlgorithms,
   TlpIRecordProtection,
   TlpTlsAlert,
   TlpTlsContentType,


### PR DESCRIPTION
Use TEphemeralECDHAgreement (deterministic fixed-length posture) for the ECDHE [d]Q, and release the client's spent ephemeral private immediately after decapsulation so its buffer is wiped.