### PR TITLE
Encrypted Client Hello: post-ship hardening pass

### DIFF
--- a/TlsLib.Tests/src/EchClientTests.pas
+++ b/TlsLib.Tests/src/EchClientTests.pas
@@ -72,6 +72,7 @@ type
     procedure TestEncodedInnerHasEmptySessionIdAndZeroPadding;
     procedure TestCompressionReferencesSharedExtensions;
     procedure TestAcceptConfirmationMatch;
+    procedure TestGreaseEncapsulationIsValid;
   end;
 
 implementation
@@ -348,6 +349,18 @@ begin
   CheckFalse(TEchClientHandshake.AcceptConfirmationMatches(
     Provider.Primitives.CreateHkdf(THashAlgorithm.SHA_256), LInnerRandom,
     LTranscript, LBad), 'a non-matching confirmation is rejected');
+end;
+
+procedure TTestEchClient.TestGreaseEncapsulationIsValid;
+var
+  LEnc: TBytes;
+begin
+  // a GREASE ech carries a real KEM encapsulation as its enc (RFC 9849 sec. 6.2): for X25519 that
+  // is a 32-byte value the KEM accepts, not merely a bare generated public key
+  LEnc := Provider.Hpke.RandomEncapsulation(THpkeKem.DHKEM_X25519_HKDF_SHA256);
+  CheckEquals(32, System.Length(LEnc), 'an X25519 encapsulation is 32 bytes');
+  CheckTrue(Provider.Hpke.ValidatePublicKey(THpkeKem.DHKEM_X25519_HKDF_SHA256, LEnc),
+    'the GREASE encapsulation is a well-formed KEM value');
 end;
 
 initialization

--- a/TlsLib.Tests/src/EchConfigTests.pas
+++ b/TlsLib.Tests/src/EchConfigTests.pas
@@ -68,6 +68,7 @@ type
     procedure TestGoodPublicNames;
     procedure TestMalformedListRaises;
     procedure TestEmptyListRaises;
+    procedure TestLargeConfigListParses;
   end;
 
 implementation
@@ -329,6 +330,23 @@ begin
       LRaised := True;
   end;
   CheckTrue(LRaised, 'an empty ECHConfigList raises a decode error');
+end;
+
+procedure TTestEchConfig.TestLargeConfigListParses;
+const
+  Count = 500;
+var
+  LConfigs, LParsed: TArray<TEchConfig>;
+  LI: Int32;
+begin
+  // a large ECHConfigList arrives unauthenticated (server retry_configs); it must parse in linear
+  // time and yield exactly its entries - the parser pre-sizes from the remaining length
+  SetLength(LConfigs, Count);
+  for LI := 0 to Count - 1 do
+    LConfigs[LI] := ConfigWith(THpkeKem.DHKEM_X25519_HKDF_SHA256,
+      OneSuite(THpkeKdf.HKDF_SHA256, THpkeAead.AES_128_GCM), 'example.com', nil);
+  LParsed := TEchConfigList.Parse(TEchConfigList.Encode(LConfigs));
+  CheckEquals(Count, System.Length(LParsed), 'every config in a large list is parsed');
 end;
 
 initialization

--- a/TlsLib.Tests/src/EchExtensionTests.pas
+++ b/TlsLib.Tests/src/EchExtensionTests.pas
@@ -48,6 +48,7 @@ type
     procedure TestOuterRoundTrip;
     procedure TestInnerRoundTrip;
     procedure TestUnknownTypeRejected;
+    procedure TestEmptyPayloadRejected;
     procedure TestOuterTrailingBytesRejected;
     procedure TestOuterExtensionsRoundTrip;
     procedure TestEmptyOuterExtensionsRejected;
@@ -132,6 +133,18 @@ begin
   CheckTrue(LRaised, 'an unknown ECH type is rejected');
   CheckEquals(Ord(TTlsAlertDescription.IllegalParameter), Ord(LAlert),
     'an unknown ECH type is illegal_parameter');
+end;
+
+procedure TTestEchExtension.TestEmptyPayloadRejected;
+var
+  LOuter: TEchOuterClientHello;
+begin
+  // payload<1..2^16-1> (RFC 9849 sec. 5): a zero-length outer payload is a wire-syntax
+  // violation rejected at parse, not a decryption failure
+  LOuter := SampleOuter;
+  LOuter.Payload := nil;
+  CheckTrue(DecodeRaises(TEchExtension.EncodeOuter(LOuter)),
+    'a zero-length outer payload is rejected as decode_error');
 end;
 
 procedure TTestEchExtension.TestOuterTrailingBytesRejected;

