### PR TITLE
Harvest OS trust anchors into an immutable snapshot at build

### DIFF
--- a/TlsLib.Tests/src/SystemTrustTests.pas
+++ b/TlsLib.Tests/src/SystemTrustTests.pas
@@ -11,7 +11,7 @@
 
 /// <summary>Tests for the optional TlsLib.Trust.System package, in two layers:
 ///
-/// 1. A portable fixture suite (always runs on every target). TFileSystemAnchorStore is portable
+/// 1. A portable fixture suite (always runs on every target). TFileSystemRootSource is portable
 ///    and takes an explicit (env, files, dirs) form, so its harvest/resolution logic is exercised
 ///    on any host by injecting throwaway fixture paths - no real /etc/ssl/certs needed - plus a
 ///    check that the TOSSystemTrust factory reports a sane capability for the build's platform.
@@ -59,7 +59,7 @@ uses
   TlsLibTestBase;
 
 type
-  /// <summary>Portable suite (always runs): drives TFileSystemAnchorStore's file/dir resolution
+  /// <summary>Portable suite (always runs): drives TFileSystemRootSource's file/dir resolution
   /// via injected fixtures, and checks the factory reports anchors for this build's platform.</summary>
   TTestSystemTrustFixtures = class(TTlsLibAlgorithmTestCase)
   private
@@ -72,6 +72,10 @@ type
     FRootDer: TBytes;   // the test root DER
     FRoot2Der: TBytes;  // a second, distinct root DER
     procedure WriteBytes(const APath: string; const AData: TBytes);
+    /// <summary>Builds a filesystem source, freezes it into an immutable snapshot, and
+    /// frees the source - the shape every caller uses. Fail-closed harvests raise here.</summary>
+    function FileSnapshot(const AEnvFile, AEnvDir: string;
+      const AFiles, ADirs: TArray<string>): ITrustAnchorStore;
   protected
     procedure SetUp; override;
     procedure TearDown; override;
@@ -82,6 +86,7 @@ type
     procedure TestDirectoryHarvestReadsCerts;
     procedure TestDuplicateCertsAreDeduplicated;
     procedure TestDistinctCertsAreNotMerged;
+    procedure TestSnapshotSurvivesSourceFileDeletion;
     procedure TestFactoryAnchorStoreMatchesSupports;
     procedure TestFactoryDelegateVerifierMatchesSupports;
   end;
@@ -154,6 +159,19 @@ implementation
 
 { TTestSystemTrustFixtures }
 
+function TTestSystemTrustFixtures.FileSnapshot(const AEnvFile, AEnvDir: string;
+  const AFiles, ADirs: TArray<string>): ITrustAnchorStore;
+var
+  LSource: TFileSystemRootSource;
+begin
+  LSource := TFileSystemRootSource.Create(FProvider, AEnvFile, AEnvDir, AFiles, ADirs);
+  try
+    Result := LSource.Snapshot;
+  finally
+    LSource.Free;
+  end;
+end;
+
 procedure TTestSystemTrustFixtures.WriteBytes(const APath: string; const AData: TBytes);
 var
   LStream: TFileStream;
@@ -203,38 +221,29 @@ begin
 end;
 
 procedure TTestSystemTrustFixtures.TestInjectedFileHarvestsRoot;
-var
-  LStore: ITrustAnchorStore;
 begin
   // a single injected bundle file yields exactly its one root
