### PR TITLE
Rename the provider HPKE facet interface to IHpkeFacet

### DIFF
--- a/TlsLib.Tests/src/MockCryptoProvider.pas
+++ b/TlsLib.Tests/src/MockCryptoProvider.pas
@@ -43,7 +43,7 @@ type
     function Certificates: ICertificateInspector;
     function PathValidation: ICertificatePathValidator;
     function Revocation: IRevocationChecker;
-    function Hpke: IHpke;
+    function Hpke: IHpkeFacet;
     function Pem: IPemCodec;
   end;
 
@@ -86,7 +86,7 @@ type
     function Certificates: ICertificateInspector;
     function PathValidation: ICertificatePathValidator;
     function Revocation: IRevocationChecker;
-    function Hpke: IHpke;
+    function Hpke: IHpkeFacet;
     function Pem: IPemCodec;
   end;
 
@@ -128,7 +128,7 @@ begin
   Result := FComposed.Revocation;
 end;
 
-function TMockCryptoProvider.Hpke: IHpke;
+function TMockCryptoProvider.Hpke: IHpkeFacet;
 begin
   Result := FComposed.Hpke;
 end;
@@ -229,7 +229,7 @@ begin
   Result := FComposed.Revocation;
 end;
 
-function TFixedAesProvider.Hpke: IHpke;
+function TFixedAesProvider.Hpke: IHpkeFacet;
 begin
   Result := FComposed.Hpke;
 end;

--- a/TlsLib/src/Crypto/TlpCryptoDomainTypes.pas
+++ b/TlsLib/src/Crypto/TlpCryptoDomainTypes.pas
@@ -44,7 +44,7 @@ type
   /// <summary>
   /// HPKE KEM identifiers (RFC 9180 sec. 7.1). Open IANA registry, opaque to this
   /// layer: which suites can be instantiated is the provider's to decide
-  /// (IHpke.Suite), and a peer's ECHConfig or an injected provider may carry a
+  /// (IHpkeFacet.Suite), and a peer's ECHConfig or an injected provider may carry a
   /// codepoint this library never enumerated - so raw UInt16 constants, not an enum.
   /// Used by Encrypted Client Hello.
   /// </summary>
@@ -81,7 +81,7 @@ type
   /// <summary>
   /// The identity of an HPKE cipher suite: the (KEM, KDF, AEAD) codepoint triple
   /// (RFC 9180). Held as raw UInt16 codepoints so an unknown suite received off the
-  /// wire round-trips; <see cref="IHpke.Suite" /> turns it into a usable
+  /// wire round-trips; <see cref="IHpkeFacet.Suite" /> turns it into a usable
   /// <see cref="IHpkeSuite" />, or nil when the provider cannot instantiate it.
   /// </summary>
   THpkeSuiteId = record

--- a/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
+++ b/TlsLib/src/Crypto/TlpDefaultCryptoProvider.pas
@@ -169,7 +169,7 @@ type
     Inspector: ICertificateInspector;
     PathValidation: ICertificatePathValidator;
     Revocation: IRevocationChecker;
-    Hpke: IHpke;
+    Hpke: IHpkeFacet;
     Pem: IPemCodec;
   end;
 
@@ -190,7 +190,7 @@ type
     FInspector: ICertificateInspector;
     FPathValidation: ICertificatePathValidator;
     FRevocation: IRevocationChecker;
-    FHpke: IHpke;
+    FHpke: IHpkeFacet;
     FPem: IPemCodec;
   public
     /// <summary>The single composition point. Resolves the effective RNG first (a supplied
@@ -214,7 +214,7 @@ type
     function Certificates: ICertificateInspector;
     function PathValidation: ICertificatePathValidator;
     function Revocation: IRevocationChecker;
-    function Hpke: IHpke;
+    function Hpke: IHpkeFacet;
     function Pem: IPemCodec;
   end;
 
@@ -234,7 +234,7 @@ type
     function WithInspector(const AInspector: ICertificateInspector): ICryptoProviderBuilder;
     function WithPathValidation(const APathValidation: ICertificatePathValidator): ICryptoProviderBuilder;
     function WithRevocation(const ARevocation: IRevocationChecker): ICryptoProviderBuilder;
-    function WithHpke(const AHpke: IHpke): ICryptoProviderBuilder;
+    function WithHpke(const AHpke: IHpkeFacet): ICryptoProviderBuilder;
     function WithPem(const APem: IPemCodec): ICryptoProviderBuilder;
     function Build: ICryptoProvider;
   end;