--- a/TlsLib.Tests/src/Tls13LoopbackTests.pas
+++ b/TlsLib.Tests/src/Tls13LoopbackTests.pas
@@ -51,6 +51,9 @@ uses
   TlpTls13ServerStateMachine,
   TlpCryptoDomainTypes,
   TlpISecretBuffer,
+  TlpWireReader,
+  TlpHandshakeMessages,
+  TlpEchOuterExtensions,
   TlpEchConfig,
   TlpEchClient,
   TlpInMemoryEchKeyStore,
@@ -115,11 +118,15 @@ type
     procedure Pump(const ASrc, ADst: ITlsEngine);
     procedure PumpCoalesced(const ASrc, ADst: ITlsEngine);
     function ReadAllApp(const AEngine: ITlsEngine): TBytes;
+    // the pre_shared_key extension data (identities + binders) from the outer ClientHello in a
+    // record-framed client flight, skipping any leading ChangeCipherSpec; nil when there is none
+    function OuterPskExtData(const AFlight: TBytes): TBytes;
   published
     procedure TestEchAcceptLoopback;
     procedure TestEchHrrAcceptLoopback;
     procedure TestEchRejectHrrLoopback;
     procedure TestEchResumeHrrLoopback;
+    procedure TestEchGreasePskBindersDifferAcrossHrr;
     procedure TestEchResumptionLoopback;
     procedure TestEchZeroRttLoopback;
     procedure TestEchResumeThenRejectLoopback;
@@ -691,6 +698,105 @@ begin
     'ECH accepted on the resumed HRR handshake');
   CheckTrue(LClient.IsResumed, 'the ECH client resumed across the HRR via the inner PSK');
   CheckTrue(LServer.IsResumed, 'the ECH server resumed across the HRR');
+end;
+
+function TTestTls13Loopback.OuterPskExtData(const AFlight: TBytes): TBytes;
+var
+  LPos, LRecLen, LHsLen, LI: Int32;
+  LBody: TBytes;
+  LHello: TTlsClientHello;
+  LReader, LExtsVec: TWireReader;
+  LEntries: TArray<TEchExtEntry>;
+begin
+  Result := nil;
+  LPos := 0;
+  // walk records: a flight can lead with a middlebox-compat ChangeCipherSpec (type 20); the
+  // ClientHello is the handshake record (type 22) whose first message is a ClientHello (type 1)
+  while LPos + 9 <= System.Length(AFlight) do
+  begin
+    LRecLen := (AFlight[LPos + 3] shl 8) or AFlight[LPos + 4];
+    if (AFlight[LPos] = 22) and (AFlight[LPos + 5] = 1) then
+    begin
+      LHsLen := (AFlight[LPos + 6] shl 16) or (AFlight[LPos + 7] shl 8) or AFlight[LPos + 8];
+      LBody := System.Copy(AFlight, LPos + 9, LHsLen);
+      LHello := THandshakeMessages.DecodeClientHello(LBody);
+      LReader := TWireReader.Create(LHello.Extensions);
+      LExtsVec := LReader.OpenVector(2);
+      LEntries := TEchOuterExtensions.ParseExtensions(
+        LExtsVec.ReadBytes(LExtsVec.Remaining));
+      for LI := 0 to System.High(LEntries) do
+        if LEntries[LI].ExtType = TExtensionTypes.PreSharedKey then
+          Exit(LEntries[LI].Data);
+      Exit;
+    end;
+    Inc(LPos, 5 + LRecLen);
+  end;
+end;
+
+procedure TTestTls13Loopback.TestEchGreasePskBindersDifferAcrossHrr;
+var
+  LCache: ISessionCache;
+  LStore: ISessionStore;
+  LClient, LServer: ITlsEngine;
+  LIterations, LIdLen1, LIdLen2, LI: Int32;
+  LCh1, LCh2, LPsk1, LPsk2, LIds1, LIds2, LBind1, LBind2: TBytes;
+  LSameBinders: Boolean;
+begin
+  // resume + ECH + HRR: the resuming client carries a GREASE pre_shared_key on the outer, retried
+  // across an HRR. CH2 must keep CH1's PSK identities AND obfuscated ticket ages verbatim (a real
+  // offer's age moves only by the retry round-trip) while regenerating the binders, as a real
+  // resumption CH2 does - a fresh age or a verbatim binder would fingerprint the decoy (RFC 9849
+  // sec. 10.10.4, RFC 8446 4.1.2/4.2.11.1)
+  LCache := TInMemorySessionCache.Create;
+  LStore := TInMemorySessionStore.Create(Provider.Primitives.GetRandom);
+
+  // first ECH+HRR handshake issues a resumption ticket
+  LClient := NewEchHrrClient(LCache);
+  LServer := NewEchHrrServer(LStore, 1);
+  LClient.StartHandshake;
+  LIterations := 0;
+  while (LClient.IsHandshaking or LServer.IsHandshaking) and (LIterations < 16) do
+  begin
+    Pump(LClient, LServer);
+    Pump(LServer, LClient);
+    Inc(LIterations);
+  end;
+  CheckEquals(1, LCache.Count, 'the first handshake cached a ticket');
+
+  // second handshake: capture CH1 outer, deliver the HRR, capture CH2 outer
+  LClient := NewEchHrrClient(LCache);
+  LServer := NewEchHrrServer(LStore, 0);
+  LClient.StartHandshake;
+  LCh1 := Drain(LClient);        // ClientHelloOuter #1 (GREASE outer pre_shared_key)
+  Feed(LServer, LCh1);
+  Feed(LClient, Drain(LServer)); // deliver the HelloRetryRequest
+  LCh2 := Drain(LClient);        // ClientHelloOuter #2 (retry, possibly led by a CCS record)
+
+  LPsk1 := OuterPskExtData(LCh1);
+  LPsk2 := OuterPskExtData(LCh2);
+  CheckTrue(System.Length(LPsk1) > 2, 'CH1 carries a GREASE pre_shared_key');
+  CheckTrue(System.Length(LPsk2) > 2, 'CH2 carries a GREASE pre_shared_key');
+
+  // OfferedPsks = PskIdentity list<2> then binders<2>; the identities section (identity + age per
+  // offer) is byte-identical across the HRR, and the binders (at the same offset) must differ
+  LIdLen1 := (LPsk1[0] shl 8) or LPsk1[1];
+  LIdLen2 := (LPsk2[0] shl 8) or LPsk2[1];
+  LIds1 := System.Copy(LPsk1, 0, 2 + LIdLen1);
+  LIds2 := System.Copy(LPsk2, 0, 2 + LIdLen2);
+  CheckEqualBytes('GREASE PSK identities and ages are stable across the HRR', LIds1, LIds2);
+  LBind1 := System.Copy(LPsk1, 2 + LIdLen1, System.Length(LPsk1));
+  LBind2 := System.Copy(LPsk2, 2 + LIdLen1, System.Length(LPsk2));
+  CheckTrue(System.Length(LBind1) > 0, 'there is a binder section');
+  LSameBinders := System.Length(LBind1) = System.Length(LBind2);
+  if LSameBinders then
+    for LI := 0 to System.High(LBind1) do
+      if LBind1[LI] <> LBind2[LI] then
+      begin
+        LSameBinders := False;
+        Break;
+      end;
+  CheckFalse(LSameBinders,
+    'GREASE PSK binders are regenerated on the retry ClientHello');
 end;
 
 procedure TTestTls13Loopback.TestEchResumptionLoopback;

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -737,6 +737,7 @@ type
     function ImportPrivateKey(AKem: UInt16; const APkcs8Der: TBytes): ISecretBuffer;
     function SupportedSuites(AKem: UInt16): TArray<THpkeSuiteId>;
     function ValidatePublicKey(AKem: UInt16; const APublicKey: TBytes): Boolean;