-  LStore := TFileSystemAnchorStore.Create(FProvider, '', '',
-    TArray<string>.Create(FFile), nil) as ITrustAnchorStore;
-  CheckEquals(1, System.Length(LStore.RootCertificates),
+  CheckEquals(1, System.Length(FileSnapshot('', '',
+    TArray<string>.Create(FFile), nil).RootCertificates),
     'the injected bundle file is harvested into one anchor');
 end;
 
 procedure TTestSystemTrustFixtures.TestFirstExistingFileCandidateWins;
-var
-  LStore: ITrustAnchorStore;
 begin
   // a missing candidate is skipped; the first EXISTING file becomes the authoritative store
-  LStore := TFileSystemAnchorStore.Create(FProvider, '', '',
-    TArray<string>.Create(FMissing, FFile), nil) as ITrustAnchorStore;
-  CheckEquals(1, System.Length(LStore.RootCertificates),
+  CheckEquals(1, System.Length(FileSnapshot('', '',
+    TArray<string>.Create(FMissing, FFile), nil).RootCertificates),
     'the first existing candidate file is used, missing ones skipped');
 end;
 
 procedure TTestSystemTrustFixtures.TestNoReadableStoreFailsClosed;
 var
-  LStore: ITrustAnchorStore;
   LRaised: Boolean;
 begin
-  // nothing readable anywhere -> fail closed, never a silent empty trust store
-  LStore := TFileSystemAnchorStore.Create(FProvider, '', '',
-    TArray<string>.Create(FMissing), TArray<string>.Create(FMissing)) as ITrustAnchorStore;
+  // nothing readable anywhere -> fail closed at build, never a silent empty trust store
   LRaised := False;
   try
-    LStore.RootCertificates;
+    FileSnapshot('', '', TArray<string>.Create(FMissing), TArray<string>.Create(FMissing));
   except
     on E: ESystemTrustUnavailableTlsLibException do
       LRaised := True;
@@ -243,32 +252,26 @@ begin
 end;
 
 procedure TTestSystemTrustFixtures.TestDirectoryHarvestReadsCerts;
-var
-  LStore: ITrustAnchorStore;
 begin
   // a directory of certificate files is enumerated and harvested
-  LStore := TFileSystemAnchorStore.Create(FProvider, '', '', nil,
-    TArray<string>.Create(FCertDir)) as ITrustAnchorStore;
-  CheckTrue(System.Length(LStore.RootCertificates) >= 1,
+  CheckTrue(System.Length(FileSnapshot('', '', nil,
+    TArray<string>.Create(FCertDir)).RootCertificates) >= 1,
     'the certificate directory is enumerated into anchors');
 end;
 
 procedure TTestSystemTrustFixtures.TestDuplicateCertsAreDeduplicated;
 var
   LDir: string;
-  LStore: ITrustAnchorStore;
 begin
   LDir := IncludeTrailingPathDelimiter(FDir) + 'dupdir';
   ForceDirectories(LDir);
   try
     WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'a.der', FRootDer);
     WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'b.der', FRootDer);
-    LStore := TFileSystemAnchorStore.Create(FProvider, '', '', nil,
-      TArray<string>.Create(LDir)) as ITrustAnchorStore;
-    CheckEquals(1, System.Length(LStore.RootCertificates),
+    CheckEquals(1, System.Length(FileSnapshot('', '', nil,
+      TArray<string>.Create(LDir)).RootCertificates),
       'the same certificate under two names is de-duplicated to one anchor');
   finally
-    LStore := nil;
     SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'a.der');
     SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'b.der');
     SysUtils.RemoveDir(LDir);
@@ -278,21 +281,41 @@ end;
 procedure TTestSystemTrustFixtures.TestDistinctCertsAreNotMerged;
 var
   LDir: string;
-  LStore: ITrustAnchorStore;
 begin
   LDir := IncludeTrailingPathDelimiter(FDir) + 'distinctdir';
   ForceDirectories(LDir);
   try
     WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'r1.der', FRootDer);
     WriteBytes(IncludeTrailingPathDelimiter(LDir) + 'r2.der', FRoot2Der);
-    LStore := TFileSystemAnchorStore.Create(FProvider, '', '', nil,
-      TArray<string>.Create(LDir)) as ITrustAnchorStore;
-    CheckEquals(2, System.Length(LStore.RootCertificates),
+    CheckEquals(2, System.Length(FileSnapshot('', '', nil,
+      TArray<string>.Create(LDir)).RootCertificates),
       'two distinct certificates are harvested as two anchors');
   finally
-    LStore := nil;
     SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'r1.der');
     SysUtils.DeleteFile(IncludeTrailingPathDelimiter(LDir) + 'r2.der');