@@ -716,8 +716,8 @@ type
       const AEnc, AInfo: TBytes): IHpkeOpener;
   end;
 
-  // IHpke - RFC 9180 base-mode HPKE over CryptoLib's ClpHpke (TDhKem for KEM key ops).
-  THpkeFacet = class(TInterfacedObject, IHpke)
+  // the RFC 9180 base-mode HPKE facet.
+  THpkeFacet = class(TInterfacedObject, IHpkeFacet)
   private
     class procedure WriteOrdinal<T>(out AResult: T; AOrdinal: UInt16); static;
     class function KemIdOf(AKem: UInt16): THpkeKemId; static;
@@ -727,7 +727,7 @@ type
     class function IsKnownKdf(AKdf: UInt16): Boolean; static;
     class function IsRealAead(AAead: UInt16): Boolean; static;
     class function KemFacade(AKem: UInt16): IHpkeKem; static;
-    class function HpkeFacade(AKem, AKdf, AAead: UInt16): ClpIHpke.IHpke; static;
+    class function HpkeFacade(AKem, AKdf, AAead: UInt16): IHpke; static;
   public
     function Suite(AKem, AKdf, AAead: UInt16): IHpkeSuite;
     function ImportRecipientKey(AKem: UInt16;
@@ -1785,7 +1785,7 @@ end;
 function THpkeRecipientKey.SetupOpener(const ASuite: IHpkeSuite;
   const AEnc, AInfo: TBytes): IHpkeOpener;
 var
-  LHpke: ClpIHpke.IHpke;
+  LHpke: IHpke;
   LCtx: IHpkeContext;
 begin
   if ASuite.Kem <> FKem then
@@ -1912,10 +1912,10 @@ begin
   Result := TDhKem.Create(KemIdOf(AKem)) as IHpkeKem;
 end;
 
-class function THpkeFacet.HpkeFacade(AKem, AKdf, AAead: UInt16): ClpIHpke.IHpke;
+class function THpkeFacet.HpkeFacade(AKem, AKdf, AAead: UInt16): IHpke;
 begin
   Result := THpke.Create(THpkeMode.Base, KemIdOf(AKem), KdfIdOf(AKdf),
-    AeadIdOf(AAead)) as ClpIHpke.IHpke;
+    AeadIdOf(AAead)) as IHpke;
 end;
 
 { THpkeSuite }
@@ -1953,7 +1953,7 @@ end;
 procedure THpkeSuite.SetupSealer(const ARecipientPublicKey, AInfo: TBytes;
   out AEnc: TBytes; out ASealer: IHpkeSealer);
 var
-  LHpke: ClpIHpke.IHpke;
+  LHpke: IHpke;
   LpkR: IAsymmetricKeyParameter;
   LCtx: IHpkeContextWithEncapsulation;
 begin
@@ -1975,7 +1975,7 @@ end;
 function THpkeFacet.ValidatePublicKey(AKem: UInt16;
   const APublicKey: TBytes): Boolean;
 var
-  LHpke: ClpIHpke.IHpke;
+  LHpke: IHpke;
   LpkR: IAsymmetricKeyParameter;
   LCtx: IHpkeContextWithEncapsulation;
 begin
@@ -1999,7 +1999,7 @@ end;
 
 function THpkeFacet.RandomEncapsulation(AKem: UInt16): TBytes;
 var
-  LHpke: ClpIHpke.IHpke;
+  LHpke: IHpke;
   LPub: TBytes;
   LPriv: ISecretBuffer;
   LpkR: IAsymmetricKeyParameter;
@@ -2020,7 +2020,7 @@ end;
 function THpkeFacet.ImportRecipientKey(AKem: UInt16;
   const APrivateKey: ISecretBuffer): IHpkeRecipientKey;
 var
-  LHpke: ClpIHpke.IHpke;
+  LHpke: IHpke;
   LKp: IAsymmetricCipherKeyPair;
   LSk, LPub: TBytes;
 begin
@@ -2191,7 +2191,7 @@ begin
   if AOverrides.Hpke <> nil then
     FHpke := AOverrides.Hpke
   else
-    FHpke := THpkeFacet.Create as IHpke;
+    FHpke := THpkeFacet.Create as IHpkeFacet;
 
   if AOverrides.Pem <> nil then
     FPem := AOverrides.Pem
@@ -2333,7 +2333,7 @@ begin
   Result := FRevocation;
 end;
 