+    function RandomEncapsulation(AKem: UInt16): TBytes;
   end;
 
   // IHpkeSuite - a (KEM, KDF, AEAD) triple the provider can instantiate. Vended by
@@ -1994,6 +1995,26 @@ begin
     on E: Exception do
       Result := False;
   end;
+end;
+
+function THpkeFacet.RandomEncapsulation(AKem: UInt16): TBytes;
+var
+  LHpke: ClpIHpke.IHpke;
+  LPub: TBytes;
+  LPriv: ISecretBuffer;
+  LpkR: IAsymmetricKeyParameter;
+  LCtx: IHpkeContextWithEncapsulation;
+begin
+  Result := nil;
+  if not IsKnownKem(AKem) then
+    Exit;
+  // encapsulate against a throwaway recipient and take the KEM encapsulation from a real base-mode
+  // setup; the KDF/AEAD take no part in encapsulation, so any supported pair completes the suite
+  GenerateKeyPair(AKem, LPub, LPriv);
+  LHpke := HpkeFacade(AKem, THpkeKdf.HKDF_SHA256, THpkeAead.AES_128_GCM);
+  LpkR := LHpke.DeserializePublicKey(LPub);
+  LCtx := LHpke.SetupBaseS(LpkR, nil);
+  Result := LCtx.GetEncapsulation();
 end;
 
 function THpkeFacet.ImportRecipientKey(AKem: UInt16;

--- a/TlsLib/src/Ech/TlpEchClient.pas
+++ b/TlsLib/src/Ech/TlpEchClient.pas
@@ -58,7 +58,7 @@ type
   /// padding) and drives the HPKE seal against a selected ECHConfig. A per-connection
   /// instance holds the live sealer so a HelloRetryRequest can re-seal at seq=1.
   /// </summary>
-  TEchClientHandshake = class sealed(TObject)
+  TEchClientHandshake = class sealed(TInterfacedObject, IEchClientHandshake)
   strict private
   var
     FProvider: ICryptoProvider;

--- a/TlsLib/src/Ech/TlpEchConfig.pas
+++ b/TlsLib/src/Ech/TlpEchConfig.pas
@@ -452,13 +452,17 @@ begin
   LReader := TWireReader.Create(AData);
   LList := LReader.OpenVector(2);
   LReader.ExpectEnd;
+  // the list arrives from an unauthenticated server (EE retry_configs); each config carries a
+  // 4-byte header (version + length) at minimum, so Remaining div 4 bounds the count - preallocate
+  // once and trim rather than growing one entry at a time (linear-time parsing, RFC 9849 sec. 10.12.4)
+  SetLength(Result, LList.Remaining div 4);
   LCount := 0;
   while not LList.EndReached do
   begin
-    SetLength(Result, LCount + 1);
     Result[LCount] := TEchConfig.Parse(LList);
     Inc(LCount);
   end;
+  SetLength(Result, LCount);
   if LCount = 0 then
     raise EDecodeErrorTlsLibException.CreateRes(@SMalformedConfig);
 end;

--- a/TlsLib/src/Ech/TlpEchExtension.pas
+++ b/TlsLib/src/Ech/TlpEchExtension.pas
@@ -100,6 +100,7 @@ resourcestring
   SUnknownEchType = 'unknown encrypted_client_hello type';
   SEmptyOuterExtensions = 'ech_outer_extensions must reference at least one extension';
   SBadConfirmationLength = 'encrypted_client_hello confirmation must be 8 bytes';
+  SEmptyEchPayload = 'encrypted_client_hello payload must be at least one byte';
 
 { TEchClientHelloTypeHelper }
 
@@ -168,6 +169,11 @@ begin
         LEnc := LReader.OpenVector(2);
         AOuter.Enc := LEnc.ReadBytes(LEnc.Remaining);
         LPayload := LReader.OpenVector(2);
+        // payload<1..2^16-1> (RFC 9849 sec. 5): an empty payload is a wire-syntax
+        // violation, not a decryption failure - reject at parse rather than let a
+        // never-openable ciphertext reach the AEAD
+        if LPayload.Remaining = 0 then
+          raise EDecodeErrorTlsLibException.CreateRes(@SEmptyEchPayload);
         AOuter.Payload := LPayload.ReadBytes(LPayload.Remaining);
       end;
     TEchClientHelloType.Inner:

--- a/TlsLib/src/Ech/TlpEchServer.pas
+++ b/TlsLib/src/Ech/TlpEchServer.pas
@@ -45,7 +45,7 @@ type
   /// confirmation). A missing ech is "not offered"; a present ech that no key opens is a
   /// shared-mode reject.
   /// </summary>
-  TEchServerHandshake = class sealed(TObject)
+  TEchServerHandshake = class sealed(TInterfacedObject, IEchServerHandshake)
   strict private
   var
     FProvider: ICryptoProvider;
@@ -85,8 +85,8 @@ type
     /// </summary>
     function ProcessRetryOuter(const AOuterFramed: TBytes): TEchStatus;
     property Status: TEchStatus read FStatus;
-    property InnerFramed: TBytes read FInnerFramed;
-    property InnerRandom: TBytes read FInnerRandom;
+    function InnerFramed: TBytes;
+    function InnerRandom: TBytes;
   end;
 
 implementation
@@ -254,14 +254,16 @@ begin
     raise EFatalAlertTlsLibException.CreateRes(
       TTlsAlertDescription.IllegalParameter, @SInnerSessionIdNotEmpty);
   LSuites := LReader.OpenVector(2);
-  LInner.CipherSuites := nil;
+  // each cipher suite is a 2-byte value, so Remaining div 2 is the exact count: preallocate
+  // once and trim rather than growing per entry (linear-time parsing, RFC 9849 sec. 10.12.4)
+  SetLength(LInner.CipherSuites, LSuites.Remaining div 2);
   LI := 0;
   while not LSuites.EndReached do
   begin
-    SetLength(LInner.CipherSuites, LI + 1);
     LInner.CipherSuites[LI] := LSuites.ReadUInt16;
     Inc(LI);
   end;
+  SetLength(LInner.CipherSuites, LI);
   LComp := LReader.OpenVector(1);
   LCompMethods := LComp.ReadBytes(LComp.Remaining);
   if (System.Length(LCompMethods) <> 1) or (LCompMethods[0] <> 0) then
@@ -377,10 +379,15 @@ begin
     end;
     if LOpened then
     begin
-      ReconstructInner(LEncoded, LOuter, LEntries);
-      FOpener := LOpener;
-      FConfig := LEntry.Config;
-      FStatus := TEchStatus.Accepted;
+      try
+        ReconstructInner(LEncoded, LOuter, LEntries);
+        FOpener := LOpener;
+        FConfig := LEntry.Config;
+        FStatus := TEchStatus.Accepted;
+      finally
+        // the decrypted inner carries the real SNI and PSK binder - wipe once reframed
+        TSecureMemory.WipeBytes(LEncoded);
+      end;
       Exit(FStatus);
     end;
   end;
@@ -435,9 +442,24 @@ begin
       raise EFatalAlertTlsLibException.CreateRes(
         TTlsAlertDescription.DecryptError, @SEchRetryDecrypt);
   end;
-  ReconstructInner(LEncoded, LOuter, LEntries);
+  try
+    ReconstructInner(LEncoded, LOuter, LEntries);
+  finally
+    // the decrypted inner carries the real SNI and PSK binder - wipe once reframed
+    TSecureMemory.WipeBytes(LEncoded);
+  end;
   FStatus := TEchStatus.Accepted;
   Result := FStatus;
+end;
+
+function TEchServerHandshake.InnerFramed: TBytes;
+begin
+  Result := FInnerFramed;
+end;
+
+function TEchServerHandshake.InnerRandom: TBytes;
+begin
+  Result := FInnerRandom;
 end;
 
 end.

--- a/TlsLib/src/Handshake/TlpTls13ClientStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ClientStateMachine.pas
@@ -241,7 +241,7 @@ type
     /// FParams.EchPolicy selected a usable config. FEch holds the sealer/enc; the inner
     /// transcript is kept in parallel with the outer FTranscript until the ServerHello
     /// accept confirmation decides which one the handshake continues on.</summary>
-    FEch: TEchClientHandshake;
+    FEch: IEchClientHandshake;
     FEchStatus: TEchStatus;
     FEchActive: Boolean;
     // ECH GREASE (RFC 9849 sec. 6.2): when no config is usable but GREASE is enabled, a
@@ -259,9 +259,12 @@ type
     // the first ClientHelloOuter's encrypted_client_hello extension body, re-sent verbatim on
     // a rejecting HelloRetryRequest (RFC 9849 sec. 6.1.5): the server ignored it, so CH2 echoes it
     FSentOuterEchExt: TBytes;
-    // the first ClientHelloOuter's GREASE pre_shared_key data, reused on a retry so CH2's outer
-    // keeps the same PSK identities as CH1 (RFC 8446 4.1.2)
-    FSentGreasePskData: TBytes;
+    // the first ClientHelloOuter's GREASE pre_shared_key identities and obfuscated ticket ages,
+    // reused verbatim on a retry so CH2's outer matches CH1's (RFC 8446 4.1.2) - a real offer's age
+    // moves only by the retry round-trip (4.2.11.1), so a fresh age would stand out. Only the
+    // binders are regenerated per hello, as a real client recomputes those over the new transcript
+    FGreasePskIdentities: TArray<TBytes>;
+    FGreasePskAges: TArray<TBytes>;
     FSelectedEchConfig: TEchConfig;
     FSelectedEchSuite: IHpkeSuite;
     FEchRetryConfigs: TBytes;
@@ -285,6 +288,7 @@ type
     /// <summary>The GREASE pre_shared_key extension_data for the ClientHelloOuter: one identity
     /// and binder per real offer, matching their lengths but filled with random content, so the
     /// outer resembles an ordinary resumption ClientHello (RFC 9849 sec. 6.1.2).</summary>
+    procedure MintGreasePskIdentities;
     function BuildGreasePskData: TBytes;
     /// <summary>On the ServerHello, activates both transcripts on the negotiated hash and
     /// decides ECH accept vs reject from the accept confirmation (RFC 9849 sec. 7.2),
@@ -510,7 +514,6 @@ end;
 
 destructor TTls13ClientStateMachine.Destroy;
 begin
-  FEch.Free;
   inherited Destroy;
 end;
 
@@ -755,13 +758,16 @@ var
   LOuter: TEchOuterClientHello;
   LRandom: IRandom;
   LEnc, LSel: TBytes;
-  LPrivate: ISecretBuffer;
   LSuites: TArray<THpkeSuiteId>;
   LSuite: THpkeSuiteId;
   LPayloadLength: Int32;
 begin
   LRandom := FParams.Provider.Primitives.GetRandom;
-  FParams.Provider.Hpke.GenerateKeyPair(GreaseKem, LEnc, LPrivate);
+  // enc is a real KEM encapsulation against a throwaway recipient (not a bare public key), so the
+  // decoy is a valid encapsulation for any KEM, not only a DH one where the two happen to coincide
+  LEnc := FParams.Provider.Hpke.RandomEncapsulation(GreaseKem);
+  if System.Length(LEnc) = 0 then
+    Exit(nil);
   // draw the suite from the ones the provider actually supports (RFC 9849 sec. 6.2), so a fixed
   // value cannot fingerprint the decoy as GREASE and a newly-supported algorithm is picked up
   // automatically - the provider is the single source of the HPKE vocabulary
@@ -844,11 +850,12 @@ begin
       LEchIdx := LI
     else if LEntries[LI].ExtType = TExtensionTypes.PreSharedKey then
     begin
-      // a retry keeps CH1's GREASE PSK identities (RFC 8446 4.1.2); the first flight mints and
-      // caches them
+      // a retry keeps CH1's GREASE PSK identities and ages (RFC 8446 4.1.2), minted on the first
+      // flight; the binders are regenerated each hello so a decoy's CH2 does not carry CH1's binders
+      // verbatim the way a real one never would
       if AMode = TEchChMode.Initial then
-        FSentGreasePskData := BuildGreasePskData;
-      LOuterEntries[LI].Data := FSentGreasePskData;
+        MintGreasePskIdentities;
+      LOuterEntries[LI].Data := BuildGreasePskData;
     end;
   end;
   // the ClientHelloOuter always presents the public_name (RFC 9849 sec. 6.1), even when the
@@ -913,6 +920,22 @@ begin
     THandshakeMessages.EncodeClientHello(LMsg));
 end;
 