+    SysUtils.RemoveDir(LDir);
+  end;
+end;
+
+procedure TTestSystemTrustFixtures.TestSnapshotSurvivesSourceFileDeletion;
+var
+  LDir, LFile: string;
+  LStore: ITrustAnchorStore;
+begin
+  // the snapshot owns its DER: once built, deleting the underlying bundle does not change it
+  LDir := IncludeTrailingPathDelimiter(FDir) + 'snapdir';
+  ForceDirectories(LDir);
+  LFile := IncludeTrailingPathDelimiter(LDir) + 'snap.der';
+  try
+    WriteBytes(LFile, FRootDer);
+    LStore := FileSnapshot('', '', TArray<string>.Create(LFile), nil);
+    CheckEquals(1, System.Length(LStore.RootCertificates),
+      'the snapshot harvested the bundle');
+    SysUtils.DeleteFile(LFile);
+    CheckEquals(1, System.Length(LStore.RootCertificates),
+      'the snapshot still returns its roots after the source file is deleted');
+  finally
+    SysUtils.DeleteFile(LFile);
     SysUtils.RemoveDir(LDir);
   end;
 end;
@@ -301,13 +324,20 @@ procedure TTestSystemTrustFixtures.TestFactoryAnchorStoreMatchesSupports;
 var
   LRaised: Boolean;
 begin
-  // the factory's AnchorStore must AGREE with Supports(Anchors) on every platform: a store where
-  // supported (Windows/macOS/Unix), a typed unsupported error where not (iOS/Android). This is
-  // platform-agnostic - the contract itself is the invariant, no per-OS expected value hardcoded.
-  // Construction is lazy (no harvest here), so this is safe on an empty box.
+  // the factory's AnchorStore must AGREE with Supports(Anchors) on every platform: a snapshot
+  // where supported (Windows/macOS/Unix), a typed UNSUPPORTED error where not (iOS/Android). On a
+  // supported platform AnchorStore harvests eagerly, so a bare box with no readable roots may
+  // instead fail closed with UNAVAILABLE - both honor the contract; only UNSUPPORTED would not.
   if TOSSystemTrust.Supports(TSystemTrustMode.Anchors) then
-    CheckTrue(TOSSystemTrust.AnchorStore(FProvider) <> nil,
-      'a platform that supports Anchors must hand back an anchor store')
+  begin
+    try
+      CheckTrue(TOSSystemTrust.AnchorStore(FProvider) <> nil,
+        'a platform that supports Anchors hands back an anchor snapshot');
+    except
+      on E: ESystemTrustUnavailableTlsLibException do
+        ; // acceptable: the platform supports Anchors but this box has no readable roots
+    end;
+  end
   else
   begin
     LRaised := False;
@@ -417,8 +447,15 @@ end;
 { TTestWindowsSystemTrust }
 
 function TTestWindowsSystemTrust.CreateAnchorStore: ITrustAnchorStore;
+var
+  LSource: TWindowsRootSource;
 begin
-  Result := TWindowsAnchorStore.Create(FProvider) as ITrustAnchorStore;
+  LSource := TWindowsRootSource.Create(FProvider);
+  try
+    Result := LSource.Snapshot;
+  finally
+    LSource.Free;
+  end;
 end;
 
 function TTestWindowsSystemTrust.PlatformName: string;
@@ -433,8 +470,15 @@ end;
 { TTestMacOSSystemTrust }
 
 function TTestMacOSSystemTrust.CreateAnchorStore: ITrustAnchorStore;
+var
+  LSource: TAppleRootSource;
 begin
-  Result := TAppleAnchorStore.Create(FProvider) as ITrustAnchorStore;
+  LSource := TAppleRootSource.Create(FProvider);
+  try
+    Result := LSource.Snapshot;
+  finally
+    LSource.Free;
+  end;
 end;
 
 function TTestMacOSSystemTrust.PlatformName: string;