-function TDefaultCryptoProvider.Hpke: IHpke;
+function TDefaultCryptoProvider.Hpke: IHpkeFacet;
 begin
   Result := FHpke;
 end;
@@ -3568,7 +3568,7 @@ begin
 end;
 
 function TCryptoProviderBuilder.WithHpke(
-  const AHpke: IHpke): ICryptoProviderBuilder;
+  const AHpke: IHpkeFacet): ICryptoProviderBuilder;
 begin
   FOverrides.Hpke := AHpke;
   Result := Self;

--- a/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
+++ b/TlsLib/src/Interfaces/Crypto/TlpICryptoProvider.pas
@@ -465,7 +465,7 @@ type
   /// <summary>
   /// A provider-instantiated HPKE suite (RFC 9180 base mode): the (KEM, KDF, AEAD) codepoint
   /// triple bound to the provider's implementation of it. Obtained from
-  /// <see cref="IHpke.Suite" />, which returns nil for a suite the provider cannot instantiate,
+  /// <see cref="IHpkeFacet.Suite" />, which returns nil for a suite the provider cannot instantiate,
   /// so an IHpkeSuite always denotes a usable suite - one you can seal or open with, needing no
   /// separate support check.
   /// </summary>
@@ -520,7 +520,7 @@ type
   /// the UInt16 HPKE codepoints, and the <see cref="IHpkeSuite" /> / <see cref="IHpkeRecipientKey" />
   /// handles. No backend type crosses this seam.
   /// </summary>
-  IHpke = interface(IInterface)
+  IHpkeFacet = interface(IInterface)
     ['{4D8F1C60-3A72-4E59-9B14-6C0D2E7A3B58}']
     /// <summary>
     /// The provider's instance of the suite (AKem, AKdf, AAead), or nil when it cannot
@@ -607,7 +607,7 @@ type
     function PathValidation: ICertificatePathValidator;
     function Revocation: IRevocationChecker;
     /// <summary>The HPKE facet (RFC 9180), used by Encrypted Client Hello.</summary>
-    function Hpke: IHpke;
+    function Hpke: IHpkeFacet;
     /// <summary>The PEM codec (RFC 7468).</summary>
     function Pem: IPemCodec;
   end;
@@ -628,7 +628,7 @@ type
     function WithInspector(const AInspector: ICertificateInspector): ICryptoProviderBuilder;
     function WithPathValidation(const APathValidation: ICertificatePathValidator): ICryptoProviderBuilder;
     function WithRevocation(const ARevocation: IRevocationChecker): ICryptoProviderBuilder;
-    function WithHpke(const AHpke: IHpke): ICryptoProviderBuilder;
+    function WithHpke(const AHpke: IHpkeFacet): ICryptoProviderBuilder;
     function WithPem(const APem: IPemCodec): ICryptoProviderBuilder;
     /// <summary>Composes the provider from the accumulated overrides.</summary>
     function Build: ICryptoProvider;


### PR DESCRIPTION
## Summary

Renames the crypto provider's HPKE facet interface from `IHpke` to
`IHpkeFacet`, a rename-only change with no behavioural effect.

## Why

`IHpke` was the odd one out among the provider facets - every sibling is
named for its role rather than the bare primitive:

| Accessor | Interface |
|---|---|
| `Certificates` | `ICertificateInspector` |
| `PathValidation` | `ICertificatePathValidator` |
| `Revocation` | `IRevocationChecker` |
| `Pem` | `IPemCodec` |
| `Hpke` | `IHpke` ← bare primitive name |

Worse, `IHpke` is the exact name CryptoLib uses for its raw HPKE engine,
so `TlpDefaultCryptoProvider` had to write `ClpIHpke.IHpke` everywhere to
disambiguate. `IHpkeFacet` is the name the interface's own doc comment
("The HPKE facet") and its concrete class (`THpkeFacet`) already use, and it
reads naturally beside the other facets.

## What changed

- `IHpke` → `IHpkeFacet` (the interface, the `Hpke`/`WithHpke` accessors, and
  doc `cref`s) across `TlpICryptoProvider`, `TlpDefaultCryptoProvider`,
  `TlpCryptoDomainTypes`, and the test `MockCryptoProvider`.
- With the clash removed, all `ClpIHpke.IHpke` qualifiers in the provider are
  dropped back to plain `IHpke` (CryptoLib's engine).
- `IHpkeSuite` / `IHpkeSealer` / `IHpkeOpener` / `IHpkeRecipientKey` and the
  `ClpIHpke` unit name are untouched.