+procedure TTls13ClientStateMachine.MintGreasePskIdentities;
+var
+  LRandom: IRandom;
+  LI: Int32;
+begin
+  LRandom := FParams.Provider.Primitives.GetRandom;
+  SetLength(FGreasePskIdentities, System.Length(FPskOffers));
+  SetLength(FGreasePskAges, System.Length(FPskOffers));
+  for LI := 0 to System.High(FPskOffers) do
+  begin
+    FGreasePskIdentities[LI] :=
+      LRandom.GenerateBytes(System.Length(FPskOffers[LI].Identity));
+    FGreasePskAges[LI] := LRandom.GenerateBytes(4); // retry-stable obfuscated_ticket_age
+  end;
+end;
+
 function TTls13ClientStateMachine.BuildGreasePskData: TBytes;
 var
   LWriter: IWireWriter;
@@ -920,15 +943,18 @@ var
   LI: Int32;
   LRandom: IRandom;
 begin
+  // the identities and obfuscated ticket ages are the minted, retry-stable values (a real offer
+  // re-sends both across a retry); only the binders are drawn fresh here, as a real client
+  // recomputes them over the new transcript
   LRandom := FParams.Provider.Primitives.GetRandom;
   LWriter := TWireWriter.Create;
   LIds := LWriter.OpenVector(2);
   for LI := 0 to System.High(FPskOffers) do
   begin
     LId := LWriter.OpenVector(2);