@@ -449,8 +493,15 @@ end;
 { TTestUnixSystemTrust }
 
 function TTestUnixSystemTrust.CreateAnchorStore: ITrustAnchorStore;
+var
+  LSource: TUnixRootSource;
 begin
-  Result := TUnixAnchorStore.Create(FProvider) as ITrustAnchorStore;
+  LSource := TUnixRootSource.Create(FProvider);
+  try
+    Result := LSource.Snapshot;
+  finally
+    LSource.Free;
+  end;
 end;
 
 function TTestUnixSystemTrust.PlatformName: string;

--- a/TlsLib.Trust.System/src/TlpAppleSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpAppleSystemTrust.pas
@@ -52,7 +52,7 @@ type
   /// setting result is Deny so OS distrust is honored. iOS has no equivalent
   /// enumeration API, so this store is macOS-only. Emits neutral DER.
   /// </summary>
-  TAppleAnchorStore = class sealed(TSystemTrustBase)
+  TAppleRootSource = class sealed(TSystemRootSource)
   strict protected
     function HarvestRoots: TArray<TBytes>; override;
     function SourceName: string; override;
@@ -547,9 +547,9 @@ begin
   end;
 end;
 
-{ TAppleAnchorStore }
+{ TAppleRootSource }
 
-function TAppleAnchorStore.HarvestRoots: TArray<TBytes>;
+function TAppleRootSource.HarvestRoots: TArray<TBytes>;
 var
   LRaw: TArray<TBytes>;
   LI: Integer;
@@ -567,7 +567,7 @@ begin
   end;
 end;
 
-function TAppleAnchorStore.SourceName: string;
+function TAppleRootSource.SourceName: string;
 begin
   Result := 'macOS';
 end;

--- a/TlsLib.Trust.System/src/TlpFileSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpFileSystemTrust.pas
@@ -34,9 +34,9 @@ type
   /// The path resolution is platform-neutral - it only manipulates strings and
   /// files - so this store is driven with injected path lists on any host, and
   /// is the reusable engine every filesystem-based platform builds on (see
-  /// TUnixAnchorStore for the Unix env + path defaults).
+  /// TUnixRootSource for the Unix env + path defaults).
   /// </summary>
-  TFileSystemAnchorStore = class(TSystemTrustBase)
+  TFileSystemRootSource = class(TSystemRootSource)
   strict private
     FEnvFile: string;
     FEnvDir: string;
@@ -73,9 +73,9 @@ resourcestring
   SBundleUnreadable =
     'the system CA bundle could not be parsed: %s';
 
-{ TFileSystemAnchorStore }
+{ TFileSystemRootSource }
 