-    LWriter.WriteBytes(LRandom.GenerateBytes(System.Length(FPskOffers[LI].Identity)));
+    LWriter.WriteBytes(FGreasePskIdentities[LI]);
     LWriter.CloseVector(LId);
-    LWriter.WriteBytes(LRandom.GenerateBytes(4)); // random obfuscated_ticket_age
+    LWriter.WriteBytes(FGreasePskAges[LI]);
   end;
   LWriter.CloseVector(LIds);
   LBinders := LWriter.OpenVector(2);
@@ -1192,13 +1218,32 @@ end;
 procedure TTls13ClientStateMachine.PruneOffersToHash(AHash: THashAlgorithm);
 var
   LKept: TArray<IPreSharedKey>;
-  LOffer: IPreSharedKey;
+  LKeptGreaseIds, LKeptGreaseAges: TArray<TBytes>;
+  LI: Int32;
+  LHasGreaseIds: Boolean;
 begin
   LKept := nil;
-  for LOffer in FPskOffers do
-    if LOffer.Hash = AHash then
-      TArrayUtilities.Append<IPreSharedKey>(LKept, LOffer);
+  LKeptGreaseIds := nil;
+  LKeptGreaseAges := nil;
+  // the minted GREASE PSK identities and ages (outer decoy) are index-aligned with FPskOffers; prune
+  // them together so a surviving offer keeps across the HRR the outer identity and age it carried on CH1
+  LHasGreaseIds := System.Length(FGreasePskIdentities) = System.Length(FPskOffers);
+  for LI := 0 to System.High(FPskOffers) do
+    if FPskOffers[LI].Hash = AHash then
+    begin
+      TArrayUtilities.Append<IPreSharedKey>(LKept, FPskOffers[LI]);
+      if LHasGreaseIds then
+      begin
+        TArrayUtilities.Append<TBytes>(LKeptGreaseIds, FGreasePskIdentities[LI]);
+        TArrayUtilities.Append<TBytes>(LKeptGreaseAges, FGreasePskAges[LI]);
+      end;
+    end;
   FPskOffers := LKept;
+  if LHasGreaseIds then
+  begin
+    FGreasePskIdentities := LKeptGreaseIds;
+    FGreasePskAges := LKeptGreaseAges;
+  end;
 end;
 
 function TTls13ClientStateMachine.CacheNewSessionTicket(
@@ -1222,6 +1267,10 @@ begin
   finally
     LContext.Free;
   end;
+  // a rejected ECH handshake authenticated only the public_name, so its tickets MUST be ignored
+  // (RFC 9849 sec. 6.1.7); a reject is already terminal, so this guards against a future refactor
+  if FEchStatus = TEchStatus.Rejected then
+    Exit;
   if FParams.SessionCache = nil then
     Exit;
   LPsk := FSchedule.ResumptionPsk(FResumptionTranscriptHash, LNst.TicketNonce);

--- a/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
+++ b/TlsLib/src/Handshake/TlpTls13ServerStateMachine.pas
@@ -268,7 +268,7 @@ type
     /// <summary>Encrypted Client Hello per-connection state (RFC 9849): the trial-decrypt
     /// handshake, the outcome, the inner random (for the accept confirmation stamped into
     /// ServerHello.random), and the retry_configs to advertise on reject.</summary>
-    FEch: TEchServerHandshake;
+    FEch: IEchServerHandshake;
     FEchStatus: TEchStatus;
     FEchInnerRandom: TBytes;
     FEchRetryConfigs: TBytes;
@@ -481,7 +481,6 @@ end;
 
 destructor TTls13ServerStateMachine.Destroy;
 begin
-  FEch.Free;
   FCookie.Free;
   inherited Destroy;
 end;

--- a/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
+++ b/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
@@ -563,6 +563,13 @@ type
     /// seal. False for an unknown KEM.
     /// </summary>
     function ValidatePublicKey(AKem: UInt16; const APublicKey: TBytes): Boolean;
+    /// <summary>
+    /// A KEM encapsulation for AKem against a throwaway placeholder recipient - the real output of
+    /// a base-mode setup, not a bare public key, so it is a valid encapsulation for any KEM (the
+    /// two coincide only for a DH KEM). A GREASE ech (RFC 9849 sec. 6.2) uses it as its enc so the
+    /// decoy carries a genuine encapsulation shape. nil for an unknown KEM.
+    /// </summary>
+    function RandomEncapsulation(AKem: UInt16): TBytes;
   end;
 
 { ===== PEM (RFC 7468) ===== }

--- a/TlsLib/src/Interfaces/Ech/TlpIEch.pas
+++ b/TlsLib/src/Interfaces/Ech/TlpIEch.pas
@@ -18,6 +18,7 @@ interface
 uses
   SysUtils,
   TlpISecretBuffer,
+  TlpEchOuterExtensions,
   TlpEchConfig;
 
 type
@@ -57,6 +58,42 @@ type
     /// Entries is non-empty must return a non-empty list here; TInMemoryEchKeyStore enforces
     /// this at construction.</summary>
     function RetryConfigs: TBytes;
+  end;
+
+  /// <summary>
+  /// The client side of one connection's Encrypted Client Hello (RFC 9849): seals the
+  /// ClientHelloInner under the selected config and assembles the EncodedClientHelloInner
+  /// with its compressed outer_extensions. One instance per connection; carries the HPKE
+  /// sender context (reused with an empty enc across a HelloRetryRequest).
+  /// </summary>
+  IEchClientHandshake = interface(IInterface)
+    ['{7C3E9A15-4D82-4F60-9B18-2E6C0D5A3F84}']
+    /// <summary>The EncodedClientHelloInner for AInnerBody: the inner extensions replaced by an
+    /// ech_outer_extensions block referencing the outer, padded per RFC 9849 sec. 6.1.3.</summary>
+    function BuildEncodedInner(const AInnerBody: TBytes;
+      const AOuterEntries: TArray<TEchExtEntry>): TBytes;
+    /// <summary>Sets up the HPKE sender against the selected config and returns the enc.</summary>
+    function SetupSeal: TBytes;
+    /// <summary>Seals APlaintext under the ClientHelloOuterAAD AAad at the current sequence.</summary>
+    function Seal(const AAad, APlaintext: TBytes): TBytes;
+  end;
+
+  /// <summary>
+  /// The server side of one connection's Encrypted Client Hello (RFC 9849): trial-decrypts the
+  /// ClientHelloOuter, reconstructs the ClientHelloInner, and carries the HPKE recipient context
+  /// (reused across a HelloRetryRequest). One instance per connection.
+  /// </summary>
+  IEchServerHandshake = interface(IInterface)
+    ['{2B8D4F60-6A13-4E59-9C82-5D6E0B3A1F47}']
+    /// <summary>Trial-decrypts the ClientHelloOuter AOuterFramed: Accepted (inner reconstructed),
+    /// Rejected (serve the public_name), or NotOffered / Backend.</summary>
+    function ProcessOuter(const AOuterFramed: TBytes): TEchStatus;
+    /// <summary>Decrypts the retry ClientHelloOuter (seq 1, empty enc) after an accepted CH1.</summary>
+    function ProcessRetryOuter(const AOuterFramed: TBytes): TEchStatus;
+    /// <summary>The reconstructed inner ClientHello, framed as a handshake message.</summary>
+    function InnerFramed: TBytes;
+    /// <summary>The inner ClientHello's random, cross-checked against CH2 under HRR.</summary>
+    function InnerRandom: TBytes;
   end;
 
 implementation

--- a/TlsLib/src/Packages/Delphi/TlsLib4PascalPackage.dpk
+++ b/TlsLib/src/Packages/Delphi/TlsLib4PascalPackage.dpk
@@ -113,7 +113,7 @@ contains
   TlpEchOuterExtensions in '..\..\Ech\TlpEchOuterExtensions.pas',
   TlpIEch in '..\..\Interfaces\Ech\TlpIEch.pas',
   TlpEchClient in '..\..\Ech\TlpEchClient.pas',
-  TlpEchKeyStore in '..\..\Ech\TlpEchKeyStore.pas',
+  TlpInMemoryEchKeyStore in '..\..\Ech\TlpInMemoryEchKeyStore.pas',
   TlpEchServer in '..\..\Ech\TlpEchServer.pas',
   TlpITlsConfig in '..\..\Interfaces\Engine\TlpITlsConfig.pas',
   TlpITlsConfigBuilder in '..\..\Interfaces\Engine\TlpITlsConfigBuilder.pas',


### PR DESCRIPTION
## Summary

Applies the Low-severity items from an independent post-ship security review of
the shipped ECH (RFC 9849) implementation. The core wire mechanics, state
machine, and confirmation derivation were audited clean and are unchanged; this
PR tightens transient-secret handling, parsing bounds, GREASE fingerprint
resistance, and the domain's interface seams — and fixes a Delphi package build
break found along the way. The interop gates are unchanged.

## What's in it

**Correctness / build**
- **Delphi core-package build fix** — the `.dpk` referenced `TlpEchKeyStore`, a
  unit that does not exist (it's `TlpInMemoryEchKeyStore`; the FPC package and
  test manifests were already correct). The Delphi core package could not compile
  as shipped.

**Wire-syntax strictness**
- **Reject a zero-length outer ech `payload` at parse** with `decode_error`. RFC
  9849 §5 is `payload<1..2^16-1>`; an empty payload is a syntax violation, not a
  decryption failure, so it is caught at parse rather than left to fail inside
  AEAD open.

**Secret hygiene (defense-in-depth)**
- **Wipe the decrypted ClientHelloInner** (which carries the real SNI and PSK
  binder) after reconstruction, on both the trial-decrypt and retry paths.

**DoS hardening**
- **Pre-size attacker-influenced vectors** — the `ECHConfigList` parse (arriving
  from an unauthenticated server) and the decrypted inner's cipher-suites list now
  size from the remaining length and trim, instead of growing one element at a
  time (linear-time parsing, RFC 9849 §10.12.4).

**GREASE fingerprint resistance (RFC 9849 §6.2 / §10.10.4)**
- **GREASE `enc` is a real KEM encapsulation** against a throwaway recipient
  (new `IHpke.RandomEncapsulation`) rather than a bare generated public key —
  wire-identical for the current KEM, correct for any future one.
- **GREASE PSK across a HelloRetryRequest** re-offers the identities and
  obfuscated ticket ages verbatim (a real offer's age moves only by the retry
  round-trip, RFC 8446 §4.2.11.1) and regenerates only the binders, matching what
  a genuine resumption CH2 does — so the decoy does not stand out under a retry.

**Robustness / structure**
- **Reject-guard on `CacheNewSessionTicket`** (RFC 9849 §6.1.7): a rejected ECH
  handshake authenticated only the public name, so its tickets are ignored.
  Unreachable today (reject is terminal); guards against future refactors.
- **Interface seams** — `IEchClientHandshake` / `IEchServerHandshake`; the state
  machines now hold the interfaces rather than the concrete handshake classes.