-constructor TFileSystemAnchorStore.Create(const AProvider: ICryptoProvider;
+constructor TFileSystemRootSource.Create(const AProvider: ICryptoProvider;
   const AEnvFile, AEnvDir: string; const AFiles, ADirs: TArray<string>);
 begin
   inherited Create(AProvider);
@@ -85,7 +85,7 @@ begin
   FDirs := ADirs;
 end;
 
-class function TFileSystemAnchorStore.ReadAllBytes(const APath: string): TBytes;
+class function TFileSystemRootSource.ReadAllBytes(const APath: string): TBytes;
 var
   LStream: TMemoryStream;
 begin
@@ -101,7 +101,7 @@ begin
   end;
 end;
 
-function TFileSystemAnchorStore.ParseBundle(const AData: TBytes): TArray<TBytes>;
+function TFileSystemRootSource.ParseBundle(const AData: TBytes): TArray<TBytes>;
 begin
   if Length(AData) = 0 then
     Result := nil
@@ -109,7 +109,7 @@ begin
     Result := Provider.Certificates.LoadChain(AData);
 end;
 
-procedure TFileSystemAnchorStore.HarvestFile(const APath: string;
+procedure TFileSystemRootSource.HarvestFile(const APath: string;
   const AAccumulator: TSystemRootAccumulator);
 var
   LCerts: TArray<TBytes>;
@@ -127,7 +127,7 @@ begin
     AddUnique(AAccumulator, LCerts[LI]);
 end;
 
-procedure TFileSystemAnchorStore.HarvestDir(const APath: string;
+procedure TFileSystemRootSource.HarvestDir(const APath: string;
   const AAccumulator: TSystemRootAccumulator);
 var
   LSearch: TSearchRec;
@@ -158,7 +158,7 @@ begin
   end;
 end;
 
-function TFileSystemAnchorStore.FirstExistingFile: string;
+function TFileSystemRootSource.FirstExistingFile: string;
 var
   LI: Integer;
 begin
@@ -173,7 +173,7 @@ begin
   end;
 end;
 
-function TFileSystemAnchorStore.FirstExistingDir: string;
+function TFileSystemRootSource.FirstExistingDir: string;
 var
   LI: Integer;
 begin
@@ -188,7 +188,7 @@ begin
   end;
 end;
 
-function TFileSystemAnchorStore.HarvestRoots: TArray<TBytes>;
+function TFileSystemRootSource.HarvestRoots: TArray<TBytes>;
 var
   LFile, LDir: string;
   LAcc: TSystemRootAccumulator;
@@ -232,7 +232,7 @@ begin
   end;
 end;
 
-function TFileSystemAnchorStore.SourceName: string;
+function TFileSystemRootSource.SourceName: string;
 begin
   Result := 'FileSystem';
 end;

--- a/TlsLib.Trust.System/src/TlpOSSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpOSSystemTrust.pas
@@ -19,6 +19,7 @@ uses
   SysUtils,
   TlpICryptoProvider,
   TlpICertificateTrust,
+  TlpSystemTrustBase,
   TlpSystemTrustExceptions
 {$IF DEFINED(TLSLIB_MSWINDOWS)}
   , TlpWindowsSystemTrust
@@ -95,24 +96,30 @@ end;
 
 class function TOSSystemTrust.AnchorStore(const AProvider: ICryptoProvider)
   : ITrustAnchorStore;
+var
+  LSource: TSystemRootSource;
 begin
-  Result := nil;
+  LSource := nil;
 {$IF DEFINED(TLSLIB_MSWINDOWS)}
-  Result := TWindowsAnchorStore.Create(AProvider);
+  LSource := TWindowsRootSource.Create(AProvider);
 {$ELSEIF DEFINED(TLSLIB_IOS)}
   raise ESystemTrustUnsupportedTlsLibException.CreateRes(@SNoHarvest);
 {$ELSEIF DEFINED(TLSLIB_MACOS)}
-  Result := TAppleAnchorStore.Create(AProvider);
+  LSource := TAppleRootSource.Create(AProvider);
 {$ELSEIF DEFINED(TLSLIB_ANDROID)}
   // Android is delegate-only: the filesystem store is stale/partial (APEX-updated roots,
   // user-installed CAs, network-security-config), so harvesting is banned - use the OS delegate.
   raise ESystemTrustUnsupportedTlsLibException.CreateRes(@SNoHarvest);
 {$ELSEIF DEFINED(TLSLIB_LINUX) OR DEFINED(TLSLIB_BSD) OR DEFINED(TLSLIB_SOLARIS)}
-  Result := TUnixAnchorStore.Create(AProvider);
+  LSource := TUnixRootSource.Create(AProvider);
 {$ELSE}
   {$MESSAGE ERROR 'UNSUPPORTED TARGET.'}
-  Result := nil;
 {$IFEND}
+  try
+    Result := LSource.Snapshot;
+  finally
+    LSource.Free;
+  end;
 end;
 
 class function TOSSystemTrust.DelegateVerifier(const AProvider: ICryptoProvider)

--- a/TlsLib.Trust.System/src/TlpSystemTrustBase.pas
+++ b/TlsLib.Trust.System/src/TlpSystemTrustBase.pas
@@ -17,10 +17,10 @@ interface
 
 uses
   SysUtils,
-  SyncObjs,
   Generics.Collections,
   TlpICryptoProvider,
   TlpICertificateTrust,
+  TlpCertificateVerifier,
   TlpSystemTrustExceptions;
 
 type
@@ -40,21 +40,21 @@ type
   end;
 
   /// <summary>
-  /// Abstract base for the platform trust-anchor harvesters. Caches the harvested
-  /// roots behind a lock (refreshable), validates each blob is a well-formed DER
-  /// certificate, and de-duplicates. Fail-closed: an empty harvest raises rather
-  /// than presenting an empty anchor set. Subclasses override HarvestRoots.
+  /// Abstract platform trust-root SOURCE - it reads the OS trust store, it is not
+  /// itself a trust store. Snapshot freezes the harvested roots into an immutable
+  /// TTrustAnchorStore that the verifier consumes, so the anchors a config validates
+  /// against are fixed at build time and never change under it; picking up OS changes
+  /// means building a new snapshot. A source is a short-lived helper the caller owns
+  /// and frees, and nothing is read until Harvest. Fail-closed: an empty or unreadable
+  /// harvest raises rather than yielding an empty anchor set. Subclasses override
+  /// HarvestRoots.
   /// </summary>
-  TSystemTrustBase = class abstract(TInterfacedObject, ITrustAnchorStore)
+  TSystemRootSource = class abstract(TObject)
   strict private
-    FLock: TCriticalSection;
     FProvider: ICryptoProvider;
-    FRoots: TArray<TBytes>;
-    FLoaded: Boolean;
-    class function CloneRoots(const ARoots: TArray<TBytes>): TArray<TBytes>; static;
   strict protected
-    /// <summary>Gather the platform's trusted roots as DER. May return empty; the
-    /// base turns an empty result into a fail-closed error.</summary>
+    /// <summary>Gather the platform's trusted roots as DER. May return empty; Harvest
+    /// turns an empty result into a fail-closed error.</summary>
     function HarvestRoots: TArray<TBytes>; virtual; abstract;
     /// <summary>Human-readable source label, used in the fail-closed message.</summary>
     function SourceName: string; virtual; abstract;
@@ -68,11 +68,12 @@ type
       const ADer: TBytes);
   public
     constructor Create(const AProvider: ICryptoProvider);
-    destructor Destroy; override;
-
-    function RootCertificates: TArray<TBytes>;
-    /// <summary>Discards the cache so the next access re-harvests the OS store.</summary>
-    procedure Refresh;
+    /// <summary>Reads the source now. Fail-closed: an empty or unreadable source
+    /// raises ESystemTrustUnavailableTlsLibException; a non-empty result is returned
+    /// as harvested.</summary>
+    function Harvest: TArray<TBytes>;
+    /// <summary>Harvests now and freezes the result into an immutable anchor store.</summary>
+    function Snapshot: ITrustAnchorStore;
   end;
 
 implementation
@@ -114,25 +115,17 @@ begin
   Result := FRoots.ToArray;
 end;
 
-{ TSystemTrustBase }
+{ TSystemRootSource }
 
-constructor TSystemTrustBase.Create(const AProvider: ICryptoProvider);
+constructor TSystemRootSource.Create(const AProvider: ICryptoProvider);
 begin
   inherited Create;
   if AProvider = nil then
     raise ESystemTrustUnavailableTlsLibException.CreateRes(@SNoProvider);
   FProvider := AProvider;
-  FLock := TCriticalSection.Create;
-  FLoaded := False;
 end;
 
-destructor TSystemTrustBase.Destroy;
-begin
-  FLock.Free;
-  inherited Destroy;
-end;
-
-procedure TSystemTrustBase.AddUnique(const AAccumulator: TSystemRootAccumulator;
+procedure TSystemRootSource.AddUnique(const AAccumulator: TSystemRootAccumulator;
   const ADer: TBytes);
 begin
   if not FProvider.Certificates.IsWellFormed(ADer) then
@@ -140,46 +133,18 @@ begin
   AAccumulator.Add(ADer);
 end;
 
-class function TSystemTrustBase.CloneRoots(
-  const ARoots: TArray<TBytes>): TArray<TBytes>;
-var
-  LI: Integer;
+function TSystemRootSource.Harvest: TArray<TBytes>;
 begin
-  Result := nil;
-  SetLength(Result, Length(ARoots));
-  for LI := 0 to Length(ARoots) - 1 do
-    Result[LI] := Copy(ARoots[LI], 0, Length(ARoots[LI]));
+  Result := HarvestRoots;
+  if Length(Result) = 0 then
+    raise ESystemTrustUnavailableTlsLibException.CreateResFmt(
+      @SSystemTrustEmpty, [SourceName]);
 end;
 
-function TSystemTrustBase.RootCertificates: TArray<TBytes>;
+function TSystemRootSource.Snapshot: ITrustAnchorStore;
 begin
-  FLock.Enter;
-  try
-    if not FLoaded then
-    begin
-      FRoots := HarvestRoots;
-      FLoaded := True;
-    end;
-
-    if Length(FRoots) = 0 then
-      raise ESystemTrustUnavailableTlsLibException.CreateResFmt(
-        @SSystemTrustEmpty, [SourceName]);
-
-    Result := CloneRoots(FRoots);
-  finally
-    FLock.Leave;
-  end;
-end;
-
-procedure TSystemTrustBase.Refresh;
-begin
-  FLock.Enter;
-  try
-    FRoots := nil;
-    FLoaded := False;
-  finally
-    FLock.Leave;
-  end;
+  // a failed harvest raises here, before any store is built
+  Result := TTrustAnchorStore.Create(Harvest) as ITrustAnchorStore;
 end;
 
 end.

--- a/TlsLib.Trust.System/src/TlpUnixSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpUnixSystemTrust.pas
@@ -26,9 +26,9 @@ type
   /// concrete SSL_CERT_FILE / SSL_CERT_DIR environment variables and the
   /// well-known CA bundle/directory table shared by Linux, the BSDs and
   /// Solaris/illumos, then defers all resolution and harvesting to
-  /// TFileSystemAnchorStore. Adding a Unix flavour is a new row in the table.
+  /// TFileSystemRootSource. Adding a Unix flavour is a new row in the table.
   /// </summary>
-  TUnixAnchorStore = class sealed(TFileSystemAnchorStore)
+  TUnixRootSource = class sealed(TFileSystemRootSource)
   strict protected
     function SourceName: string; override;
   public
@@ -86,9 +86,9 @@ begin
   );
 end;
 
-{ TUnixAnchorStore }
+{ TUnixRootSource }
 
-constructor TUnixAnchorStore.Create(const AProvider: ICryptoProvider);
+constructor TUnixRootSource.Create(const AProvider: ICryptoProvider);
 begin
   inherited Create(AProvider,
     GetEnvironmentVariable(TUnixTrustPaths.EnvFileVar),
@@ -97,7 +97,7 @@ begin
     TUnixTrustPaths.CandidateDirs);
 end;
 
-function TUnixAnchorStore.SourceName: string;
+function TUnixRootSource.SourceName: string;
 begin
   Result := 'Unix';
 end;

--- a/TlsLib.Trust.System/src/TlpWindowsSystemTrust.pas
+++ b/TlsLib.Trust.System/src/TlpWindowsSystemTrust.pas
@@ -32,7 +32,7 @@ type
   /// system stores, subtracting any certificate present in the "Disallowed" store
   /// so OS distrust is honored. Emits neutral DER.
   /// </summary>
-  TWindowsAnchorStore = class sealed(TSystemTrustBase)
+  TWindowsRootSource = class sealed(TSystemRootSource)
   strict protected
     function HarvestRoots: TArray<TBytes>; override;
     function SourceName: string; override;
@@ -428,9 +428,9 @@ begin
   end;
 end;
 
-{ TWindowsAnchorStore }
+{ TWindowsRootSource }
 
-function TWindowsAnchorStore.HarvestRoots: TArray<TBytes>;
+function TWindowsRootSource.HarvestRoots: TArray<TBytes>;
 var
   LRaw: TArray<TBytes>;
   LI: Integer;
@@ -448,7 +448,7 @@ begin
   end;
 end;
 
-function TWindowsAnchorStore.SourceName: string;
+function TWindowsRootSource.SourceName: string;
 begin
   Result := 'Windows';
 end;

--- a/TlsLib/src/Trust/TlpCertificateVerifier.pas
+++ b/TlsLib/src/Trust/TlpCertificateVerifier.pas
@@ -47,8 +47,9 @@ type
   end;
 
   /// <summary>Unions several anchor sources: RootCertificates is the concatenation of
-  /// every child store's roots, resolved on each call so a live source (e.g. an OS store)
-  /// stays current. Used when more than one anchor contribution is configured.</summary>
+  /// every child store's roots, resolved on each call. Used when more than one anchor
+  /// contribution is configured. (A harvested OS store is an immutable snapshot; per-call
+  /// resolution matters only for a caller-supplied store whose own roots vary.)</summary>
   TUnionTrustAnchorStore = class sealed(TInterfacedObject, ITrustAnchorStore)
   strict private
   var


### PR DESCRIPTION
## Summary

Recasts the platform OS-trust classes from lazily-harvesting, lock-guarded
anchor stores (that also carried an unreachable `Refresh`) into trust-root
**sources** that read the OS store and hand back an **immutable snapshot**.
Both `AnchorStore` and `WithSystemTrust` now harvest — and fail closed — at
config-build time on every path, instead of deferring the read and the
failure to the first handshake.

The anchors a frozen config validates against are now fixed at build and
never change under it. Picking up OS trust changes means building a new
snapshot (the same idiom the library already uses for credential rotation);
for trust that tracks the OS per handshake, `Delegate` mode is unchanged.

## What changed

- **`TSystemTrustBase` → `TSystemRootSource`** — a source whose constructor
  only stores the provider. `Harvest` reads the OS store and fails closed on
  an empty/unreadable result; `Snapshot` freezes the harvest into the
  existing immutable `TTrustAnchorStore`. Drops the lock, the lazy cache,
  `CloneRoots`, and `Refresh`. Harvesting is an explicit call after
  construction, so there is no virtual call from a constructor and nothing is
  left half-built when a harvest fails closed.
- **Rename the harvesters** `T*AnchorStore` → `T*RootSource` (Windows, Apple,
  FileSystem, Unix) — they are sources, not stores.
- **`TOSSystemTrust.AnchorStore`** builds a source, snapshots it, and frees it.
- **Union-store doc** reworded: a harvested OS store is an immutable snapshot,
  not a live view; per-call resolution matters only for a caller-supplied
  store whose own roots vary.

## Behavior

- `AnchorStore` / `WithSystemTrust` perform the OS read at build. On a box with
  no readable roots they now fail closed at that point (`ESystemTrustUnavailable`)
  rather than at the first handshake; unsupported platforms (iOS/Android) still
  raise `ESystemTrustUnsupported` as before.
- The public method surface is otherwise unchanged: `AnchorStore` still returns
  an `ITrustAnchorStore`, and `WithSystemTrust` still wires it into the builder.

## Tests

- A `FileSnapshot` helper drives the source→snapshot shape across the fixtures.
- The fail-closed case now asserts the raise at build.
- The factory test accepts a snapshot **or** a typed unavailable error on a
  supported platform (an eager harvest can fail closed on a bare box); only an
  *unsupported* error would violate the contract.
- New `TestSnapshotSurvivesSourceFileDeletion`: snapshot a bundle, delete the
  file, and confirm the snapshot still returns its roots — the immutability
  contract.